### PR TITLE
Fixing an error in respond_to?

### DIFF
--- a/lib/ox/element.rb
+++ b/lib/ox/element.rb
@@ -161,7 +161,7 @@ module Ox
       nodes.each do |n|
         return true if n.value == id_str || n.value == id_sym
       end
-      if instance_variable_defined?(:@attributes)
+      if instance_variable_defined?(:@attributes) && @attributes.present?
         return true if @attributes.has_key?(id_str)
         return true if @attributes.has_key?(id_sym)
       end


### PR DESCRIPTION
Elements without attributes have @attributes=nil.  When calling this respond_to? method, it was erroring out, because @attributes is defined but nil.  So I added a check for @attributes.present? to ensure it's not trying to call has_key? on nil.

Example:

> > test = Ox::Element.new("test")
> > => #<Ox::Element:0x10c623cb8 @nodes=nil, @attributes=nil, @value="test">
