### PR TITLE
CI: Fix CI error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 group :development do
   gem 'rake-compiler', '>= 1.2', '< 2.0'
   gem 'rubocop', '~> 1.47', require: false
+  gem 'test-unit', '~> 3.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ task test_all: [:clean, :compile] do
   exitcode = 0
   status = 0
 
-  cmds = 'ruby test/tests.rb -v'
+  cmds = 'bundle exec ruby test/tests.rb -v'
 
   $stdout.syswrite "\n#{'#' * 90}\n#{cmds}\n"
   Bundler.with_original_env do

--- a/ox.gemspec
+++ b/ox.gemspec
@@ -37,4 +37,6 @@ serialization. }
   s.required_ruby_version = '>= 2.7.0'
 
   s.metadata['rubygems_mfa_required'] = 'true'
+
+  s.add_runtime_dependency 'bigdecimal', '>= 3.0'
 end


### PR DESCRIPTION
Since Ruby-HEAD fails to load some gems, this patch gives `bundle exe` so that gems are loaded via bundler.
Similar with https://github.com/ohler55/oj/pull/924

This PR requires https://github.com/ohler55/ox/pull/355