### PR TITLE
Add explicit 3.1 and 3.2 Ruby version to CI matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,8 @@ jobs:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby:
           - head
+          - '3.2'
+          - '3.1'
           - '3.0'
           - '2.7'
           - '2.6'


### PR DESCRIPTION
3.2 is probably the same as the HEAD right now, but probably good to be explicit