### PR TITLE
Add prepend_child method for Element nodes

### DIFF
--- a/lib/ox/element.rb
+++ b/lib/ox/element.rb
@@ -10,9 +10,9 @@ module Ox
   # sub elements or attributes simply by name. Repeating elements with the
   # same name can be referenced with an element count as well. A few examples
   # should explain the 'easy' API more clearly.
-  # 
+  #
   # *Example*
-  # 
+  #
   #   doc = Ox.parse(%{
   #   <?xml?>
   #   <People>
@@ -26,7 +26,7 @@ module Ox
   #     </Person>
   #   </People>
   #   })
-  #   
+  #
   #   doc.People.Person.given.text
   #   => "Peter"
   #   doc.People.Person(1).given.text
@@ -35,7 +35,7 @@ module Ox
   #   => "58"
   class Element < Node
     include HasAttrs
-    
+
     # Creates a new Element with the specified name.
     # - +name+ [String] name of the Element
     def initialize(name)
@@ -44,7 +44,7 @@ module Ox
       @nodes = []
     end
     alias name value
-    
+
     # Returns the Element's nodes array. These are the sub-elements of this
     # Element.
     # *return* [Array] all child Nodes.
@@ -63,6 +63,16 @@ module Ox
       self
     end
 
+    # Prepend a Node to the Element's nodes array. Returns the element itself
+    # so multiple appends can be chained together.
+    # - +node+ [Node] Node to prepend to the nodes array
+    def prepend_child(node)
+      raise "argument to << must be a String or Ox::Node." unless node.is_a?(String) or node.is_a?(Node)
+      @nodes = [] if !instance_variable_defined?(:@nodes) or @nodes.nil?
+      @nodes.unshift(node)
+      self
+    end
+
     # Returns true if this Object and other are of the same type and have the
     # equivalent value and the equivalent elements otherwise false is returned.
     # - +other+ [Object] Object compare _self_ to.
@@ -74,7 +84,7 @@ module Ox
       true
     end
     alias == eql?
-    
+
     # Returns the first String in the elements nodes array or nil if there is
     # no String node.
     def text()
@@ -168,7 +178,7 @@ module Ox
       end
       found
     end
-    
+
     # Handles the 'easy' API that allows navigating a simple XML by
     # referencing elements and attributes by name.
     # - +id+ [Symbol] element or attribute name

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -237,7 +237,7 @@ class Func < ::Test::Unit::TestCase
     dump_and_load(Bag.new({ }), false)
     dump_and_load(Bag.new(:@x => 3), false)
   end
-  
+
   def test_bad_object
     Ox::default_options = $ox_object_options
     xml = %{<?xml version="1.0"?>
@@ -785,7 +785,7 @@ class Func < ::Test::Unit::TestCase
     end
     assert(false)
   end
-  
+
   def test_mutex
     Ox::default_options = $ox_object_options
     if defined?(Mutex) && 'rubinius' != $ruby
@@ -918,7 +918,7 @@ class Func < ::Test::Unit::TestCase
 </Family>
 }
   end
-  
+
   def test_each
     Ox::default_options = $ox_object_options
     doc = Ox.parse(each_xml)
@@ -926,7 +926,7 @@ class Func < ::Test::Unit::TestCase
     doc.Family.Pete.each { |n| n.is_a?(Ox::Element) && nodes << n.id }
     assert_equal(['Nicole', 'Pamela', 'Fictional'], nodes)
   end
-  
+
   def test_each_name
     Ox::default_options = $ox_object_options
     doc = Ox.parse(each_xml)
@@ -970,7 +970,7 @@ class Func < ::Test::Unit::TestCase
 <!--One Only-->
 }
   end
-  
+
   def test_locate_self
     Ox::default_options = $ox_object_options
     doc = Ox.parse(locate_xml)
@@ -1142,7 +1142,7 @@ class Func < ::Test::Unit::TestCase
 </Family>
 }
   end
-  
+
   def test_easy_attribute
     Ox::default_options = $ox_object_options
     doc = Ox.parse(easy_xml)
@@ -1198,7 +1198,7 @@ class Func < ::Test::Unit::TestCase
     k1.replace_text('Spam')
     assert_equal('Spam', doc.Family.Pete.Kid(1).text)
   end
-  
+
   def test_easy_element_index
     Ox::default_options = $ox_object_options
     doc = Ox.parse(easy_xml)
@@ -1263,6 +1263,31 @@ class Func < ::Test::Unit::TestCase
 |, Ox.dump(doc))
   end
 
+  def test_prepend_child_invalid_node
+    parent = Ox::Element.new('Parent')
+    invalid_node = 12345
+    assert_raise { parent.prepend_child(invalid_node) }
+  end
+
+  def test_prepend_child_when_nodes_are_empty
+    parent = Ox::Element.new('Parent')
+    assert_equal(parent.nodes, [])
+    child = Ox::Element.new('Child')
+    parent.prepend_child(child)
+    assert_equal([child], parent.nodes)
+  end
+
+  def test_prepend_child_when_nodes_not_empty
+    parent = Ox::Element.new('Parent')
+    child0 = Ox::Element.new('Child0').tap { |n| parent << n }
+    child1 = Ox::Element.new('Child1').tap { |n| parent << n }
+    assert_equal(parent.nodes, [child0, child1])
+
+    child2 = Ox::Element.new('Child2')
+    parent.prepend_child(child2)
+    assert_equal([child2, child0, child1], parent.nodes)
+  end
+
   def test_builder
     b = Ox::Builder.new(:indent => 2)
     assert_equal(1, b.line())
@@ -1317,7 +1342,7 @@ comment -->
     b.pop()
     b.pop()
     b.close()
-    
+
     xml = File.read(filename)
     xml.force_encoding('UTF-8')
     assert_equal(%|<?xml version="1.0" encoding="UTF-8"?>
@@ -1361,7 +1386,7 @@ comment -->
       end
     end
   end
-  
+
   def test_builder_block
     xml = Ox::Builder.new(:indent => 2) { |b|
       b.instruct(:xml, :version => '1.0', :encoding => 'UTF-8')
@@ -1393,7 +1418,7 @@ comment -->
           b.text("my name is \"ピーター\"")
         }
       }
-    }    
+    }
     xml = File.read(filename)
     xml.force_encoding('UTF-8')
     assert_equal(%|<?xml version="1.0" encoding="UTF-8"?>
@@ -1436,7 +1461,7 @@ comment -->
       end
     end
   end
-  
+
   def test_builder_no_newline
     b = Ox::Builder.new(:indent => -1)
     b.instruct(:xml, :version => '1.0', :encoding => 'UTF-8')


### PR DESCRIPTION
I am working on a project where we need to manipulate some large XML and for performance reasons I moved from Nokogiri to Ox.

I was wrapping some methods around the original implementation of this gem, but it could be interesting actually to add them to the gem itself.

This first PR is about to provide `prepend_child` method for an `Element` instance.

Ps. my text editor settings remove trailing white spaces on save