### PR TITLE
Remove unnecessary check for T_COMPLEX, T_RATIONAL and RB_GC_GUARD

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -159,12 +159,8 @@ static Type obj_class_code(VALUE obj) {
     case T_OBJECT: return (ox_document_clas == clas || ox_element_clas == clas) ? RawCode : ObjectCode;
     case T_REGEXP: return RegexpCode;
     case T_BIGNUM: return BignumCode;
-#ifdef T_COMPLEX
     case T_COMPLEX: return ComplexCode;
-#endif
-#ifdef T_RATIONAL
     case T_RATIONAL: return RationalCode;
-#endif
     case T_CLASS: return ClassCode;
     default: return 0;
     }
@@ -899,7 +895,6 @@ static void dump_obj(ID aid, VALUE obj, int depth, Out out) {
         out->w_end(out, &e);
         break;
     }
-#ifdef T_COMPLEX
     case T_COMPLEX: e.type = ComplexCode; out->w_start(out, &e);
 #ifdef RCOMPLEX
         dump_obj(0, RCOMPLEX(obj)->real, depth + 1, out);
@@ -910,8 +905,6 @@ static void dump_obj(ID aid, VALUE obj, int depth, Out out) {
 #endif
         out->w_end(out, &e);
         break;
-#endif
-#ifdef T_RATIONAL
     case T_RATIONAL: e.type = RationalCode; out->w_start(out, &e);
 #ifdef RRATIONAL
         dump_obj(0, RRATIONAL(obj)->num, depth + 1, out);
@@ -922,7 +915,6 @@ static void dump_obj(ID aid, VALUE obj, int depth, Out out) {
 #endif
         out->w_end(out, &e);
         break;
-#endif
     case T_CLASS: {
         e.type     = ClassCode;
         e.clas.str = rb_class2name(obj);

--- a/ext/ox/gen_load.c
+++ b/ext/ox/gen_load.c
@@ -73,9 +73,7 @@ static void create_doc(PInfo pi) {
 
     helper_stack_init(&pi->helpers);
     doc = rb_obj_alloc(ox_document_clas);
-#ifdef RB_GC_GUARD
     RB_GC_GUARD(doc);
-#endif
     nodes = rb_ary_new();
     rb_ivar_set(doc, ox_attributes_id, rb_hash_new());
     rb_ivar_set(doc, ox_nodes_id, nodes);

--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -639,23 +639,17 @@ static void end_element(PInfo pi, const char *ename) {
                 rb_hash_aset(gh->obj, ph->obj, h->obj);
             } break;
             case ComplexCode:
-#ifdef T_COMPLEX
                 if (Qundef == ph->obj) {
                     ph->obj = h->obj;
                 } else {
                     ph->obj = rb_complex_new(ph->obj, h->obj);
                 }
-#else
-                set_error(&pi->err, "Complex Objects not implemented in Ruby 1.8.7", pi->str, pi->s);
-                return;
-#endif
                 break;
             case RationalCode: {
                 if (Qundef == h->obj || RUBY_T_FIXNUM != rb_type(h->obj)) {
                     set_error(&pi->err, "Invalid object format", pi->str, pi->s);
                     return;
                 }
-#ifdef T_RATIONAL
                 if (Qundef == ph->obj) {
                     ph->obj = h->obj;
                 } else {
@@ -669,10 +663,6 @@ static void end_element(PInfo pi, const char *ename) {
                     ph->obj = rb_rational_new(ph->obj, h->obj);
 #endif
                 }
-#else
-                set_error(&pi->err, "Rational Objects not implemented in Ruby 1.8.7", pi->str, pi->s);
-                return;
-#endif
                 break;
             }
             default:

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -683,17 +683,13 @@ static VALUE to_obj(VALUE self, VALUE ruby_xml) {
         xml = ALLOCA_N(char, len);
     }
     memcpy(xml, x, len);
-#ifdef RB_GC_GUARD
     rb_gc_disable();
-#endif
     obj = ox_parse(xml, len - 1, ox_obj_callbacks, 0, &options, &err);
     if (SMALL_XML < len) {
         xfree(xml);
     }
-#ifdef RB_GC_GUARD
     RB_GC_GUARD(obj);
     rb_gc_enable();
-#endif
     if (err_has(&err)) {
         ox_err_raise(&err);
     }
@@ -873,14 +869,10 @@ static VALUE load(char *xml, size_t len, int argc, VALUE *argv, VALUE self, VALU
     xml = defuse_bom(xml, &options);
     switch (options.mode) {
     case ObjMode:
-#ifdef RB_GC_GUARD
         rb_gc_disable();
-#endif
         obj = ox_parse(xml, len, ox_obj_callbacks, 0, &options, err);
-#ifdef RB_GC_GUARD
         RB_GC_GUARD(obj);
         rb_gc_enable();
-#endif
         break;
     case GenMode: obj = ox_parse(xml, len, ox_gen_callbacks, 0, &options, err); break;
     case LimMode: obj = ox_parse(xml, len, ox_limited_callbacks, 0, &options, err); break;
@@ -1655,8 +1647,6 @@ _ox_raise_error(const char *msg, const char *xml, const char *current, const cha
             xline++;
         }
     }
-#ifdef RB_GC_GUARD
     rb_gc_enable();
-#endif
     rb_raise(ox_parse_error_class, "%s at line %d, column %d [%s:%d]\n", msg, xline, col, file, line);
 }


### PR DESCRIPTION
T_COMPLEX and T_RATIONAL were introduced at Ruby 1.9.0 https://github.com/ruby/ruby/commit/6125552c27b40a8da9e162af2655feca82ac16d3

RB_GC_GUARD was introduced at Ruby 1.9.0
https://github.com/ruby/ruby/commit/46603a78afde1386f92b38f9b16ca86daa93ad88