### PR TITLE
Introduce an Ox::SyntaxError class

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -167,7 +167,7 @@ append_string(Builder b, const char *str, size_t size, const char *table, bool s
 		default:
 		    // Must be one of the invalid characters.
 		    if (!strip_invalid_chars) {
-			rb_raise(rb_eSyntaxError, "'\\#x%02x' is not a valid XML character.", *str);
+			rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *str);
 		    }
 		    break;
 		}

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -388,7 +388,7 @@ dump_str_value(Out out, const char *value, size_t size, const char *table) {
 	    default:
 		// Must be one of the invalid characters.
 		if (StrictEffort == out->opts->effort) {
-		    rb_raise(rb_eSyntaxError, "'\\#x%02x' is not a valid XML character.", *value);
+		    rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *value);
 		}
 		if (Yes == out->opts->allow_invalid) {
 		    *out->cur++ = '&';

--- a/ext/ox/err.h
+++ b/ext/ox/err.h
@@ -17,6 +17,7 @@ typedef struct _err {
 
 extern VALUE	ox_arg_error_class;
 extern VALUE	ox_parse_error_class;
+extern VALUE	ox_syntax_error_class;
 
 extern void	ox_err_set(Err e, VALUE clas, const char *format, ...);
 extern void	_ox_err_set_with_location(Err err, const char *msg, const char *xml, const char *current, const char* file, int line);

--- a/ext/ox/gen_load.c
+++ b/ext/ox/gen_load.c
@@ -90,7 +90,7 @@ create_prolog_doc(PInfo pi, const char *target, Attr attrs) {
     volatile VALUE	sym;
 
     if (!helper_stack_empty(&pi->helpers)) { /* top level object */
-        ox_err_set(&pi->err, rb_eSyntaxError, "Prolog must be the first element in an XML document.\n");
+        ox_err_set(&pi->err, ox_syntax_error_class, "Prolog must be the first element in an XML document.\n");
 	return;
     }
     doc = rb_obj_alloc(ox_document_clas);
@@ -161,7 +161,7 @@ instruct(PInfo pi, const char *target, Attr attrs, const char *content) {
         for (; 0 != attrs->name; attrs++) {
             if (0 == strcmp("version", attrs->name)) {
                 if (0 != strcmp("1.0", attrs->value)) {
-                    ox_err_set(&pi->err, rb_eSyntaxError, "Only Ox XML Object version 1.0 supported, not %s.\n", attrs->value);
+                    ox_err_set(&pi->err, ox_syntax_error_class, "Only Ox XML Object version 1.0 supported, not %s.\n", attrs->value);
 		    return;
                 }
             }
@@ -180,7 +180,7 @@ nomode_instruct(PInfo pi, const char *target, Attr attrs, const char *content) {
         for (; 0 != attrs->name; attrs++) {
             if (0 == strcmp("version", attrs->name)) {
                 if (0 != strcmp("1.0", attrs->value)) {
-                    ox_err_set(&pi->err, rb_eSyntaxError, "Only Ox XML Object version 1.0 supported, not %s.\n", attrs->value);
+                    ox_err_set(&pi->err, ox_syntax_error_class, "Only Ox XML Object version 1.0 supported, not %s.\n", attrs->value);
 		    return;
                 }
             } else if (0 == strcmp("mode", attrs->name)) {
@@ -195,7 +195,7 @@ nomode_instruct(PInfo pi, const char *target, Attr attrs, const char *content) {
                     pi->obj = Qnil;
 		    helper_stack_init(&pi->helpers);
                 } else {
-                    ox_err_set(&pi->err, rb_eSyntaxError, "%s is not a valid processing instruction mode.\n", attrs->value);
+                    ox_err_set(&pi->err, ox_syntax_error_class, "%s is not a valid processing instruction mode.\n", attrs->value);
 		    return;
                 }
             }

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -102,6 +102,7 @@ VALUE	ox_instruct_clas;
 VALUE	ox_parse_error_class;
 VALUE	ox_stringio_class;
 VALUE	ox_struct_class;
+VALUE	ox_syntax_error_class;
 VALUE	ox_time_class;
 
 Cache	ox_symbol_cache = 0;
@@ -1454,6 +1455,7 @@ void Init_ox() {
     ox_time_class = rb_const_get(rb_cObject, rb_intern("Time"));
     ox_date_class = rb_const_get(rb_cObject, rb_intern("Date"));
     ox_parse_error_class = rb_const_get_at(Ox, rb_intern("ParseError"));
+    ox_syntax_error_class = rb_const_get_at(Ox, rb_intern("SyntaxError"));
     ox_arg_error_class = rb_const_get_at(Ox, rb_intern("ArgError"));
     ox_struct_class = rb_const_get(rb_cObject, rb_intern("Struct"));
     ox_stringio_class = rb_const_get(rb_cObject, rb_intern("StringIO"));

--- a/lib/ox/error.rb
+++ b/lib/ox/error.rb
@@ -13,6 +13,10 @@ module Ox
   class ArgError < Error
   end # ArgError
 
+  # An Exception that is raised as a result of invalid XML syntax.
+  class SyntaxError < Error
+  end
+
   # An Exception raised if a path is not valid.
   class InvalidPath < Error
     # Create a new instance with the +path+ specified.

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -301,7 +301,15 @@ class Func < ::Test::Unit::TestCase
     assert_equal('Test', loaded);
   end
 
-  def test_syntax_error
+  def test_dump_invalid_character
+    assert_raise(Ox::SyntaxError) { Ox.dump("foo\x19bar") }
+  end
+
+  def test_unsupported_ox_version
+    assert_raise(Ox::SyntaxError) { Ox.parse(%{<?ox version="10"?><s>foobar</s>})}
+  end
+
+  def test_prolog_syntax_error
     xml = %{<blah><?xml version="1.0" ?><s>Test</s></blah>}
     assert_raise(Ox::SyntaxError) { Ox.parse(xml) }
   end

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -301,6 +301,11 @@ class Func < ::Test::Unit::TestCase
     assert_equal('Test', loaded);
   end
 
+  def test_syntax_error
+    xml = %{<blah><?xml version="1.0" ?><s>Test</s></blah>}
+    assert_raise(Ox::SyntaxError) { Ox.parse(xml) }
+  end
+
   def test_xml_instruction
     Ox::default_options = $ox_object_options
     xml = Ox.dump("test", :mode => :object, :with_xml => false)


### PR DESCRIPTION
Ox currently raises a `SyntaxError` when certain invalid XML is encountered (for instance, if a the document contains a prolog that is not the first element.)  Typically, `SyntaxError` is raised by the Ruby interpreter when code with invalid syntax is encountered.  From that standpoint, it is an unexpected error for Ox to be raising.  Additionally, `SyntaxError` does not inherit from `StandardError`, meaning that it must be explicitly rescued (or `Exception` must be rescued) and a bare rescue statement will not capture the error.  This behavior has tripped me up multiple times.

This change replaces Ox's use of `SyntaxError` with a new `Ox::SyntaxError` class that does inherit from `StandardError` and will be more natural for developers to work with.

I recognize that this is a breaking change and will likely require a major version bump.  I'm happy to expand the test cases to cover other places where `Ox::SyntaxError` is raised if this change is going to be accepted.