### PR TITLE
Add getter and setter for the indent value of `Ox::Builder`

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -881,6 +881,15 @@ builder_column(VALUE self) {
     return LONG2NUM(((Builder)DATA_PTR(self))->col);
 }
 
+/* call-seq: indent()
+ *
+ * Returns the indentation level
+ */
+static VALUE
+builder_get_indent(VALUE self) {
+    return INT2NUM(((Builder)DATA_PTR(self))->indent);
+}
+
 /* call-seq: pos()
  *
  * Returns the number of bytes written.
@@ -940,4 +949,5 @@ ox_init_builder(VALUE ox) {
     rb_define_method(builder_class, "line", builder_line, 0);
     rb_define_method(builder_class, "column", builder_column, 0);
     rb_define_method(builder_class, "pos", builder_pos, 0);
+    rb_define_method(builder_class, "indent", builder_get_indent, 0);
 }

--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -890,6 +890,26 @@ builder_get_indent(VALUE self) {
     return INT2NUM(((Builder)DATA_PTR(self))->indent);
 }
 
+/* call-seq: indent=(indent)
+ *
+ * Sets the indentation level
+ *
+ * - +indent+ (Fixnum) indentaion level, negative values excludes terminating newline
+ */
+static VALUE
+builder_set_indent(VALUE self, VALUE indent) {
+#ifdef RUBY_INTEGER_UNIFICATION
+    if (rb_cInteger != rb_obj_class(indent)) {
+#else
+    if (rb_cFixnum != rb_obj_class(indent)) {
+#endif
+      rb_raise(ox_parse_error_class, "indent must be a fixnum.\n");
+    }
+
+    ((Builder)DATA_PTR(self))->indent = NUM2INT(indent);
+    return Qnil;
+}
+
 /* call-seq: pos()
  *
  * Returns the number of bytes written.
@@ -950,4 +970,5 @@ ox_init_builder(VALUE ox) {
     rb_define_method(builder_class, "column", builder_column, 0);
     rb_define_method(builder_class, "pos", builder_pos, 0);
     rb_define_method(builder_class, "indent", builder_get_indent, 0);
+    rb_define_method(builder_class, "indent=", builder_set_indent, 1);
 }

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -1511,6 +1511,31 @@ comment -->
 |, xml)
   end
 
+  def test_builder_set_indent
+    b = Ox::Builder.new(:indent => 2)
+    assert_equal(2, b.indent())
+    b.instruct(:xml, :version => '1.0', :encoding => 'UTF-8')
+    b.element('one')
+    b.element('two')
+    b.indent = 0
+    b.text('Sample ')
+    b.element('three', :a => 'ack')
+    b.text('sample')
+    b.pop() # </three>
+    b.pop() # </two>
+    b.indent = 2
+    b.element('four')
+    b.pop()
+    b.close()
+    xml = b.to_s
+    assert_equal(%|<?xml version="1.0" encoding="UTF-8"?>
+<one>
+  <two>Sample <three a="ack">sample</three></two>
+  <four/>
+</one>
+|, xml)
+  end
+
   def test_builder_file
     filename = File.join(File.dirname(__FILE__), 'create_file_test.xml')
     b = Ox::Builder.file(filename, :indent => 2)

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -1471,6 +1471,7 @@ class Func < ::Test::Unit::TestCase
 
   def test_builder
     b = Ox::Builder.new(:indent => 2)
+    assert_equal(2, b.indent())
     assert_equal(1, b.line())
     assert_equal(1, b.column())
     assert_equal(0, b.pos())


### PR DESCRIPTION
First of all, thank you for the great gem and for keeping it easy to use.

I ran into a situation where the [XML file format](https://www.gala-global.org/tmx-14b) I'm generating has some requirements regarding the formatting, especially the whitespaces.

<details>
<summary>TMX specific details</summary>

[`<seg>` specifications](https://www.gala-global.org/tmx-14b#seg)
> ... All spacing and line-breaking characters are significant within a `<seg>` element.
</details>

In order to generate a human-readable XML, I'd like to keep the indentation for the rest of the file, and only switch the indentation off when the given node is being open.

This is my first contribution to a C extension, so let me know if I need to make changes to the `.c` file or if you think more testing is needed.