### PR TITLE
Clean up RUBY_INTEGER_UNIFICATION

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -337,21 +337,13 @@ static VALUE builder_new(int argc, VALUE *argv, VALUE self) {
 
         rb_check_type(*argv, T_HASH);
         if (Qnil != (v = rb_hash_lookup(*argv, ox_indent_sym))) {
-#ifdef RUBY_INTEGER_UNIFICATION
             if (rb_cInteger != rb_obj_class(v)) {
-#else
-            if (rb_cFixnum != rb_obj_class(v)) {
-#endif
                 rb_raise(ox_parse_error_class, ":indent must be a fixnum.\n");
             }
             indent = NUM2INT(v);
         }
         if (Qnil != (v = rb_hash_lookup(*argv, ox_size_sym))) {
-#ifdef RUBY_INTEGER_UNIFICATION
             if (rb_cInteger != rb_obj_class(v)) {
-#else
-            if (rb_cFixnum != rb_obj_class(v)) {
-#endif
                 rb_raise(ox_parse_error_class, ":size must be a fixnum.\n");
             }
             buf_size = NUM2LONG(v);
@@ -400,21 +392,13 @@ static VALUE builder_file(int argc, VALUE *argv, VALUE self) {
 
         rb_check_type(argv[1], T_HASH);
         if (Qnil != (v = rb_hash_lookup(argv[1], ox_indent_sym))) {
-#ifdef RUBY_INTEGER_UNIFICATION
             if (rb_cInteger != rb_obj_class(v)) {
-#else
-            if (rb_cFixnum != rb_obj_class(v)) {
-#endif
                 rb_raise(ox_parse_error_class, ":indent must be a fixnum.\n");
             }
             indent = NUM2INT(v);
         }
         if (Qnil != (v = rb_hash_lookup(argv[1], ox_size_sym))) {
-#ifdef RUBY_INTEGER_UNIFICATION
             if (rb_cInteger != rb_obj_class(v)) {
-#else
-            if (rb_cFixnum != rb_obj_class(v)) {
-#endif
                 rb_raise(ox_parse_error_class, ":size must be a fixnum.\n");
             }
             buf_size = NUM2LONG(v);
@@ -461,21 +445,13 @@ static VALUE builder_io(int argc, VALUE *argv, VALUE self) {
 
         rb_check_type(argv[1], T_HASH);
         if (Qnil != (v = rb_hash_lookup(argv[1], ox_indent_sym))) {
-#ifdef RUBY_INTEGER_UNIFICATION
             if (rb_cInteger != rb_obj_class(v)) {
-#else
-            if (rb_cFixnum != rb_obj_class(v)) {
-#endif
                 rb_raise(ox_parse_error_class, ":indent must be a fixnum.\n");
             }
             indent = NUM2INT(v);
         }
         if (Qnil != (v = rb_hash_lookup(argv[1], ox_size_sym))) {
-#ifdef RUBY_INTEGER_UNIFICATION
             if (rb_cInteger != rb_obj_class(v)) {
-#else
-            if (rb_cFixnum != rb_obj_class(v)) {
-#endif
                 rb_raise(ox_parse_error_class, ":size must be a fixnum.\n");
             }
             buf_size = NUM2LONG(v);
@@ -857,11 +833,7 @@ static VALUE builder_get_indent(VALUE self) {
  * - +indent+ (Fixnum) indentaion level, negative values excludes terminating newline
  */
 static VALUE builder_set_indent(VALUE self, VALUE indent) {
-#ifdef RUBY_INTEGER_UNIFICATION
     if (rb_cInteger != rb_obj_class(indent)) {
-#else
-    if (rb_cFixnum != rb_obj_class(indent)) {
-#endif
         rb_raise(ox_parse_error_class, "indent must be a fixnum.\n");
     }
 

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -809,13 +809,8 @@ static void dump_obj(ID aid, VALUE obj, int depth, Out out) {
         } else {
             char num_buf[16];
             int  d2 = depth + 1;
-#ifdef RUBY_INTEGER_UNIFICATION
             long i;
-            long cnt = NUM2LONG(rb_struct_size(obj));
-#else   // UNIFY_FIXNUM_AND_INTEGER
-            int i;
-            int cnt = (int)RSTRUCT_LEN(obj);
-#endif  // UNIFY_FIXNUM_AND_INTEGER
+            long cnt   = NUM2LONG(rb_struct_size(obj));
             e.type     = StructCode;
             e.clas.str = rb_class2name(clas);
             e.clas.len = strlen(e.clas.str);

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -1194,21 +1194,13 @@ static void parse_dump_options(VALUE ropts, Options copts) {
         VALUE v;
 
         if (Qnil != (v = rb_hash_lookup(ropts, ox_indent_sym))) {
-#ifdef RUBY_INTEGER_UNIFICATION
             if (rb_cInteger != rb_obj_class(v) && T_FIXNUM != rb_type(v)) {
-#else
-            if (rb_cFixnum != rb_obj_class(v)) {
-#endif
                 rb_raise(ox_parse_error_class, ":indent must be a Fixnum.\n");
             }
             copts->indent = NUM2INT(v);
         }
         if (Qnil != (v = rb_hash_lookup(ropts, trace_sym))) {
-#ifdef RUBY_INTEGER_UNIFICATION
             if (rb_cInteger != rb_obj_class(v) && T_FIXNUM != rb_type(v)) {
-#else
-            if (rb_cFixnum != rb_obj_class(v)) {
-#endif
                 rb_raise(ox_parse_error_class, ":trace must be a Fixnum.\n");
             }
             copts->trace = NUM2INT(v);


### PR DESCRIPTION
RUBY_INTEGER_UNIFICATION was introduced at Ruby 2.4.0. https://github.com/ruby/ruby/blob/8c6b349805e2f17a57576b8dfad31e5681d6b0e9/doc/NEWS/NEWS-2.4.0#compatibility-issues-excluding-feature-bug-fixes-

Now, ox gem supports Ruby 2.7.0 or later.

So, this patch will remove unnecessary code for old Ruby.