### PR TITLE
add stdint.h to avoid compilation issues

### DIFF
--- a/ext/ox/cache8.h
+++ b/ext/ox/cache8.h
@@ -32,6 +32,12 @@
 #define __OX_CACHE8_H__
 
 #include "ruby.h"
+#include RUBY_EXTCONF_H
+
+#ifdef HAVE_STDINT_H
+#include "stdint.h"
+#endif
+
 
 typedef struct _Cache8   *Cache8;
 

--- a/ext/ox/extconf.rb
+++ b/ext/ox/extconf.rb
@@ -1,7 +1,14 @@
 require 'mkmf'
 
+
+headers = []
+headers << "stdint.h" if have_header("stdint.h")
+
 $CPPFLAGS += ' -Wall'
 #puts "*** $CPPFLAGS: #{$CPPFLAGS}"
 extension_name = 'ox'
 dir_config(extension_name)
+
+create_header()
+
 create_makefile(extension_name)


### PR DESCRIPTION
I conditionally

```
#include "stdint.h"
```

in `cache8.h` to avoid compilation issues (working on Mac OS X 10.6.8 Core 2 Duo) and declare `uint64_t`

otherwise this resulted in:

```
make
gcc -I. -I/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/universal-darwin10.0 -  I/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/universal-darwin10.0 -I. -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE   -Wall -fno-common -arch i386 -arch x86_64 -g -Os -pipe -   fno-common -DENABLE_DTRACE  -fno-common  -pipe -fno-common   -c cache8.c
In file included from cache8.c:9:
cache8.h:41: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘ox_cache8_get’
cache8.c:19: error: expected specifier-qualifier-list before ‘uint64_t’
cache8.c:60: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘ox_cache8_get’
In file included from cache8.c:9:
cache8.h:41: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘ox_cache8_get’
cache8.c:19: error: expected specifier-qualifier-list before ‘uint64_t’
cache8.c:60: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘ox_cache8_get’
lipo: can't open input file: /var/folders/YY/YYW-2HdOFPydlLIpGnt6oU+++TI/-Tmp-//ccKSINMl.out (No such file or directory)
make: *** [cache8.o] Error 1
```

as I didn't find any way to run all tests at once this it not fully tested.
