### PR TITLE
Allow locate based on attribute presence

### DIFF
--- a/lib/ox/element.rb
+++ b/lib/ox/element.rb
@@ -158,6 +158,8 @@ module Ox
     # * <code>element.locate("Family/Pete/*")</code> returns all children of the Pete Element.
     # * <code>element.locate("Family/?[1]")</code> returns the first element in the Family Element.
     # * <code>element.locate("Family/?[<3]")</code> returns the first 3 elements in the Family Element.
+    # * <code>element.locate("Family/?[@age]")</code> returns the elements with an age attribute defined in the Family Element.
+    # * <code>element.locate("Family/Kid[@age]")</code> returns the Kid elements with an age attribute defined in the Family Element.
     # * <code>element.locate("Family/?[@age=32]")</code> returns the elements with an age attribute equal to 32 in the Family Element.
     # * <code>element.locate("Family/Kid[@age=32]")</code> returns the Kid elements with an age attribute equal to 32 in the Family Element.
     # * <code>element.locate("Family/?/@age")</code> returns the arg attribute for each child in the Family Element.
@@ -285,7 +287,11 @@ module Ox
             match = index <= match.size ? match[index + 1..-1] : []
           when '@'
             k,v = step[i..-2].split('=')
-            match = match.select { |n| n.is_a?(Element) && (v == n.attributes[k.to_sym] || v == n.attributes[k]) }
+            if v
+              match = match.select { |n| n.is_a?(Element) && (v == n.attributes[k.to_sym] || v == n.attributes[k]) }
+            else
+              match = match.select { |n| n.is_a?(Element) && (n.attributes[k.to_sym] || n.attributes[k]) }
+            end
           else
             raise InvalidPath.new(path)
           end

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -1138,6 +1138,24 @@ class Func < ::Test::Unit::TestCase
     assert_equal([], nodes.map { |e| e.value } )
   end
 
+  def test_locate_attr_presence
+    parent = Ox::Element.new('Parent')
+    son_with_job = Ox::Element.new('Son').tap do |n|
+      n['job'] = 'a job'
+      parent << n
+    end
+    son_without_job = Ox::Element.new('Son').tap { |n| parent << n }
+    daughter_with_job = Ox::Element.new('Daughter').tap do |n|
+      n['job'] = 'another job'
+      parent << n
+    end
+    assert_equal([son_with_job, son_without_job, daughter_with_job], parent.nodes)
+
+    assert_equal([son_with_job, daughter_with_job], parent.locate('?[@job]'))
+    assert_equal([son_with_job], parent.locate('Son[@job]'))
+    assert_equal([daughter_with_job], parent.locate('Daughter[@job]'))
+  end
+
   def easy_xml()
     %{<?xml?>
 <Family real="false">


### PR DESCRIPTION
In the current implementation the search pattern `?[@attribute]` is not working as expected:

```rb
parent = Ox::Element.new('Parent')
son_with_job = Ox::Element.new('Son').tap do |n|
  n['job'] = 'a job'
  parent << n
end
son_without_job = Ox::Element.new('Son').tap { |n| parent << n }
daughter_with_job = Ox::Element.new('Daughter').tap do |n|
  n['job'] = 'another job'
  parent << n
end
parent.locate('?[@job]')
=> [son_with_job, son_without_job, daughter_with_job]
```

The hack I needed to implement to look into sub-nodes was:

```rb
result = parent.locate('Something').select |n1|
  n1['attribute'] || n1[:attribute]
end.flat_map |n2|
  n2.locate('SomethingElse')
end
```

Thanks to this pr it will be possible to check the attribute presence when a value is not specified for a given node attribute:

```rb
parent.locate('?[@job]')
=> [son_with_job, daughter_with_job]
parent.locate('Son[@job]')
=> [son_with_job]
parent.locate('Daughter[@job]')
=> [daughter_with_job]
```

