### PR TITLE
Chaining appends onto an element

### DIFF
--- a/lib/ox/element.rb
+++ b/lib/ox/element.rb
@@ -1,4 +1,3 @@
-
 module Ox
 
   # An Element represents a element of an XML document. It has a name,
@@ -54,12 +53,14 @@ module Ox
       @nodes
     end
 
-    # Appends a Node to the Element's nodes array.
+    # Appends a Node to the Element's nodes array. Returns the element itself
+    # so multiple appends can be chained together.
     # @param [Node] node Node to append to the nodes array
     def <<(node)
       @nodes = [] if !instance_variable_defined?(:@nodes) or @nodes.nil?
       raise "argument to << must be a String or Ox::Node." unless node.is_a?(String) or node.is_a?(Node)
       @nodes << node
+      self
     end
 
     # Returns true if this Object and other are of the same type and have the


### PR DESCRIPTION
The method `<<` returns `self` instead of the nodes array so multiple appends can be chained together.

For example:

```
require 'ox'
include Ox

doc = Document.new

elem1 = Element.new('elem1')
elem2 = Element.new('elem2')

p doc << elem1 << elem2

# Currently returns this:
# => [#<Ox::Element:0x007fe4b205a840 @value="elem1", @attributes=nil, @nodes=nil>, 
#     #<Ox::Element:0x007fe4b205a750 @value="elem2", @attributes=nil, @nodes=nil>]

# But should return this: 
# => #<Ox::Document:0x007fad5b05a9a0 @value="", @attributes={}, @nodes=[
#       #<Ox::Element:0x007fad5b05a888 @value="elem1", @attributes=nil, @nodes=nil>, 
#       #<Ox::Element:0x007fad5b05a838 @value="elem2", @attributes=nil, @nodes=nil>]>
```
