### PR TITLE
Avoid invalid length when building name symbol (#348)

### DIFF
--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -984,7 +984,7 @@ static char read_element_end(SaxDrive dr) {
             } else {
                 snprintf(msg, sizeof(msg) - 1, "%selement '%s' closed but not opened", EL_MISMATCH, dr->buf.str);
                 ox_sax_drive_error_at(dr, msg, pos, line, col);
-                name = str2sym(dr, dr->buf.str, dr->buf.tail - dr->buf.str - 2, 0);
+                name = str2sym(dr, dr->buf.str, strlen(dr->buf.str), 0);
                 if (dr->has_start_element && 0 >= dr->blocked &&
                     (NULL == h || ActiveOverlay == h->overlay || NestOverlay == h->overlay)) {
                     VALUE args[1];

--- a/test/sax/sax_test.rb
+++ b/test/sax/sax_test.rb
@@ -927,6 +927,26 @@ encoding = "UTF-8" ?>},
     end
   end
 
+  def test_sax_last_element_closed_not_opened
+    Ox.default_options = $ox_sax_options
+    parse_compare(%{</top>},
+                  [
+                    [:error, "Start End Mismatch: element 'top' closed but not opened", 1, 1],
+                    [:start_element, :top],
+                    [:end_element, :top]
+                  ])
+  end
+
+  def test_sax_last_unnamed_element_closed_not_opened
+    Ox.default_options = $ox_sax_options
+    parse_compare(%{</>},
+                  [
+                    [:error, "Start End Mismatch: element '' closed but not opened", 1, 1],
+                    [:start_element, :''],
+                    [:end_element, :'']
+                  ])
+  end
+
   def test_sax_value_fixnum
     Ox.default_options = $ox_sax_options
     handler = TypeSax.new(:as_i)


### PR DESCRIPTION
Small fix to avoid shorten element name or error on last closed not opened (aka orphan) element reported into ohler55/ox#348.

- Use strlen instead of calculation on dr->buf to manage both strings with and without \0 last character.
- Add tests on last element closed not opened (aka orphan).

Fixes ohler55/ox#348