### PR TITLE
Introduce a raw type

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -1116,6 +1116,8 @@ dump_gen_nodes(VALUE obj, int depth, Out out) {
 		indent_needed = (1 == cnt) ? 0 : 1;
 	    } else if (ox_comment_clas == clas) {
 		dump_gen_val_node(*np, d2, "<!-- ", 5, " -->", 4, out);
+        } else if (ox_raw_clas == clas) {
+        dump_gen_val_node(*np, d2, "", 0, "", 0, out);
 	    } else if (ox_cdata_clas == clas) {
 		dump_gen_val_node(*np, d2, "<![CDATA[", 9, "]]>", 3, out);
 	    } else if (ox_doctype_clas == clas) {

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -1,21 +1,21 @@
 /* ox.c
  * Copyright (c) 2011, Peter Ohler
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * - Redistributions of source code must retain the above copyright notice, this
  *   list of conditions and the following disclaimer.
- * 
+ *
  * - Redistributions in binary form must reproduce the above copyright notice,
  *   this list of conditions and the following disclaimer in the documentation
  *   and/or other materials provided with the distribution.
- * 
+ *
  * - Neither the name of Peter Ohler nor the names of its contributors may be
  *   used to endorse or promote products derived from this software without
  *   specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -106,6 +106,7 @@ VALUE	ox_bag_clas;
 VALUE	ox_bigdecimal_class;
 VALUE	ox_cdata_clas;
 VALUE	ox_comment_clas;
+VALUE   ox_raw_clas;
 VALUE	ox_date_class;
 VALUE	ox_doctype_clas;
 VALUE	ox_document_clas;
@@ -319,7 +320,7 @@ set_def_opts(VALUE self, VALUE opts) {
     };
     YesNoOpt	o;
     VALUE	v;
-    
+
     Check_Type(opts, T_HASH);
 
     v = rb_hash_aref(opts, ox_encoding_sym);
@@ -492,7 +493,7 @@ load(char *xml, int argc, VALUE *argv, VALUE self, VALUE encoding, Err err) {
     if (1 == argc && rb_cHash == rb_obj_class(*argv)) {
 	VALUE	h = *argv;
 	VALUE	v;
-	
+
 	if (Qnil != (v = rb_hash_lookup(h, mode_sym))) {
 	    if (object_sym == v) {
 		options.mode = ObjMode;
@@ -729,7 +730,7 @@ sax_parse(int argc, VALUE *argv, VALUE self) {
     if (3 <= argc && rb_cHash == rb_obj_class(argv[2])) {
 	VALUE	h = argv[2];
 	VALUE	v;
-	
+
 	if (Qnil != (v = rb_hash_lookup(h, convert_special_sym))) {
 	    options.convert_special = (Qtrue == v);
 	}
@@ -763,10 +764,10 @@ parse_dump_options(VALUE ropts, Options copts) {
 	{ Qnil, 0 }
     };
     YesNoOpt	o;
-    
+
     if (rb_cHash == rb_obj_class(ropts)) {
 	VALUE	v;
-	
+
 	if (Qnil != (v = rb_hash_lookup(ropts, indent_sym))) {
 	    if (rb_cFixnum != rb_obj_class(v)) {
 		rb_raise(ox_parse_error_class, ":indent must be a Fixnum.\n");
@@ -832,7 +833,7 @@ dump(int argc, VALUE *argv, VALUE self) {
     char		*xml;
     struct _Options	copts = ox_default_options;
     VALUE		rstr;
-    
+
     if (2 == argc) {
 	parse_dump_options(argv[1], &copts);
     }
@@ -873,7 +874,7 @@ dump(int argc, VALUE *argv, VALUE self) {
 static VALUE
 to_file(int argc, VALUE *argv, VALUE self) {
     struct _Options	copts = ox_default_options;
-    
+
     if (3 == argc) {
 	parse_dump_options(argv[2], &copts);
     }
@@ -1023,6 +1024,7 @@ void Init_ox() {
     ox_element_clas = rb_const_get_at(Ox, rb_intern("Element"));
     ox_instruct_clas = rb_const_get_at(Ox, rb_intern("Instruct"));
     ox_comment_clas = rb_const_get_at(Ox, rb_intern("Comment"));
+    ox_raw_clas = rb_const_get_at(Ox, rb_intern("Raw"));
     ox_doctype_clas = rb_const_get_at(Ox, rb_intern("DocType"));
     ox_cdata_clas = rb_const_get_at(Ox, rb_intern("CData"));
     ox_bag_clas = rb_const_get_at(Ox, rb_intern("Bag"));

--- a/ext/ox/ox.h
+++ b/ext/ox/ox.h
@@ -1,21 +1,21 @@
 /* ox.h
  * Copyright (c) 2011, Peter Ohler
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * - Redistributions of source code must retain the above copyright notice, this
  *   list of conditions and the following disclaimer.
- * 
+ *
  * - Redistributions in binary form must reproduce the above copyright notice,
  *   this list of conditions and the following disclaimer in the documentation
  *   and/or other materials provided with the distribution.
- * 
+ *
  * - Neither the name of Peter Ohler nor the names of its contributors may be
  *   used to endorse or promote products derived from this software without
  *   specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -259,6 +259,7 @@ extern VALUE	ox_element_clas;
 extern VALUE	ox_instruct_clas;
 extern VALUE	ox_bag_clas;
 extern VALUE	ox_comment_clas;
+extern VALUE    ox_raw_clas;
 extern VALUE	ox_doctype_clas;
 extern VALUE	ox_cdata_clas;
 

--- a/lib/ox.rb
+++ b/lib/ox.rb
@@ -11,7 +11,7 @@
 #   this list of conditions and the following disclaimer in the documentation
 #   and/or other materials provided with the distribution.
 #
-# - Neither the name of Peter Ohler nor the names of its contributors may be 
+# - Neither the name of Peter Ohler nor the names of its contributors may be
 #   used to endorse or promote products derived from this software without
 #   specific prior written permission.
 #
@@ -27,57 +27,57 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # === Description:
-# 
+#
 # Ox handles XML documents in two ways. It is a generic XML parser and writer as
 # well as a fast Object / XML marshaller. Ox was written for speed as a
 # replacement for Nokogiri and for Marshal.
-# 
+#
 # As an XML parser it is 2 or more times faster than Nokogiri and as a generic
 # XML writer it is 14 times faster than Nokogiri. Of course different files may
 # result in slightly different times.
-# 
+#
 # As an Object serializer Ox is 4 times faster than the standard Ruby
 # Marshal.dump(). Ox is 3 times faster than Marshal.load().
-# 
+#
 # === Object Dump Sample:
-# 
+#
 #   require 'ox'
-# 
+#
 #   class Sample
 #     attr_accessor :a, :b, :c
-# 
+#
 #     def initialize(a, b, c)
 #       @a = a
 #       @b = b
 #       @c = c
 #     end
 #   end
-# 
+#
 #   # Create Object
 #   obj = Sample.new(1, "bee", ['x', :y, 7.0])
 #   # Now dump the Object to an XML String.
 #   xml = Ox.dump(obj)
 #   # Convert the object back into a Sample Object.
 #   obj2 = Ox.parse_obj(xml)
-# 
+#
 # === Generic XML Writing and Parsing:
-# 
+#
 #   require 'ox'
-# 
+#
 #   doc = Ox::Document.new(:version => '1.0')
-# 
+#
 #   top = Ox::Element.new('top')
 #   top[:name] = 'sample'
 #   doc << top
-# 
+#
 #   mid = Ox::Element.new('middle')
 #   mid[:name] = 'second'
 #   top << mid
-# 
+#
 #   bot = Ox::Element.new('bottom')
 #   bot[:name] = 'third'
 #   mid << bot
-# 
+#
 #   xml = Ox.dump(doc)
 #   puts xml
 #   doc2 = Ox.parse(xml)
@@ -91,6 +91,7 @@ require 'ox/error'
 require 'ox/hasattrs'
 require 'ox/node'
 require 'ox/comment'
+require 'ox/raw'
 require 'ox/instruct'
 require 'ox/cdata'
 require 'ox/doctype'

--- a/lib/ox/raw.rb
+++ b/lib/ox/raw.rb
@@ -1,0 +1,13 @@
+
+module Ox
+  # Coments represent XML comments in an XML document. A comment as value
+  # attribute only.
+  class Raw < Node
+    # Creates a new Raw element with the specified value.
+    # @param value [String] string value for the comment
+    def initialize(value)
+      super
+    end
+
+  end # Raw
+end # Ox


### PR DESCRIPTION
To cache partials in a bigger xml, I need to be able to initiate a node with a string, where the string is the actual xml. (so I dump the xml, put it in cache, when I fetch it, I put it in a raw node).

If you think this is a good idea, I'll clean up the tabs/comment and make a proper pull request out of it.