### PR TITLE
Load C extension with require_relative

### DIFF
--- a/lib/ox.rb
+++ b/lib/ox.rb
@@ -76,4 +76,9 @@ require 'ox/document'
 require 'ox/bag'
 require 'ox/sax'
 
-require 'ox/ox' # C extension
+# C extension
+begin
+  require_relative 'ox.so'
+rescue LoadError
+  require 'ox/ox'
+end


### PR DESCRIPTION
Fixed https://github.com/ohler55/ox/issues/300

RubyGems 3.4 cleaned-up build artifact automatically. We should use `require_relative` from `ox.rb` without `ext` directory.