### PR TITLE
Fix segfault on non closed elements with overlayer set to nest_ok

### DIFF
--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -1100,7 +1100,7 @@ read_element_end(SaxDrive dr) {
 		    rb_ivar_set(dr->handler, ox_at_column_id, LONG2NUM(col));
 		}
 		for (nv = stack_pop(&dr->stack); match < nv; nv = stack_pop(&dr->stack)) {
-		    if (dr->has.end_element && 0 >= dr->blocked && (NULL == nv->hint || ActiveOverlay == nv->hint->overlay || NestOverlay == h->overlay)) {
+		    if (dr->has.end_element && 0 >= dr->blocked && (NULL == nv->hint || ActiveOverlay == nv->hint->overlay || NestOverlay == nv->hint->overlay)) {
 			rb_funcall(dr->handler, ox_end_element_id, 1, nv->val);
 		    }
 		    if (NULL != nv->hint && BlockOverlay == nv->hint->overlay && 0 < dr->blocked) {

--- a/test/sax/smart_test.rb
+++ b/test/sax/smart_test.rb
@@ -658,4 +658,19 @@ class SaxSmartTableTagTest < SaxSmartTest
                        {:overlay => hints})
   end
   
+  def test_nest_ok_auto_closing
+    html = %{<html><body><h5>test</body></html>}
+    hints = Ox.sax_html_overlay()
+    hints['h5'] = :nest_ok
+    html_parse_compare(html,
+                       [[:start_element, :html],
+                        [:start_element, :body],
+                        [:start_element, :h5],
+                        [:text, "test"],
+                        [:error, "Start End Mismatch: element 'body' close does not match 'h5' open", 1, 21],
+                        [:end_element, :h5],
+                        [:end_element, :body],
+                        [:end_element, :html]],
+                       {:overlay => hints})
+  end
 end


### PR DESCRIPTION
Looks like a copy & paste bug. Thanks for the new `nest_ok` option!