### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99


### PR DESCRIPTION
Noticed that the `actions/checkout` was behind by a major version, so instead of bumping it, I thought adding Dependabot to keep them in sync would be better.