### PR TITLE
HAS_TM_GMTOFF false under Cygwin

### DIFF
--- a/ext/ox/extconf.rb
+++ b/ext/ox/extconf.rb
@@ -20,7 +20,7 @@ dflags = {
   'HAS_RB_TIME_TIMESPEC' => ('ruby' == type && ('1.9.3' == RUBY_VERSION)) ? 1 : 0,
   #'HAS_RB_TIME_TIMESPEC' => ('ruby' == type && ('1.9.3' == RUBY_VERSION || '2' <= version[0])) ? 1 : 0,
   'HAS_TM_GMTOFF' => ('ruby' == type && (('1' == version[0] && '9' == version[1]) || '2' <= version[0]) && 
-                      !(platform.include?('solaris') || platform.include?('linux') || RUBY_PLATFORM =~ /(win|w)32$/)) ? 1 : 0,
+                      !(platform.include?('cygwin') || platform.include?('solaris') || platform.include?('linux') || RUBY_PLATFORM =~ /(win|w)32$/)) ? 1 : 0,
   'HAS_ENCODING_SUPPORT' => (('ruby' == type || 'rubinius' == type) &&
                              (('1' == version[0] && '9' == version[1]) || '2' <= version[0])) ? 1 : 0,
   'HAS_PRIVATE_ENCODING' => ('jruby' == type && '1' == version[0] && '9' == version[1]) ? 1 : 0,


### PR DESCRIPTION
Hi,

`struct tm` does not contain a `tm_gmtoff` member under Cygwin. Added clause to `extconf.rb` for that case so macro `HAS_TM_GMTOFF` is false (see line 508 of dump.c).

Tested with an up to date installation of Cygwin. Google suggests Cygwin's `struct tm` has not had `tm_gmtoff` for at least 6 years (and presumably forever) so change should not break older Cygwin users.
