### PR TITLE
Fix issue where closing tag name was not escaped

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -286,7 +286,7 @@ pop(Builder b) {
 	    append_indent(b);
 	}
 	buf_append_string(&b->buf, "</", 2);
-	buf_append_string(&b->buf, e->name, e->len);
+	append_string(b, e->name, e->len, xml_element_chars, false);
 	buf_append(&b->buf, '>');
 	b->col += e->len + 3;
 	b->pos += e->len + 3;

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -517,6 +517,14 @@ class Func < ::Test::Unit::TestCase
     }
   end
 
+  def test_escape_open_close_tag_names
+    Ox::default_options = $ox_object_options
+    b = Ox::Builder.new
+    b.element(%(/><script></script>)) { b.text('xss') }
+    s = b.to_s
+    assert_equal(%(</&gt;&lt;script&gt;&lt;/script&gt;>xss<//&gt;&lt;script&gt;&lt;/script&gt;>\n), s)
+  end
+
   def test_attr_as_string
     Ox::default_options = $ox_object_options
     xml = %{<top name="Pete"/>}


### PR DESCRIPTION
Previous behavior, when using the builder, only the open tag was properly escaped. Closing tags were rendered as-is. For example, when provided with a dangerous tag name and running the included test:

```
     522:     b = Ox::Builder.new
     523:     b.element('/><script></script>') { b.text('test') }
     524:     s = b.to_s
  => 525:     assert_equal('</&gt;&lt;script&gt;&lt;/script&gt;>test<//&gt;&lt;script&gt;&lt;/script&gt;>\n', s)
     526:   end
     527: 
     528:   def test_attr_as_string
test/tests.rb:525:in `test_escape_open_close_tag_names'
<"</&gt;&lt;script&gt;&lt;/script&gt;>test<//&gt;&lt;script&gt;&lt;/script&gt;>\\n">(UTF-8) expected but was
<"</&gt;&lt;script&gt;&lt;/script&gt;>test<//><script></script>>\n">(ASCII-8BIT)

diff:
? </&gt;&lt;script&gt;&lt;/script&gt;>test<//><      script><      /script    >> 
?                                            &gt;&lt;      &gt;&lt;       &gt; \n
  
? Encoding: ASCII-8BIT
?           UTF       
Failure: test_escape_open_close_tag_names(Func)
```