### PR TITLE
Autofix Rubocop Layout rules - Batch  4

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,11 +9,17 @@ on:
       - ".rubocop*.yml"
       - ".github/workflows/rubocop.yml"
       - "**/*.rb"
+      - "**/*.gemspec"
+      - "**/*.gemfile"
+      - "Gemfile"
   pull_request:
     paths:
       - ".rubocop*.yml"
       - ".github/workflows/rubocop.yml"
       - "**/*.rb"
+      - "**/*.gemspec"
+      - "**/*.gemfile"
+      - "Gemfile"
 
 jobs:
   formatting-check:
@@ -28,12 +34,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.7"
-
-      - name: Install rubocop
-        run: gem install rubocop --no-doc
+          bundler-cache: true
 
       - name: Set-up RuboCop Problem Matcher
         uses: r7kamura/rubocop-problem-matchers-action@v1
 
       - name: Run rubocop
-        run: rubocop
+        run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
 
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
 Naming/MethodName:
   EnforcedStyle: snake_case
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,29 +16,6 @@ Layout/MultilineHashBraceLayout:
     - 'test/sample/file.rb'
     - 'test/tests.rb'
 
-# Offense count: 106
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideHashLiteralBraces:
-  Exclude:
-    - 'contrib/xbuilder_test.rb'
-    - 'examples/obj.rb'
-    - 'lib/ox/bag.rb'
-    - 'lib/ox/document.rb'
-    - 'lib/ox/hasattrs.rb'
-    - 'test/ox/doc.rb'
-    - 'test/ox/hasprops.rb'
-    - 'test/perf_gen.rb'
-    - 'test/perf_mars.rb'
-    - 'test/sample/doc.rb'
-    - 'test/sample/file.rb'
-    - 'test/sample/hasprops.rb'
-    - 'test/sax/sax_test.rb'
-    - 'test/sax/smart_test.rb'
-    - 'test/tests.rb'
-
 # Offense count: 12
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,18 +16,6 @@ Layout/MultilineHashBraceLayout:
     - 'test/sample/file.rb'
     - 'test/tests.rb'
 
-# Offense count: 10
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowForAlignment, EnforcedStyleForExponentOperator.
-# SupportedStylesForExponentOperator: space, no_space
-Layout/SpaceAroundOperators:
-  Exclude:
-    - 'contrib/xbuilder_test.rb'
-    - 'lib/ox/element.rb'
-    - 'test/perf_mars.rb'
-    - 'test/sax/sax_test.rb'
-    - 'test/tests.rb'
-
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,31 +16,6 @@ Layout/MultilineHashBraceLayout:
     - 'test/sample/file.rb'
     - 'test/tests.rb'
 
-# Offense count: 26
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceAroundEqualsInParameterDefault:
-  Exclude:
-    - 'lib/ox/bag.rb'
-    - 'lib/ox/document.rb'
-    - 'lib/ox/element.rb'
-    - 'test/ox/change.rb'
-    - 'test/ox/doc.rb'
-    - 'test/ox/oval.rb'
-    - 'test/ox/rect.rb'
-    - 'test/ox/shape.rb'
-    - 'test/ox/text.rb'
-    - 'test/perf_mars.rb'
-    - 'test/sample.rb'
-    - 'test/sample/change.rb'
-    - 'test/sample/doc.rb'
-    - 'test/sample/oval.rb'
-    - 'test/sample/rect.rb'
-    - 'test/sample/shape.rb'
-    - 'test/sample/text.rb'
-    - 'test/tests.rb'
-
 # Offense count: 10
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowForAlignment, EnforcedStyleForExponentOperator.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,18 +16,6 @@ Layout/MultilineHashBraceLayout:
     - 'test/sample/file.rb'
     - 'test/tests.rb'
 
-# Offense count: 4
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.
-# SupportedStyles: space, no_space
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideBlockBraces:
-  Exclude:
-    - 'contrib/xbuilder.rb'
-    - 'test/perf.rb'
-    - 'test/sax/smart_test.rb'
-    - 'test/tests.rb'
-
 # Offense count: 106
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,14 +16,6 @@ Layout/MultilineHashBraceLayout:
     - 'test/sample/file.rb'
     - 'test/tests.rb'
 
-# Offense count: 12
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, compact, no_space
-Layout/SpaceInsideParens:
-  Exclude:
-    - 'test/tests.rb'
-
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowSafeAssignment.

--- a/contrib/sax_benchmark.rb
+++ b/contrib/sax_benchmark.rb
@@ -93,7 +93,7 @@ class NokogiriHandler < Nokogiri::XML::SAX::Document
     end
   end
 
-  def start_element(key, attrs = [])
+  def start_element(key, attrs=[])
     @stack << @node = {}
     attrs.each do |attr|
       key, val = *attr

--- a/contrib/xbuilder.rb
+++ b/contrib/xbuilder.rb
@@ -16,7 +16,7 @@ module Ox
         when Hash
           arg.each { |k, v| n[k.to_s] = v }
         when Array
-          arg.each { |c| n << c if c}
+          arg.each { |c| n << c if c }
         else
           n << arg if arg
         end

--- a/contrib/xbuilder_test.rb
+++ b/contrib/xbuilder_test.rb
@@ -32,13 +32,13 @@ class XBuilderTest < Test::Unit::TestCase
         x_if(false, 'child5')
       ]
 
-    n=x('parent',
-        x('child1', {'atr1'=>'atr1_value', :atr2 => 'atr2_value'},
-          x('subchild1', 'some text'),
-          x('subchild2', {'atr3' => 'default_value'}, {'atr3' => 'atr3_value'},
-            x('sometag'),
-            x_if(false, 'never'))),
-        children)
+    n = x('parent',
+          x('child1', {'atr1' => 'atr1_value', :atr2 => 'atr2_value'},
+            x('subchild1', 'some text'),
+            x('subchild2', {'atr3' => 'default_value'}, {'atr3' => 'atr3_value'},
+              x('sometag'),
+              x_if(false, 'never'))),
+          children)
 
     assert_equal(Ox.dump(n), Ox.dump(Ox.parse(xml)))
   end

--- a/contrib/xbuilder_test.rb
+++ b/contrib/xbuilder_test.rb
@@ -33,9 +33,9 @@ class XBuilderTest < Test::Unit::TestCase
       ]
 
     n = x('parent',
-          x('child1', {'atr1' => 'atr1_value', :atr2 => 'atr2_value'},
+          x('child1', { 'atr1' => 'atr1_value', :atr2 => 'atr2_value' },
             x('subchild1', 'some text'),
-            x('subchild2', {'atr3' => 'default_value'}, {'atr3' => 'atr3_value'},
+            x('subchild2', { 'atr3' => 'default_value' }, { 'atr3' => 'atr3_value' },
               x('sometag'),
               x_if(false, 'never'))),
           children)

--- a/examples/obj.rb
+++ b/examples/obj.rb
@@ -21,7 +21,7 @@ class Classy
   end
 end
 
-obj = Classy.new(23, ['abc', {x: true}])
+obj = Classy.new(23, ['abc', { x: true }])
 
 doc = Ox.dump(obj, mode: :object)
 

--- a/examples/sax_ractor.rb
+++ b/examples/sax_ractor.rb
@@ -18,7 +18,7 @@ class Saxtor < Ox::Sax
   # yield it if its `ietf` matches our `needle`,
   # and throw it away otherwise.
   CYO = Struct.new(:ietf, :globs, :description) do
-    def initialize(ietf = nil, globs = [], description = nil)
+    def initialize(ietf=nil, globs=[], description=nil)
       super(ietf, globs, description)
     end
 

--- a/lib/ox/bag.rb
+++ b/lib/ox/bag.rb
@@ -14,7 +14,7 @@ module Ox
     #
     #  Ox::Bag.new(:@x => 42, :@y => 57)
     #
-    def initialize(args={ })
+    def initialize(args={})
       args.each do |k, v|
         instance_variable_set(k, v)
       end

--- a/lib/ox/document.rb
+++ b/lib/ox/document.rb
@@ -9,7 +9,7 @@ module Ox
     #   - _:standalone_ [String] indicates the document is standalone
     def initialize(prolog={})
       super(nil)
-      @attributes = { }
+      @attributes = {}
       @attributes[:version] = prolog[:version] unless prolog[:version].nil?
       @attributes[:encoding] = prolog[:encoding] unless prolog[:encoding].nil?
       @attributes[:standalone] = prolog[:standalone] unless prolog[:standalone].nil?

--- a/lib/ox/element.rb
+++ b/lib/ox/element.rb
@@ -269,7 +269,7 @@ module Ox
           name = step
           qual = nil
         else
-          name = step[0..i-1]
+          name = step[0..i - 1]
           raise InvalidPath.new(path) unless step.end_with?(']')
 
           i += 1
@@ -350,7 +350,7 @@ module Ox
           name = step
           qual = nil
         else
-          name = step[0..i-1]
+          name = step[0..i - 1]
           raise InvalidPath.new(path) unless step.end_with?(']')
 
           i += 1

--- a/lib/ox/hasattrs.rb
+++ b/lib/ox/hasattrs.rb
@@ -8,7 +8,7 @@ module Ox
     # Returns all the attributes of the Instruct as a Hash.
     # *return* [Hash] all attributes and attribute values.
     def attributes
-      @attributes = { } if !instance_variable_defined?(:@attributes) or @attributes.nil?
+      @attributes = {} if !instance_variable_defined?(:@attributes) or @attributes.nil?
       @attributes
     end
 
@@ -26,7 +26,7 @@ module Ox
     def []=(attr, value)
       raise 'argument to [] must be a Symbol or a String.' unless attr.is_a?(Symbol) or attr.is_a?(String)
 
-      @attributes = { } if !instance_variable_defined?(:@attributes) or @attributes.nil?
+      @attributes = {} if !instance_variable_defined?(:@attributes) or @attributes.nil?
       a_str = attr.to_s
       a_sym = attr.to_sym
       if @attributes.has_key?(a_str)

--- a/test/ox/doc.rb
+++ b/test/ox/doc.rb
@@ -24,7 +24,7 @@ module Test
         @title = title
         @user = ENV['USER']
         @create_time = Time.now
-        @layers = { }
+        @layers = {}
         @change_history = []
       end
 

--- a/test/ox/hasprops.rb
+++ b/test/ox/hasprops.rb
@@ -2,12 +2,12 @@ module Test
   module Ox
     module HasProps
       def add_prop(key, value)
-        @props = { } unless instance_variable_defined?(:@props)
+        @props = {} unless instance_variable_defined?(:@props)
         @props[key] = value
       end
 
       def props
-        @props = { } unless instance_variable_defined?(:@props)
+        @props = {} unless instance_variable_defined?(:@props)
         @props
       end
     end # HashProps

--- a/test/perf.rb
+++ b/test/perf.rb
@@ -17,7 +17,7 @@ class Perf
   end
 
   def run(iter)
-    base = Item.new(nil, nil) { }
+    base = Item.new(nil, nil) {}
     base.run(iter, 0.0)
     @items.each do |i|
       i.run(iter, base.duration)

--- a/test/perf_gen.rb
+++ b/test/perf_gen.rb
@@ -55,7 +55,7 @@ opts.on('-i', '--iterations [Int]', Integer, 'iterations')  { |it| $iter = it }
 opts.on('-h', '--help', 'Show this display')                { puts opts; Process.exit!(0) }
 files = opts.parse(ARGV)
 
-Ox.default_options = {mode: :generic}
+Ox.default_options = { mode: :generic }
 
 data = []
 

--- a/test/perf_mars.rb
+++ b/test/perf_mars.rb
@@ -61,7 +61,7 @@ s = Struct.new('Zoo', :x, :y, :z)
   data[:Symbol].values << "Symbol#{i}".to_sym
   data[:Time].values << (Time.now + i)
   data[:Array].values << []
-  data[:Hash].values << { }
+  data[:Hash].values << {}
   data[:Range].values << (0..7)
   data[:Regexp].values << /^[0-9]/
   data[:Bignum].values << (7**55)

--- a/test/perf_mars.rb
+++ b/test/perf_mars.rb
@@ -64,7 +64,7 @@ s = Struct.new('Zoo', :x, :y, :z)
   data[:Hash].values << { }
   data[:Range].values << (0..7)
   data[:Regexp].values << /^[0-9]/
-  data[:Bignum].values << (7 ** 55)
+  data[:Bignum].values << (7**55)
   data[:Complex].values << Complex(1, 2)
   data[:Rational].values << Rational(1, 3)
   data[:Struct].values << s.new(1, 3, 5)

--- a/test/perf_sax.rb
+++ b/test/perf_sax.rb
@@ -117,7 +117,7 @@ unless defined?(Nokogiri).nil?
   end
 
   class NoAllSax < NoSax
-    def start_element(name, attrs = []); end
+    def start_element(name, attrs=[]); end
     def characters(text); end
     def cdata_block(string); end
     def comment(string); end

--- a/test/sample/doc.rb
+++ b/test/sample/doc.rb
@@ -23,7 +23,7 @@ module Sample
       @title = title
       @user = ENV['USER']
       @create_time = Time.now
-      @layers = { }
+      @layers = {}
       @change_history = []
     end
 

--- a/test/sample/file.rb
+++ b/test/sample/file.rb
@@ -17,15 +17,15 @@ module Sample
           'user' => {
             'read' => (0 != (stat.mode & 0x0100)),
             'write' => (0 != (stat.mode & 0x0080)),
-            'execute' => (0 != (stat.mode & 0x0040))},
+            'execute' => (0 != (stat.mode & 0x0040)) },
           'group' => {
             'read' => (0 != (stat.mode & 0x0020)),
             'write' => (0 != (stat.mode & 0x0010)),
-            'execute' => (0 != (stat.mode & 0x0008))},
+            'execute' => (0 != (stat.mode & 0x0008)) },
           'other' => {
             'read' => (0 != (stat.mode & 0x0004)),
             'write' => (0 != (stat.mode & 0x0002)),
-            'execute' => (0 != (stat.mode & 0x0001))}
+            'execute' => (0 != (stat.mode & 0x0001)) }
         }
       else
         @permissions = {

--- a/test/sample/hasprops.rb
+++ b/test/sample/hasprops.rb
@@ -1,12 +1,12 @@
 module Sample
   module HasProps
     def add_prop(key, value)
-      @props = { } unless instance_variable_defined?(:@props)
+      @props = {} unless instance_variable_defined?(:@props)
       @props[key] = value
     end
 
     def props
-      @props = { } unless instance_variable_defined?(:@props)
+      @props = {} unless instance_variable_defined?(:@props)
       @props
     end
   end # HasProps

--- a/test/sax/helpers.rb
+++ b/test/sax/helpers.rb
@@ -15,7 +15,7 @@ module SaxTestHelpers
   #                 [:end_element, :top]
   #                ], AllSax, :convert_special => true, :smart => true)
   #
-  def parse_compare(xml, expected, handler_class = AllSax, opts = {}, handler_attr = :calls)
+  def parse_compare(xml, expected, handler_class=AllSax, opts={}, handler_attr=:calls)
     handler = handler_class.new
     input = StringIO.new(xml)
     options = {

--- a/test/sax/sax_test.rb
+++ b/test/sax/sax_test.rb
@@ -1276,7 +1276,7 @@ this is not part of the xml document
     Ox.default_options = $ox_sax_options
     handler = AllSax.new
 
-    Ox.sax_html(handler, '<html><h1>title</h1><hr/><p>Hello</p></html>', :overlay => {'hr'=>:inactive})
+    Ox.sax_html(handler, '<html><h1>title</h1><hr/><p>Hello</p></html>', :overlay => {'hr' => :inactive})
     assert_equal([
                    [:start_element, :html],
                    [:start_element, :h1],

--- a/test/sax/sax_test.rb
+++ b/test/sax/sax_test.rb
@@ -1276,7 +1276,7 @@ this is not part of the xml document
     Ox.default_options = $ox_sax_options
     handler = AllSax.new
 
-    Ox.sax_html(handler, '<html><h1>title</h1><hr/><p>Hello</p></html>', :overlay => {'hr' => :inactive})
+    Ox.sax_html(handler, '<html><h1>title</h1><hr/><p>Hello</p></html>', :overlay => { 'hr' => :inactive })
     assert_equal([
                    [:start_element, :html],
                    [:start_element, :h1],

--- a/test/sax/smart_test.rb
+++ b/test/sax/smart_test.rb
@@ -357,7 +357,7 @@ class SaxSmartNormalTagTest < SaxSmartTest
 </html>
 }
     overlay = Ox.sax_html_overlay.dup
-    overlay.each_key {|k| overlay[k] = :off }
+    overlay.each_key { |k| overlay[k] = :off }
     overlay['!--'] = :active
 
     handler = AllSax.new

--- a/test/sax/smart_test.rb
+++ b/test/sax/smart_test.rb
@@ -40,7 +40,7 @@ class SaxSmartTest < Test::Unit::TestCase
     'cite' => {},
     'colgroup' => { 'parents' => ['table'], 'childs' => ['col'] },
     'data' => {},
-    'datalist' => { 'childs' => ['option']},
+    'datalist' => { 'childs' => ['option'] },
     'dl' => { 'childs' => ['dt', 'dd'] },
     'dt' => { 'parents' => ['dl'] },
     'dd' => { 'parents' => ['dl'] },
@@ -634,7 +634,7 @@ class SaxSmartTableTagTest < SaxSmartTest
                         [:end_element, :table],
                         [:end_element, :body],
                         [:end_element, :html]],
-                       {:overlay => hints})
+                       { :overlay => hints })
   end
 
   def test_nest_ok_auto_closing
@@ -650,6 +650,6 @@ class SaxSmartTableTagTest < SaxSmartTest
                         [:end_element, :h5],
                         [:end_element, :body],
                         [:end_element, :html]],
-                       {:overlay => hints})
+                       { :overlay => hints })
   end
 end

--- a/test/sax/smart_test.rb
+++ b/test/sax/smart_test.rb
@@ -136,7 +136,7 @@ class SaxSmartTest < Test::Unit::TestCase
   }
 
   # Make the :smart => true option the default one
-  def smart_parse_compare(xml, expected, handler = AllSax, opts = {}, handler_attr = :calls)
+  def smart_parse_compare(xml, expected, handler=AllSax, opts={}, handler_attr=:calls)
     parse_compare(xml, expected, handler, opts.merge(:smart => true, :skip => :skip_white), handler_attr)
   end
 end
@@ -155,7 +155,7 @@ class ErrorsOnParentNormalElementTest < SaxSmartTest
     NORMALELEMENTS[el]['parents'] || ['body']
   end
 
-  def ancestry_of(el, parent = nil)
+  def ancestry_of(el, parent=nil)
     p = parent || parents_of(el)[0]
     [el] + (p ? ancestry_of(p) : [])
   end
@@ -588,7 +588,7 @@ class SaxSmartTableTagTest < SaxSmartTest
                          [:end_element, :html]])
   end
 
-  def html_parse_compare(xml, expected, opts = {})
+  def html_parse_compare(xml, expected, opts={})
     handler = AllSax.new
     input = StringIO.new(xml)
     options = {

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -1195,52 +1195,52 @@ class Func < Test::Unit::TestCase
     Ox.default_options = $ox_object_options
     doc = Ox.parse(locate_xml)
     nodes = doc.locate('Family/Pete/?[0]')
-    assert_equal(['Kid1'], nodes.map { |e| e.value } )
+    assert_equal(['Kid1'], nodes.map { |e| e.value })
     nodes = doc.locate('Family/Pete/?[1]')
-    assert_equal(['Nicole'], nodes.map { |e| e.value } )
+    assert_equal(['Nicole'], nodes.map { |e| e.value })
     nodes = doc.locate('Family/Pete/?[2]')
-    assert_equal(['Kid2'], nodes.map { |e| e.value } )
+    assert_equal(['Kid2'], nodes.map { |e| e.value })
   end
 
   def test_locate_qual_less
     Ox.default_options = $ox_object_options
     doc = Ox.parse(locate_xml)
     nodes = doc.locate('Family/Pete/?[<1]')
-    assert_equal(['Kid1'], nodes.map { |e| e.value } )
+    assert_equal(['Kid1'], nodes.map { |e| e.value })
   end
 
   def test_locate_qual_great
     Ox.default_options = $ox_object_options
     doc = Ox.parse(locate_xml)
     nodes = doc.locate('Family/Pete/?[>1]')
-    assert_equal(['Kid2', 'Pamela'], nodes.map { |e| e.value } )
+    assert_equal(['Kid2', 'Pamela'], nodes.map { |e| e.value })
   end
 
   def test_locate_qual_last
     Ox.default_options = $ox_object_options
     doc = Ox.parse(locate_xml)
     nodes = doc.locate('Family/Pete/?[-1]')
-    assert_equal(['Pamela'], nodes.map { |e| e.value } )
+    assert_equal(['Pamela'], nodes.map { |e| e.value })
   end
 
   def test_locate_qual_last_attr
     Ox.default_options = $ox_object_options
     doc = Ox.parse(locate_xml)
     nodes = doc.locate('Family/Pete/?[-2]/@age')
-    assert_equal(['31'], nodes )
+    assert_equal(['31'], nodes)
   end
 
   def test_locate_attr_match
     Ox.default_options = $ox_object_options
     doc = Ox.parse(locate_xml)
     nodes = doc.locate('Family/Pete/?[@age=32]')
-    assert_equal(['Kid1'], nodes.map { |e| e.value } )
+    assert_equal(['Kid1'], nodes.map { |e| e.value })
 
     nodes = doc.locate('Family/Pete/Kid1[@age=32]')
-    assert_equal(['Kid1'], nodes.map { |e| e.value } )
+    assert_equal(['Kid1'], nodes.map { |e| e.value })
 
     nodes = doc.locate('Family/Pete/Kid1[@age=31]')
-    assert_equal([], nodes.map { |e| e.value } )
+    assert_equal([], nodes.map { |e| e.value })
   end
 
   def test_locate_attr_presence
@@ -1418,7 +1418,7 @@ class Func < Test::Unit::TestCase
   def test_namespace_strip_wild
     Ox.default_options = $ox_generic_options
     results = []
-    doc = Ox.load('<spaced:one><two spaced:out="no">inside</two></spaced:one>', :strip_namespace => true )
+    doc = Ox.load('<spaced:one><two spaced:out="no">inside</two></spaced:one>', :strip_namespace => true)
     assert_equal(%|
 <one>
   <two out="no">inside</two>
@@ -1890,7 +1890,7 @@ comment -->
 }
     ep = lambda { |k| k.downcase }
     ap = lambda { |k| 'a' + k }
-    doc = Ox.load(xml, mode: :generic, attr_key_mod: ap, element_key_mod: ep )
+    doc = Ox.load(xml, mode: :generic, attr_key_mod: ap, element_key_mod: ep)
     xml2 = Ox.dump(doc)
     assert_equal(%{
 <changeme ax="A"/>

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -104,7 +104,7 @@ class Func < Test::Unit::TestCase
       :strip_namespace => 'spaced',
       :overlay => nil,
     }
-    o3 = { :xsd_date=>false }
+    o3 = { :xsd_date => false }
     Ox.default_options = o2
     opts = Ox.default_options
     assert_equal(o2, opts);
@@ -209,8 +209,8 @@ class Func < Test::Unit::TestCase
 
   def test_bignum
     Ox.default_options = $ox_object_options
-    dump_and_load(7 ** 55, false)
-    dump_and_load(-7 ** 55, false)
+    dump_and_load(7**55, false)
+    dump_and_load(-7**55, false)
   end
 
   def test_bigdecimal
@@ -350,7 +350,7 @@ class Func < Test::Unit::TestCase
     assert_equal(Ox::Instruct, inst.class)
     assert_equal('attrs', inst.target)
     assert_nil(inst.content)
-    assert_equal({:dog=>'big'}, inst.attributes)
+    assert_equal({:dog => 'big'}, inst.attributes)
 
     inst = doc.top.content
     assert_equal(Ox::Instruct, inst.class)

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -307,7 +307,7 @@ class Func < Test::Unit::TestCase
   end
 
   def test_unsupported_ox_version
-    assert_raise(Ox::SyntaxError) { Ox.parse(%{<?ox version="10"?><s>foobar</s>})}
+    assert_raise(Ox::SyntaxError) { Ox.parse(%{<?ox version="10"?><s>foobar</s>}) }
   end
 
   def test_prolog_syntax_error

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -179,7 +179,7 @@ class Func < Test::Unit::TestCase
 
   def test_hash
     Ox.default_options = $ox_object_options
-    dump_and_load({ }, false)
+    dump_and_load({}, false)
     dump_and_load({ 'a' => 1, 2 => 'b' }, false)
   end
 
@@ -241,7 +241,7 @@ class Func < Test::Unit::TestCase
 
   def test_object
     Ox.default_options = $ox_object_options
-    dump_and_load(Bag.new({ }), false)
+    dump_and_load(Bag.new({}), false)
     dump_and_load(Bag.new(:@x => 3), false)
   end
 
@@ -350,7 +350,7 @@ class Func < Test::Unit::TestCase
     assert_equal(Ox::Instruct, inst.class)
     assert_equal('attrs', inst.target)
     assert_nil(inst.content)
-    assert_equal({:dog => 'big'}, inst.attributes)
+    assert_equal({ :dog => 'big' }, inst.attributes)
 
     inst = doc.top.content
     assert_equal(Ox::Instruct, inst.class)
@@ -782,12 +782,12 @@ class Func < Test::Unit::TestCase
 
   def test_complex
     Ox.default_options = $ox_object_options
-    dump_and_load(Bag.new(:@o => Bag.new(:@a => [2]), :@a => [1, {:b => 3, :a => [5], :c => Bag.new(:@x => 7)}]), false)
+    dump_and_load(Bag.new(:@o => Bag.new(:@a => [2]), :@a => [1, { :b => 3, :a => [5], :c => Bag.new(:@x => 7) }]), false)
   end
 
   def test_dump_margin
     Ox.default_options = $ox_object_options
-    x = Ox.dump(Bag.new(:@o => Bag.new(:@a => [2]), :@a => [1, {:b => 3, :a => [5], :c => Bag.new(:@x => 7)}]), :indent => 1, :margin => '##')
+    x = Ox.dump(Bag.new(:@o => Bag.new(:@a => [2]), :@a => [1, { :b => 3, :a => [5], :c => Bag.new(:@x => 7) }]), :indent => 1, :margin => '##')
 
     assert(x.include?('## <o a="@o" c="Bag">
 ##  <a a="@a">
@@ -1722,7 +1722,7 @@ comment -->
     xml = %{<top>This is the top.</top>
 }
     doc = Ox.load(xml, :mode => :hash)
-    assert_equal({top: 'This is the top.'}, doc)
+    assert_equal({ top: 'This is the top.' }, doc)
   end
 
   def test_hash_no_attrs_mode_simple_nested
@@ -1737,7 +1737,7 @@ comment -->
 </top>
 }
     doc = Ox.load(xml, :mode => :hash)
-    assert_equal({top: {one: 'This is a one.', mid: {a: 'alpha', b: 'bravo'}}}, doc)
+    assert_equal({ top: { one: 'This is a one.', mid: { a: 'alpha', b: 'bravo' } } }, doc)
   end
 
   def test_hash_no_attrs_mode_multi_text
@@ -1745,7 +1745,7 @@ comment -->
     xml = %{<top>First<empty/>Second<empty></empty>Third</top>
 }
     doc = Ox.load(xml, :mode => :hash)
-    assert_equal({top: ['First', {empty: nil}, 'Second', {empty: nil}, 'Third']}, doc)
+    assert_equal({ top: ['First', { empty: nil }, 'Second', { empty: nil }, 'Third'] }, doc)
   end
 
   def test_hash_mode_simple
@@ -1753,7 +1753,7 @@ comment -->
     xml = %{<top>This is the top.</top>
 }
     doc = Ox.load(xml, :mode => :hash)
-    assert_equal({top: 'This is the top.'}, doc)
+    assert_equal({ top: 'This is the top.' }, doc)
   end
 
   def test_hash_mode_simple_nested
@@ -1768,7 +1768,7 @@ comment -->
 </top>
 }
     doc = Ox.load(xml, :mode => :hash)
-    assert_equal({top: {one: 'This is a one.', mid: {a: 'alpha', b: 'bravo'}}}, doc)
+    assert_equal({ top: { one: 'This is a one.', mid: { a: 'alpha', b: 'bravo' } } }, doc)
   end
 
   def test_hash_mode_simple_cdata
@@ -1783,10 +1783,10 @@ comment -->
 </top>
 }
     doc = Ox.load(xml, mode: :hash, with_cdata: true)
-    assert_equal({top: {one: 'This is a one.', mid: {a: 'alpha', b: 'bravo'}}}, doc)
+    assert_equal({ top: { one: 'This is a one.', mid: { a: 'alpha', b: 'bravo' } } }, doc)
 
     doc = Ox.load(xml, mode: :hash, with_cdata: false)
-    assert_equal({top: {one: 'This is a one.', mid: {a: nil, b: nil}}}, doc)
+    assert_equal({ top: { one: 'This is a one.', mid: { a: nil, b: nil } } }, doc)
   end
 
   def test_hash_mode_multi_text
@@ -1794,7 +1794,7 @@ comment -->
     xml = %{<top>First<empty/>Second<empty></empty>Third</top>
 }
     doc = Ox.load(xml, :mode => :hash)
-    assert_equal({top: ['First', {empty: nil}, 'Second', {empty: nil}, 'Third']}, doc)
+    assert_equal({ top: ['First', { empty: nil }, 'Second', { empty: nil }, 'Third'] }, doc)
   end
 
   def test_hash_mode_simple_attrs
@@ -1802,7 +1802,7 @@ comment -->
     xml = %{<top type="string">This is the top.</top>
 }
     doc = Ox.load(xml, :mode => :hash)
-    assert_equal({top: [{type: 'string'}, 'This is the top.']}, doc)
+    assert_equal({ top: [{ type: 'string' }, 'This is the top.'] }, doc)
   end
 
   def test_hash_mode_attrs
@@ -1818,13 +1818,13 @@ comment -->
 </result>
 }
     doc = Ox.load(xml, :mode => :hash)
-    assert_equal({result: {
+    assert_equal({ result: {
                    variables: {
                      var: [
-                       [{name: 'Blue'}, '14'],
-                       [{name: 'Jack'}, '14'],
-                       [{name: 'Magenta'}, '12'],
-                       [{name: 'Yellow'}, '14']
+                       [{ name: 'Blue' }, '14'],
+                       [{ name: 'Jack' }, '14'],
+                       [{ name: 'Magenta' }, '12'],
+                       [{ name: 'Yellow' }, '14']
                      ],
                    }
                  }
@@ -1844,13 +1844,13 @@ comment -->
 </result>
 }
     doc = Ox.load(xml, :mode => :hash)
-    assert_equal({result: {
+    assert_equal({ result: {
                    variables: {
                      var: [
                        '14',
-                       [{name: 'Jack'}, '14'],
-                       [{name: 'Magenta'}, '12'],
-                       [{name: 'Yellow'}, '14']
+                       [{ name: 'Jack' }, '14'],
+                       [{ name: 'Magenta' }, '12'],
+                       [{ name: 'Yellow' }, '14']
                      ],
                    }
                  }
@@ -1870,13 +1870,13 @@ comment -->
 </result>
 }
     doc = Ox.load(xml, :mode => :hash)
-    assert_equal({result: {
+    assert_equal({ result: {
                    variables: {
                      var: [
-                       [{name: 'Blue'}, '14'],
+                       [{ name: 'Blue' }, '14'],
                        '14',
-                       [{name: 'Magenta'}, '12'],
-                       [{name: 'Yellow'}, '14']
+                       [{ name: 'Magenta' }, '12'],
+                       [{ name: 'Yellow' }, '14']
                      ],
                    }
                  }

--- a/test/weather/wnosax.rb
+++ b/test/weather/wnosax.rb
@@ -23,7 +23,7 @@ module Weather
       @cell = 0
     end
 
-    def start_element(name, attrs = [])
+    def start_element(name, attrs=[])
       case name
       when 'Cell'
         @cell += 1


### PR DESCRIPTION
Forth run a the autofixing the Layout related Rubocop rules.
Most of these have options allowing overriding specific things if they style isn't preffered.

This is the last of the Layout, except for the 2 that were removed from the last batch