### PR TITLE
Fix infinite loops in Builder caused by newlines

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -87,10 +87,12 @@ append_string(Builder b, const char *str, size_t size) {
 	
 	buf_append_string(&b->buf, str, size);
 	b->col += size;
-	while (NULL != (s = strchr(s, '\n'))) {
-	    b->line++;
-	    b->col = end - s;
-	}
+        s = strchr(s, '\n');
+        while (NULL != s) {
+            b->line++;
+            b->col = end - s;
+            s = strchr(s + 1, '\n');
+        }
 	b->pos += size;
     } else {
 	char	buf[256];
@@ -714,9 +716,11 @@ builder_cdata(VALUE self, VALUE data) {
     b->pos += 9;
     buf_append_string(&b->buf, str, len);
     b->col += len;
-    while (NULL != (s = strchr(s, '\n'))) {
-	b->line++;
-	b->col = end - s;
+    s = strchr(s, '\n');
+    while (NULL != s) {
+        b->line++;
+        b->col = end - s;
+        s = strchr(s + 1, '\n');
     }
     b->pos += len;
     buf_append_string(&b->buf, "]]>", 3);
@@ -751,9 +755,11 @@ builder_raw(VALUE self, VALUE text) {
     i_am_a_child(b, true);
     buf_append_string(&b->buf, str, len);
     b->col += len;
-    while (NULL != (s = strchr(s, '\n'))) {
-	b->line++;
-	b->col = end - s;
+    s = strchr(s, '\n');
+    while (NULL != s) {
+        b->line++;
+        b->col = end - s;
+        s = strchr(s + 1, '\n');
     }
     b->pos += len;
 

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -1156,6 +1156,9 @@ class Func < ::Minitest::Test
     b.element('three')
     b.text("my name is \"ピーター\"")
     b.pop()
+    b.cdata("multi\nline\ncdata")
+    b.raw("<multi></multi>\n<line></line>\n<raw></raw>")
+    b.comment("Multi\nline\ncomment")
     b.close()
     xml = b.to_s
     assert_equal(%|<?xml version="1.0" encoding="UTF-8"?>
@@ -1163,6 +1166,14 @@ class Func < ::Minitest::Test
   <two/>
   <!-- just a comment --/>
   <three>my name is &quot;ピーター&quot;</three>
+  <![CDATA[multi
+line
+cdata]]><multi></multi>
+<line></line>
+<raw></raw>
+  <!-- Multi
+line
+comment --/>
 </one>
 |, xml)
   end


### PR DESCRIPTION
If using `Ox::Builder`, passing a string with a newline character in it to `Ox::Builder#raw` or `Ox::Builder#cdata` would result in an infinite loop.