### PR TITLE
Properly handle empty CDATA elements.

### DIFF
--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -452,6 +452,8 @@ read_cdata(SaxDrive dr) {
     int         end = 0;
 
     dr->str = dr->cur - 1; // mark the start
+    dr->cur--; // back up to the start in case the cdata is empty
+
     while (1) {
         c = sax_drive_get(dr);
         if (']' == c) {

--- a/test/sax_test.rb
+++ b/test/sax_test.rb
@@ -351,6 +351,24 @@ encoding = "UTF-8" ?>},
                    [:error, "invalid format, cdata terminated unexpectedly", 5, 1]])
   end
   
+  def test_sax_cdata_empty
+    parse_compare(%{<?xml version="1.0"?>
+<top>
+  <child><![CDATA[]]></child>
+  <child><![CDATA[This is CDATA.]]></child>
+</top>
+},
+                  [[:instruct, 'xml'],
+                   [:attr, :version, '1.0'],
+                   [:start_element, :top],
+                   [:start_element, :child],
+                   [:cdata, ''],
+                   [:end_element, :child],
+                   [:start_element, :child],
+                   [:cdata, 'This is CDATA.'],
+                   [:end_element, :child],
+                   [:end_element, :top]])
+  end
 
   def test_sax_mixed
     parse_compare(%{<?xml version="1.0"?>


### PR DESCRIPTION
When reading '<![CDATA[]]>' the read would start with the second ']' and thus not terminate the read properly.
