### PR TITLE
Escape special characters when writing attributes

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -1103,7 +1103,7 @@ dump_gen_attr(VALUE key, VALUE value, Out out) {
     fill_value(out, ks, klen);
     *out->cur++ = '=';
     *out->cur++ = '"';
-    fill_value(out, StringValuePtr(value), RSTRING_LEN(value));
+    dump_str_value(out, StringValuePtr(value), RSTRING_LEN(value));
     *out->cur++ = '"';
 
     return ST_CONTINUE;

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -258,6 +258,14 @@ class Func < ::Test::Unit::TestCase
     assert_equal('Pete', doc.attributes[:name])
   end
 
+  def test_escape_value
+    xml = %{\n<top name="&lt;&amp;test&gt;"/>\n}
+    doc = Ox.parse(xml)
+    assert_equal('<&test>', doc.attributes[:name])
+    dumped_xml = Ox.dump(doc)
+    assert_equal(xml, dumped_xml)
+  end
+
   def test_attr_as_string
     xml = %{<top name="Pete"/>}
     doc = Ox.load(xml, :mode => :generic, :symbolize_keys => false)


### PR DESCRIPTION
I found an error when parsing dumped XML; an attribute value with an ampersand is written out unescaped, and parsing it back in then failed.

This one line fix seems to work, and I added a quick test demonstrating the case.  (Not the cleanest test, but I tried to roughly follow the style of existing tests).
