### PR TITLE
Add rake task in order to invoke tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,12 +32,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: build
-        run: |
-          cd ./ext/ox
-          ruby extconf.rb
-          make
-      - name: test
-        run: |
-          cd test
-          ./tests.rb
+          bundler-cache: true
+      - run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Makefile
 .yardoc
 doc
 Gemfile.lock
+test/create_file_test.xml
+tmp

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rake/extensiontask'
+require 'rake/testtask'
+
+Rake::ExtensionTask.new('ox') do |ext|
+  ext.lib_dir = 'lib/ox'
+end
+
+task test_all: [:clean, :compile] do
+  $stdout.flush
+  exitcode = 0
+  status = 0
+
+  cmds = 'ruby test/tests.rb -v'
+
+  $stdout.syswrite "\n#{'#' * 90}\n#{cmds}\n"
+  Bundler.with_original_env do
+    status = system(cmds)
+  end
+  exitcode = 1 unless status
+
+  Rake::Task['test'].invoke
+  exit(1) if exitcode == 1
+end
+
+task default: :test_all

--- a/ox.gemspec
+++ b/ox.gemspec
@@ -28,5 +28,7 @@ serialization. }
 
   s.required_ruby_version = '>= 2.7.0'
 
+  s.add_development_dependency 'rake-compiler', '>= 1.2', '< 2.0'
+
   s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -1556,6 +1556,8 @@ comment -->
   end
 
   def test_builder_io
+    omit 'needs fork' unless Process.respond_to?(:fork)
+
     IO.pipe do |r, w|
       if fork
         w.close
@@ -1632,6 +1634,8 @@ comment -->
   end
 
   def test_builder_block_io
+    omit 'needs fork' unless Process.respond_to?(:fork)
+
     IO.pipe do |r, w|
       if fork
         w.close


### PR DESCRIPTION
Seems that several steps should be taken to invoke the tests for ox gem.

Since it is easy to make a mistake for me, this patch will invoke the tests with the `rake` command only.