### PR TITLE
Enable Rubocop Gemspec/RequiredRubyVersion

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,13 +22,6 @@ Gemspec/RequireMFA:
   Exclude:
     - 'ox.gemspec'
 
-# Offense count: 1
-# Configuration parameters: Severity, Include.
-# Include: **/*.gemspec
-Gemspec/RequiredRubyVersion:
-  Exclude:
-    - 'ox.gemspec'
-
 # Offense count: 18
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/ox.gemspec
+++ b/ox.gemspec
@@ -27,4 +27,6 @@ serialization. }
 
   s.extra_rdoc_files = ['README.md', 'CHANGELOG.md']
   s.rdoc_options = ['--main', 'README.md', '--title', 'Ox', '--exclude', 'extconf.rb', 'lib', 'ext/ox', 'README.md']
+
+  s.required_ruby_version = '>= 2.5.0'
 end


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecrequiredrubyversion

Went by the currently tested version in CI, but wasn't sure if it was intentional to support the EOL 2.5, 2.6, and (soon) 2.7 versions, but left it as-is