### PR TITLE
Fix issue with name/value alias for elements

### DIFF
--- a/lib/ox/element.rb
+++ b/lib/ox/element.rb
@@ -44,6 +44,7 @@ module Ox
       @nodes = []
     end
     alias name value
+    alias name= value=
 
     # Returns the Element's nodes array. These are the sub-elements of this
     # Element.


### PR DESCRIPTION
For Ox elements, `name` is an alias of `value`.

When renaming an element, only `value=` was working.

This PR makes `name=` work as well.

https://stackoverflow.com/questions/913349/what-is-the-best-way-to-create-alias-to-attributes-in-ruby