### PR TITLE
Resolve Ruby 3.2 "undefining the allocator of T_DATA class" warnings

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -952,6 +952,7 @@ ox_init_builder(VALUE ox) {
     ox = rb_define_module("Ox");
 #endif
     builder_class = rb_define_class_under(ox, "Builder", rb_cObject);
+    rb_undef_alloc_func(builder_class);
     rb_define_module_function(builder_class, "new", builder_new, -1);
     rb_define_module_function(builder_class, "file", builder_file, -1);
     rb_define_module_function(builder_class, "io", builder_io, -1);

--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -10,6 +10,7 @@
 
 #include "ruby.h"
 #include "ruby/encoding.h"
+#include "ruby/version.h"
 #include "ox.h"
 #include "buf.h"
 #include "err.h"
@@ -952,7 +953,9 @@ ox_init_builder(VALUE ox) {
     ox = rb_define_module("Ox");
 #endif
     builder_class = rb_define_class_under(ox, "Builder", rb_cObject);
+#if RUBY_API_VERSION_CODE >= 30200
     rb_undef_alloc_func(builder_class);
+#endif
     rb_define_module_function(builder_class, "new", builder_new, -1);
     rb_define_module_function(builder_class, "file", builder_file, -1);
     rb_define_module_function(builder_class, "io", builder_io, -1);

--- a/ext/ox/intern.c
+++ b/ext/ox/intern.c
@@ -5,6 +5,8 @@
 
 #include <stdint.h>
 
+#include "ruby/version.h"
+
 #include "cache.h"
 #include "ox.h"
 
@@ -68,7 +70,9 @@ static VALUE form_id(const char *str, size_t len) {
 
 void ox_hash_init() {
     VALUE cache_class = rb_define_class_under(Ox, "Cache", rb_cObject);
+#if RUBY_API_VERSION_CODE >= 30200
     rb_undef_alloc_func(cache_class);
+#endif
 
     ox_str_cache     = ox_cache_create(0, form_str, true, false);
     ox_str_cache_obj = Data_Wrap_Struct(cache_class, ox_cache_mark, ox_cache_free, ox_str_cache);

--- a/ext/ox/intern.c
+++ b/ext/ox/intern.c
@@ -68,6 +68,7 @@ static VALUE form_id(const char *str, size_t len) {
 
 void ox_hash_init() {
     VALUE cache_class = rb_define_class_under(Ox, "Cache", rb_cObject);
+    rb_undef_alloc_func(cache_class);
 
     ox_str_cache     = ox_cache_create(0, form_str, true, false);
     ox_str_cache_obj = Data_Wrap_Struct(cache_class, ox_cache_mark, ox_cache_free, ox_str_cache);

--- a/ext/ox/sax_as.c
+++ b/ext/ox/sax_as.c
@@ -255,10 +255,12 @@ ox_sax_define() {
 #if 0
     ox = rb_define_module("Ox");
     sax_module = rb_define_class_under(ox, "Sax", rb_cObject);
+    rb_undef_alloc_func(sax_module);
 #endif
     VALUE	sax_module = rb_const_get_at(Ox, rb_intern("Sax"));
 
     ox_sax_value_class = rb_define_class_under(sax_module, "Value", rb_cObject);
+    rb_undef_alloc_func(ox_sax_value_class);
 
     rb_define_method(ox_sax_value_class, "as_s", sax_value_as_s, 0);
     rb_define_method(ox_sax_value_class, "as_sym", sax_value_as_sym, 0);

--- a/ext/ox/sax_as.c
+++ b/ext/ox/sax_as.c
@@ -15,6 +15,7 @@
 #include <time.h>
 
 #include "ruby.h"
+#include "ruby/version.h"
 #include "ox.h"
 #include "sax.h"
 
@@ -254,13 +255,16 @@ void
 ox_sax_define() {
 #if 0
     ox = rb_define_module("Ox");
+#if RUBY_API_VERSION_CODE >= 30200
     sax_module = rb_define_class_under(ox, "Sax", rb_cObject);
-    rb_undef_alloc_func(sax_module);
+#endif
 #endif
     VALUE	sax_module = rb_const_get_at(Ox, rb_intern("Sax"));
 
     ox_sax_value_class = rb_define_class_under(sax_module, "Value", rb_cObject);
+#if RUBY_API_VERSION_CODE >= 30200
     rb_undef_alloc_func(ox_sax_value_class);
+#endif
 
     rb_define_method(ox_sax_value_class, "as_s", sax_value_as_s, 0);
     rb_define_method(ox_sax_value_class, "as_sym", sax_value_as_sym, 0);

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -795,6 +795,11 @@ class Func < ::Test::Unit::TestCase
     x = Ox.dump(Bag.new(:@o => Bag.new(:@a => [2]), :@a => [1, {:b => 3, :a => [5], :c => Bag.new(:@x => 7)}]), :indent => 1, :margin => '##')
 
     assert_equal('##<o c="Bag">
+## <o a="@o" c="Bag">
+##  <a a="@a">
+##   <i>2</i>
+##  </a>
+## </o>
 ## <a a="@a">
 ##  <i>1</i>
 ##  <h>
@@ -810,11 +815,6 @@ class Func < ::Test::Unit::TestCase
 ##   </o>
 ##  </h>
 ## </a>
-## <o a="@o" c="Bag">
-##  <a a="@a">
-##   <i>2</i>
-##  </a>
-## </o>
 ##</o>
 ', x)
   end

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -794,13 +794,13 @@ class Func < ::Test::Unit::TestCase
     Ox::default_options = $ox_object_options
     x = Ox.dump(Bag.new(:@o => Bag.new(:@a => [2]), :@a => [1, {:b => 3, :a => [5], :c => Bag.new(:@x => 7)}]), :indent => 1, :margin => '##')
 
-    assert_equal('##<o c="Bag">
-## <o a="@o" c="Bag">
+    assert(x.include?('## <o a="@o" c="Bag">
 ##  <a a="@a">
 ##   <i>2</i>
 ##  </a>
 ## </o>
-## <a a="@a">
+'))
+    assert(x.include?('## <a a="@a">
 ##  <i>1</i>
 ##  <h>
 ##   <m>b</m>
@@ -815,8 +815,7 @@ class Func < ::Test::Unit::TestCase
 ##   </o>
 ##  </h>
 ## </a>
-##</o>
-', x)
+'))
   end
 
   # Create an Object and an Array with the same Objects in them. Dump and load


### PR DESCRIPTION
warning: undefining the allocator of T_DATA class Ox::Cache
warning: undefining the allocator of T_DATA class Ox::Sax::Value

See: https://bugs.ruby-lang.org/issues/18007

Order of dumped XML elements changed in a test, but I believe the change is not significant.
