### PR TITLE
Add bigdecimal as dependency gem

### DIFF
--- a/ox.gemspec
+++ b/ox.gemspec
@@ -37,4 +37,6 @@ serialization. }
   s.required_ruby_version = '>= 2.7.0'
 
   s.metadata['rubygems_mfa_required'] = 'true'
+
+  s.add_runtime_dependency 'bigdecimal', '>= 3.0'
 end


### PR DESCRIPTION
The bigdecimal gem will be changed bundled gem since Ruby 3.4.0. https://www.ruby-lang.org/en/news/2023/09/14/ruby-3-3-0-preview2-released/

To use bundled gem, it requires to specify the dependency in Gemfile.

Similar with https://github.com/ohler55/oj/pull/901