### PR TITLE
Removed unnecessary lines

### DIFF
--- a/lib/ox/element.rb
+++ b/lib/ox/element.rb
@@ -68,7 +68,6 @@ module Ox
     # - +other+ [Object] Object compare _self_ to.
     # *return* [Boolean] true if both Objects are equivalent, otherwise false.
     def eql?(other)
-      return false if (other.nil? or self.class != other.class)
       return false unless super(other)
       return false unless self.attributes == other.attributes
       return false unless self.nodes == other.nodes

--- a/lib/ox/instruct.rb
+++ b/lib/ox/instruct.rb
@@ -25,7 +25,6 @@ module Ox
     # - +other+ [Object] Object compare _self_ to.
     # *return* [Boolean] true if both Objects are equivalent, otherwise false.
     def eql?(other)
-      return false if (other.nil? or self.class != other.class)
       return false unless super(other)
       return false unless self.attributes == other.attributes
       return false unless self.content == other.content


### PR DESCRIPTION
`Element` and `Instruct` both inherit from `Node`. They then override `Node#eql?` to include additional behavior, but still call `super` for the basic check, which makes the lines I removed be redundant.