### PR TITLE
Clean up by removing CRuby API checks that are no longer needed

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -866,7 +866,6 @@ static void dump_obj(ID aid, VALUE obj, int depth, Out out) {
             dump_gen_element(obj, depth + 1, out);
             out->w_end(out, &e);
         } else { /* Object */
-#if HAVE_RB_IVAR_FOREACH
             e.type   = (Qtrue == rb_obj_is_kind_of(obj, rb_eException)) ? ExceptionCode : ObjectCode;
             cnt      = (int)rb_ivar_count(obj);
             e.closed = (0 >= cnt);
@@ -879,29 +878,6 @@ static void dump_obj(ID aid, VALUE obj, int depth, Out out) {
                 out->depth = od;
                 out->w_end(out, &e);
             }
-#else
-            volatile VALUE vars = rb_obj_instance_variables(obj);
-            // volatile VALUE	   vars = rb_funcall2(obj, rb_intern("instance_variables"), 0, 0);
-
-            e.type   = (Qtrue == rb_obj_is_kind_of(obj, rb_eException)) ? ExceptionCode : ObjectCode;
-            cnt      = (int)RARRAY_LEN(vars);
-            e.closed = (0 >= cnt);
-            out->w_start(out, &e);
-            if (0 < cnt) {
-                const VALUE *np = RARRAY_PTR(vars);
-                ID           vid;
-                unsigned int od = out->depth;
-                int          i;
-
-                out->depth = depth + 1;
-                for (i = cnt; 0 < i; i--, np++) {
-                    vid = rb_to_id(*np);
-                    dump_var(vid, rb_ivar_get(obj, vid), out);
-                }
-                out->depth = od;
-                out->w_end(out, &e);
-            }
-#endif
         }
         break;
     }

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -440,19 +440,13 @@ inline static void dump_num(Out out, VALUE obj) {
 }
 
 static void dump_time_thin(Out out, VALUE obj) {
-    char  buf[64];
-    char *b = buf + sizeof(buf) - 1;
-#if HAVE_RB_TIME_TIMESPEC
+    char            buf[64];
+    char           *b    = buf + sizeof(buf) - 1;
     struct timespec ts   = rb_time_timespec(obj);
     time_t          sec  = ts.tv_sec;
     long            nsec = ts.tv_nsec;
-#else
-    time_t sec  = NUM2LONG(rb_funcall2(obj, ox_tv_sec_id, 0, 0));
-    long   nsec = NUM2LONG(rb_funcall2(obj, ox_tv_nsec_id, 0, 0));
-    // long		nsec = NUM2LONG(rb_funcall2(obj, ox_tv_usec_id, 0, 0)) * 1000;
-#endif
-    char *dot = b - 10;
-    long  size;
+    char           *dot  = b - 10;
+    long            size;
 
     *b-- = '\0';
     for (; dot < b; b--, nsec /= 10) {
@@ -495,18 +489,12 @@ static void dump_date(Out out, VALUE obj) {
 }
 
 static void dump_time_xsd(Out out, VALUE obj) {
-    struct tm *tm;
-#if HAVE_RB_TIME_TIMESPEC
+    struct tm      *tm;
     struct timespec ts   = rb_time_timespec(obj);
     time_t          sec  = ts.tv_sec;
     long            nsec = ts.tv_nsec;
-#else
-    time_t sec  = NUM2LONG(rb_funcall2(obj, ox_tv_sec_id, 0, 0));
-    long   nsec = NUM2LONG(rb_funcall2(obj, ox_tv_nsec_id, 0, 0));
-    // long		nsec = NUM2LONG(rb_funcall2(obj, ox_tv_usec_id, 0, 0)) * 1000;
-#endif
-    int  tzhour, tzmin;
-    char tzsign = '+';
+    int             tzhour, tzmin;
+    char            tzsign = '+';
 
     if (out->end - out->cur <= 33) {
         grow(out, 33);

--- a/ext/ox/extconf.rb
+++ b/ext/ox/extconf.rb
@@ -33,7 +33,6 @@ CONFIG['warnflags'].slice!(/ -Wdeclaration-after-statement/)
 CONFIG['warnflags'].slice!(/ -Wmissing-noreturn/)
 
 have_func('rb_time_timespec')
-have_func('rb_struct_alloc_noinit')
 have_func('rb_ivar_foreach')
 have_func('rb_ext_ractor_safe', 'ruby.h')
 have_func('pthread_mutex_init')

--- a/ext/ox/extconf.rb
+++ b/ext/ox/extconf.rb
@@ -33,7 +33,6 @@ CONFIG['warnflags'].slice!(/ -Wdeclaration-after-statement/)
 CONFIG['warnflags'].slice!(/ -Wmissing-noreturn/)
 
 have_func('rb_time_timespec')
-have_func('rb_ivar_foreach')
 have_func('rb_ext_ractor_safe', 'ruby.h')
 have_func('pthread_mutex_init')
 have_func('rb_enc_interned_str')

--- a/ext/ox/extconf.rb
+++ b/ext/ox/extconf.rb
@@ -34,7 +34,6 @@ CONFIG['warnflags'].slice!(/ -Wmissing-noreturn/)
 
 have_func('rb_time_timespec')
 have_func('rb_struct_alloc_noinit')
-have_func('rb_obj_encoding')
 have_func('rb_ivar_foreach')
 have_func('rb_ext_ractor_safe', 'ruby.h')
 have_func('pthread_mutex_init')

--- a/ext/ox/extconf.rb
+++ b/ext/ox/extconf.rb
@@ -35,7 +35,6 @@ CONFIG['warnflags'].slice!(/ -Wmissing-noreturn/)
 have_func('rb_ext_ractor_safe', 'ruby.h')
 have_func('pthread_mutex_init')
 have_func('rb_enc_interned_str')
-have_func('rb_time_nano_new')
 have_func('index')
 
 have_header('ruby/st.h')

--- a/ext/ox/extconf.rb
+++ b/ext/ox/extconf.rb
@@ -32,7 +32,6 @@ CONFIG['warnflags'].slice!(/ -Wsuggest-attribute=format/)
 CONFIG['warnflags'].slice!(/ -Wdeclaration-after-statement/)
 CONFIG['warnflags'].slice!(/ -Wmissing-noreturn/)
 
-have_func('rb_time_timespec')
 have_func('rb_ext_ractor_safe', 'ruby.h')
 have_func('pthread_mutex_init')
 have_func('rb_enc_interned_str')

--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -715,11 +715,7 @@ static VALUE parse_double_time(const char *text, VALUE clas) {
     for (; text - dot <= 9; text++) {
         v2 *= 10;
     }
-#if HAVE_RB_TIME_NANO_NEW
     return rb_time_nano_new(v, v2);
-#else
-    return rb_time_new(v, v2 / 1000);
-#endif
 }
 
 typedef struct _tp {
@@ -770,11 +766,7 @@ static VALUE parse_xsd_time(const char *text, VALUE clas) {
     tm.tm_hour = (int)cargs[3];
     tm.tm_min  = (int)cargs[4];
     tm.tm_sec  = (int)cargs[5];
-#if HAVE_RB_TIME_NANO_NEW
     return rb_time_nano_new(mktime(&tm), cargs[6]);
-#else
-    return rb_time_new(mktime(&tm), cargs[6] / 1000);
-#endif
 }
 
 // debug functions

--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -106,11 +106,7 @@ inline static VALUE structname2obj(const char *name) {
         }
     }
     ost = rb_const_get(ox_struct_class, rb_intern(s));
-#if HAVE_RB_STRUCT_ALLOC_NOINIT
     return rb_struct_alloc_noinit(ost);
-#else
-    return rb_struct_new(ost);
-#endif
 }
 
 inline static VALUE parse_ulong(const char *s, PInfo pi) {

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -75,9 +75,6 @@ ID ox_text_id;
 ID ox_to_c_id;
 ID ox_to_s_id;
 ID ox_to_sym_id;
-ID ox_tv_nsec_id;
-ID ox_tv_sec_id;
-ID ox_tv_usec_id;
 ID ox_value_id;
 
 VALUE ox_encoding_sym;
@@ -1467,9 +1464,6 @@ void Init_ox() {
     ox_to_c_id              = rb_intern("to_c");
     ox_to_s_id              = rb_intern("to_s");
     ox_to_sym_id            = rb_intern("to_sym");
-    ox_tv_nsec_id           = rb_intern("tv_nsec");
-    ox_tv_sec_id            = rb_intern("tv_sec");
-    ox_tv_usec_id           = rb_intern("tv_usec");
     ox_value_id             = rb_intern("value");
 
     encoding_id = rb_intern("encoding");

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -952,11 +952,7 @@ static VALUE load_str(int argc, VALUE *argv, VALUE self) {
     } else {
         xml = ALLOCA_N(char, len);
     }
-#if HAVE_RB_OBJ_ENCODING
     encoding = rb_obj_encoding(*argv);
-#else
-    encoding = Qnil;
-#endif
     memcpy(xml, StringValuePtr(*argv), len);
     xml[len - 1] = '\0';
     obj          = load(xml, len - 1, argc - 1, argv + 1, self, encoding, &err);

--- a/ext/ox/ox.h
+++ b/ext/ox/ox.h
@@ -207,9 +207,6 @@ extern ID ox_text_id;
 extern ID ox_to_c_id;
 extern ID ox_to_s_id;
 extern ID ox_to_sym_id;
-extern ID ox_tv_sec_id;
-extern ID ox_tv_nsec_id;
-extern ID ox_tv_usec_id;
 extern ID ox_value_id;
 
 extern rb_encoding *ox_utf8_encoding;

--- a/ext/ox/sax_as.c
+++ b/ext/ox/sax_as.c
@@ -43,11 +43,7 @@ static VALUE parse_double_time(const char *text) {
     for (; text - dot <= 9; text++) {
         v2 *= 10;
     }
-#if HAVE_RB_TIME_NANO_NEW
     return rb_time_nano_new(v, v2);
-#else
-    return rb_time_new(v, v2 / 1000);
-#endif
 }
 
 typedef struct _tp {
@@ -102,11 +98,7 @@ static VALUE parse_xsd_time(const char *text) {
     tm.tm_hour = (int)cargs[3];
     tm.tm_min  = (int)cargs[4];
     tm.tm_sec  = (int)cargs[5];
-#if HAVE_RB_TIME_NANO_NEW
     return rb_time_nano_new(mktime(&tm), cargs[6]);
-#else
-    return rb_time_new(mktime(&tm), cargs[6] / 1000);
-#endif
 }
 
 /* call-seq: as_s()


### PR DESCRIPTION
Currently, ox gem has supported Ruby 2.7 or later.
https://github.com/ohler55/ox/blob/52ff373b759fcf7bc95a09163139f8fdd21c2a26/ox.gemspec#L29

The APIs introduced in older Ruby are free to use.

- rb_obj_encoding() was introduced at Ruby 1.9.0
  - https://github.com/ruby/ruby/commit/19dee8af57634c5813286ffbb63cc82611748378
- rb_struct_alloc_noinit() was introduced at Ruby 1.9.0
  - https://github.com/ruby/ruby/commit/0d8956725284206788bae5fbd6ed032f186ad366
- rb_ivar_foreach() was introduced at Ruby 1.9.0
  -  https://github.com/ruby/ruby/commit/5c0e68c39c3fc7717311826549a30d1615eb2007
- rb_time_timespec() was introduced at Ruby 2.3.0
  - https://github.com/ruby/ruby/commit/f1df08e76deadd8a22dc53b86d68cad5f6c11c22
- rb_time_nano_new() was introduced at Ruby 1.9.0
  - https://github.com/ruby/ruby/commit/a070c4fbe3cff184d224d1abb8a3101e3c11fc48