### PR TITLE
Fix the load path of the extension

### DIFF
--- a/lib/ox.rb
+++ b/lib/ox.rb
@@ -76,4 +76,4 @@ require 'ox/document'
 require 'ox/bag'
 require 'ox/sax'
 
-require 'ox/ox' # C extension
+require 'ox.so' # C extension


### PR DESCRIPTION
The require of the extension in the Ruby library assumes it is in stalled
as a gem and hence loads 'ox/ox', but it should just load the installed
'ox.so'.