### PR TITLE
New :skip_off mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 
 rvm:
+  - 2.2.8
   - 2.3.5
   - 2.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+## 2.8.0 - September 22, 2017
+
+  - Added :skip_off mode to make sax callback on every none empty string even
+    if there are not other non-whitespace characters present.
+
 ## 2.7.0 - August 18, 2017
 
   - Two new load modes added, :hash and :hash_no_attrs. Both load an XML

--- a/ext/ox/ox.h
+++ b/ext/ox/ox.h
@@ -96,6 +96,7 @@ typedef enum {
 } LoadMode;
 
 typedef enum {
+    OffSkip  = 'o',
     NoSkip   = 'n',
     CrSkip   = 'r',
     SpcSkip  = 's',

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -124,8 +124,8 @@ ox_parse(char *xml, ParseCallbacks pcb, char **endp, Options options, Err err) {
     /* initialize parse info */
     helper_stack_init(&pi.helpers);
     // Protect against GC
-    wrap = rb_data_object_wrap(rb_cObject, &pi, mark_pi_cb, NULL);
-    //wrap = Data_Wrap_Struct(rb_cObject, &pi, mark_pi_cb, NULL);
+    //wrap = rb_data_object_wrap(rb_cObject, &pi, mark_pi_cb, NULL);
+    wrap = Data_Wrap_Struct(rb_cObject, mark_pi_cb, NULL, &pi);
 
     err_init(&pi.err);
     pi.str = xml;

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -124,7 +124,7 @@ ox_parse(char *xml, ParseCallbacks pcb, char **endp, Options options, Err err) {
     /* initialize parse info */
     helper_stack_init(&pi.helpers);
     // Protect against GC
-    wrap = rb_data_object_wrap(rb_cObject, &pi, mark_pi_cb, NULL);
+    wrap = Data_Wrap_Struct(rb_cObject, &pi, mark_pi_cb, NULL);
 
     err_init(&pi.err);
     pi.str = xml;

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -124,7 +124,6 @@ ox_parse(char *xml, ParseCallbacks pcb, char **endp, Options options, Err err) {
     /* initialize parse info */
     helper_stack_init(&pi.helpers);
     // Protect against GC
-    //wrap = rb_data_object_wrap(rb_cObject, &pi, mark_pi_cb, NULL);
     wrap = Data_Wrap_Struct(rb_cObject, mark_pi_cb, NULL, &pi);
 
     err_init(&pi.err);

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -617,6 +617,7 @@ read_element(PInfo pi) {
 			    *start = '\0';
 			    break;
 			case NoSkip:
+			case OffSkip:
 			default:
 			    break;
 			}
@@ -745,6 +746,7 @@ read_text(PInfo pi) {
 			}			
 			break;
 		    case NoSkip:
+		    case OffSkip:
 		    default:
 			*b++ = c;
 			break;

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -124,7 +124,8 @@ ox_parse(char *xml, ParseCallbacks pcb, char **endp, Options options, Err err) {
     /* initialize parse info */
     helper_stack_init(&pi.helpers);
     // Protect against GC
-    wrap = Data_Wrap_Struct(rb_cObject, &pi, mark_pi_cb, NULL);
+    wrap = rb_data_object_wrap(rb_cObject, &pi, mark_pi_cb, NULL);
+    //wrap = Data_Wrap_Struct(rb_cObject, &pi, mark_pi_cb, NULL);
 
     err_init(&pi.err);
     pi.str = xml;

--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -1157,7 +1157,9 @@ read_text(SaxDrive dr) {
 	int	isEnd = ('/' == buf_get(&dr->buf));
 
 	buf_backup(&dr->buf);
-	if (NoSkip == dr->options.skip && dr->has.text && !isEnd) {
+	if (dr->has.text &&
+	    ((NoSkip == dr->options.skip && !isEnd) ||
+	     (OffSkip == dr->options.skip))) {
 	    args[0] = rb_str_new2(dr->buf.str);
 #if HAS_ENCODING_SUPPORT
 	    if (0 != dr->encoding) {

--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -175,7 +175,12 @@ sax_drive_init(SaxDrive dr, VALUE handler, VALUE io, SaxOptions options) {
     dr->buf.dr = dr;
     stack_init(&dr->stack);
     dr->handler = handler;
-    dr->value_obj = Data_Wrap_Struct(ox_sax_value_class, dr, 0, 0);
+    //dr->value_obj = Data_Wrap_Struct(ox_sax_value_class, dr, 0, 0);
+#if HAS_DATA_OBJECT_WRAP
+    dr->value_obj = rb_data_object_wrap(ox_sax_value_class, dr, 0, 0);
+#else
+    dr->value_obj = rb_data_object_alloc(ox_sax_value_class, dr, 0, 0);
+#endif
     rb_gc_register_address(&dr->value_obj);
     dr->options = *options;
     dr->err = 0;

--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -176,13 +176,6 @@ sax_drive_init(SaxDrive dr, VALUE handler, VALUE io, SaxOptions options) {
     stack_init(&dr->stack);
     dr->handler = handler;
     dr->value_obj = Data_Wrap_Struct(ox_sax_value_class, 0, 0, dr);
-#if 0
-#if HAS_DATA_OBJECT_WRAP
-    dr->value_obj = rb_data_object_wrap(ox_sax_value_class, dr, 0, 0);
-#else
-    dr->value_obj = rb_data_object_alloc(ox_sax_value_class, dr, 0, 0);
-#endif
-#endif
     rb_gc_register_address(&dr->value_obj);
     dr->options = *options;
     dr->err = 0;

--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -175,11 +175,13 @@ sax_drive_init(SaxDrive dr, VALUE handler, VALUE io, SaxOptions options) {
     dr->buf.dr = dr;
     stack_init(&dr->stack);
     dr->handler = handler;
-    //dr->value_obj = Data_Wrap_Struct(ox_sax_value_class, dr, 0, 0);
+    dr->value_obj = Data_Wrap_Struct(ox_sax_value_class, 0, 0, dr);
+#if 0
 #if HAS_DATA_OBJECT_WRAP
     dr->value_obj = rb_data_object_wrap(ox_sax_value_class, dr, 0, 0);
 #else
     dr->value_obj = rb_data_object_alloc(ox_sax_value_class, dr, 0, 0);
+#endif
 #endif
     rb_gc_register_address(&dr->value_obj);
     dr->options = *options;

--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -175,11 +175,7 @@ sax_drive_init(SaxDrive dr, VALUE handler, VALUE io, SaxOptions options) {
     dr->buf.dr = dr;
     stack_init(&dr->stack);
     dr->handler = handler;
-#if HAS_DATA_OBJECT_WRAP
-    dr->value_obj = rb_data_object_wrap(ox_sax_value_class, dr, 0, 0);
-#else
-    dr->value_obj = rb_data_object_alloc(ox_sax_value_class, dr, 0, 0);
-#endif
+    dr->value_obj = Data_Wrap_Struct(ox_sax_value_class, dr, 0, 0);
     rb_gc_register_address(&dr->value_obj);
     dr->options = *options;
     dr->err = 0;

--- a/lib/ox/version.rb
+++ b/lib/ox/version.rb
@@ -1,5 +1,5 @@
 
 module Ox
   # Current version of the module. 
-  VERSION = '2.8.0b1'
+  VERSION = '2.8.0'
 end

--- a/lib/ox/version.rb
+++ b/lib/ox/version.rb
@@ -1,5 +1,5 @@
 
 module Ox
   # Current version of the module. 
-  VERSION = '2.7.0'
+  VERSION = '2.8.0b1'
 end


### PR DESCRIPTION
Added skip_off mode that turns off all skipping of whitespace. Even all white space strings will be included in the SAX parsing.