### PR TITLE
SAX buf - avoid overflow

### DIFF
--- a/ext/ox/sax_buf.c
+++ b/ext/ox/sax_buf.c
@@ -203,7 +203,7 @@ ox_stpncpy(char *dest, const char *src, size_t n) {
 	cnt = n;
     }
     if (cnt > dest_s){
-      cnt = dest_s - 1;
+      cnt = dest_s;
     }
     strncpy(dest, src, cnt);
 

--- a/ext/ox/sax_buf.c
+++ b/ext/ox/sax_buf.c
@@ -197,12 +197,13 @@ read_from_fd(Buf buf) {
 static char*
 ox_stpncpy(char *dest, const char *src, size_t n) {
     size_t	cnt = strlen(src) + 1;
+    size_t	dest_s = sizeof(dest) - 1;
 
     if (n < cnt) {
 	cnt = n;
     }
-    if (cnt > sizeof(dest) - 1){
-      cnt = sizeof(dest) - 1;
+    if (cnt > dest_s){
+      cnt = dest_s - 1;
     }
     strncpy(dest, src, cnt);
 

--- a/ext/ox/sax_buf.c
+++ b/ext/ox/sax_buf.c
@@ -9,7 +9,7 @@
 #include <strings.h>
 #include <sys/types.h>
 #if NEEDS_UIO
-#include <sys/uio.h>    
+#include <sys/uio.h>
 #endif
 #include <unistd.h>
 #include <time.h>
@@ -73,7 +73,7 @@ int
 ox_sax_buf_read(Buf buf) {
     int         err;
     size_t      shift = 0;
-    
+
     // if there is not much room to read into, shift or realloc a larger buffer.
     if (buf->head < buf->tail && 4096 > buf->end - buf->tail) {
         if (0 == buf->pro) {
@@ -84,7 +84,7 @@ ox_sax_buf_read(Buf buf) {
         if (0 >= shift) { /* no space left so allocate more */
             char        *old = buf->head;
             size_t      size = buf->end - buf->head + BUF_PAD;
-        
+
             if (buf->head == buf->base) {
                 buf->head = ALLOC_N(char, size * 2);
                 memcpy(buf->head, old, size);
@@ -201,6 +201,9 @@ ox_stpncpy(char *dest, const char *src, size_t n) {
     if (n < cnt) {
 	cnt = n;
     }
+    if (cnt > sizeof(dest) - 1){
+      cnt = sizeof(dest) - 1;
+    }
     strncpy(dest, src, cnt);
 
     return dest + cnt - 1;
@@ -225,4 +228,3 @@ read_from_str(Buf buf) {
 
     return 0;
 }
-


### PR DESCRIPTION
check that the actual size of dest buffer before performing the strncpy

reference https://github.com/ohler55/ox/issues/195
