### PR TITLE
Fix empty output with negative indent problem - not terminated buffer at start

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -1270,6 +1270,7 @@ dump_obj_to_xml(VALUE obj, Options copts, Out out) {
     out->circ_cnt = 0;
     out->opts = copts;
     out->obj = obj;
+    *out->cur = '\0';
     if (Yes == copts->circular) {
 	ox_cache8_new(&out->circ_cache);
     }

--- a/lib/ox/version.rb
+++ b/lib/ox/version.rb
@@ -1,5 +1,5 @@
 
 module Ox
-  # Current version of the module. 
-  VERSION = '2.9.3'
+  # Current version of the module.
+  VERSION = '2.9.4'
 end


### PR DESCRIPTION
We found some problem in `v2.9.3`
> related with: https://github.com/ohler55/ox/issues/215

-------- how it was
when 
output is empty 
and 
indent is set to -1

we got previous dumb_obj_to_xml result
--------
so I think that we should dump_value almost empty to fix this edge case 