### PR TITLE
Locate a specific element based on an attribute value

### DIFF
--- a/lib/ox/element.rb
+++ b/lib/ox/element.rb
@@ -159,6 +159,7 @@ module Ox
     # * <code>element.locate("Family/?[1]")</code> returns the first element in the Family Element.
     # * <code>element.locate("Family/?[<3]")</code> returns the first 3 elements in the Family Element.
     # * <code>element.locate("Family/?[@age=32]")</code> returns the elements with an age attribute equal to 32 in the Family Element.
+    # * <code>element.locate("Family/Kid[@age=32]")</code> returns the Kid elements with an age attribute equal to 32 in the Family Element.
     # * <code>element.locate("Family/?/@age")</code> returns the arg attribute for each child in the Family Element.
     # * <code>element.locate("Family/*/@type")</code> returns the type attribute value for decendents of the Family.
     # * <code>element.locate("Family/^Comment")</code> returns any comments that are a child of Family.
@@ -283,7 +284,7 @@ module Ox
           when '>'
             match = index <= match.size ? match[index + 1..-1] : []
           when '@'
-            k,v = step[3..-2].split('=')
+            k,v = step[i..-2].split('=')
             match = match.select { |n| n.is_a?(Element) && (v == n.attributes[k.to_sym] || v == n.attributes[k]) }
           else
             raise InvalidPath.new(path)

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -1130,6 +1130,12 @@ class Func < ::Test::Unit::TestCase
     doc = Ox.parse(locate_xml)
     nodes = doc.locate('Family/Pete/?[@age=32]')
     assert_equal(['Kid1'], nodes.map { |e| e.value } )
+
+    nodes = doc.locate('Family/Pete/Kid1[@age=32]')
+    assert_equal(['Kid1'], nodes.map { |e| e.value } )
+
+    nodes = doc.locate('Family/Pete/Kid1[@age=31]')
+    assert_equal([], nodes.map { |e| e.value } )
   end
 
   def easy_xml()


### PR DESCRIPTION
This light pr introduces a new search pattern in the `locate` method.

So far is possible to search only all children with a given attribute-value pair.
Thanks to this small change is possible to specify the `Element` type when performing the `locate` action.

E.g.

```ruby
# Test XML
%{<?xml?>
<Family real="false">
  <Pete age="57" type="male">
    <Son age="31" twin="true" name="John"/>
    <Daughter age="31" twin="true" name="Pamela"/>
  </Pete>
</Family>
<!--One Only-->
}
end
# Current implementation allows only:
element.locate("Family/?[@age=31]").map { |n| n[:name] }
=> ['John', 'Pamela']

# New feature allows also:
element.locate("Family/Son[@age=31]").map { |n| n[:name }
=> ['John']
```