### PR TITLE
Fix type check for RationalCode

### DIFF
--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -653,7 +653,7 @@ static void end_element(PInfo pi, const char *ename) {
                 if (Qundef == ph->obj) {
                     ph->obj = h->obj;
                 } else {
-                    if (Qundef == ph->obj || RUBY_T_FIXNUM != rb_type(h->obj)) {
+                    if (Qundef == ph->obj || RUBY_T_FIXNUM != rb_type(ph->obj)) {
                         set_error(&pi->err, "Corrupt parse stack, container is wrong type", pi->str, pi->s);
                         return;
                     }


### PR DESCRIPTION
It has already checked the type under `RUBY_T_FIXNUM != rb_type(h->obj)` conditions in https://github.com/ohler55/ox/blob/83eca82be8f1bae9eb453cf12ad26f057ca9c6c8/ext/ox/obj_load.c#L649

So this patch will check the type of `ph->obj` instead.