### PR TITLE
Use rb_str_intern() to get symbol instead of rb_funcall()

### DIFF
--- a/ext/ox/gen_load.c
+++ b/ext/ox/gen_load.c
@@ -104,7 +104,7 @@ static void create_prolog_doc(PInfo pi, const char *target, Attr attrs) {
                 VALUE rstr = rb_str_new2(attrs->name);
 
                 rb_enc_associate(rstr, pi->options->rb_enc);
-                sym = rb_funcall(rstr, ox_to_sym_id, 0);
+                sym = rb_str_intern(rstr);
             } else {
                 sym = ID2SYM(rb_intern(attrs->name));
             }

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -74,7 +74,6 @@ ID ox_string_id;
 ID ox_text_id;
 ID ox_to_c_id;
 ID ox_to_s_id;
-ID ox_to_sym_id;
 ID ox_value_id;
 
 VALUE ox_encoding_sym;
@@ -1463,7 +1462,6 @@ void Init_ox() {
     ox_text_id              = rb_intern("text");
     ox_to_c_id              = rb_intern("to_c");
     ox_to_s_id              = rb_intern("to_s");
-    ox_to_sym_id            = rb_intern("to_sym");
     ox_value_id             = rb_intern("value");
 
     encoding_id = rb_intern("encoding");

--- a/ext/ox/ox.h
+++ b/ext/ox/ox.h
@@ -206,7 +206,6 @@ extern ID ox_string_id;
 extern ID ox_text_id;
 extern ID ox_to_c_id;
 extern ID ox_to_s_id;
-extern ID ox_to_sym_id;
 extern ID ox_value_id;
 
 extern rb_encoding *ox_utf8_encoding;


### PR DESCRIPTION
There is an API to get a Symbol object from a String object.

The same API is eventually called with rb_funcall(), but it might have some overhead. https://github.com/ruby/ruby/blob/master/string.c#L11988