### PR TITLE
Use TypedData_Wrap_Struct() macro to suppress deprecated messages

### DIFF
--- a/ext/ox/cache.c
+++ b/ext/ox/cache.c
@@ -54,6 +54,17 @@ typedef struct _cache {
     bool    mark;
 } *Cache;
 
+const rb_data_type_t ox_cache_type = {
+    "Ox/Cache",
+    {
+        ox_cache_mark,
+        ox_cache_free,
+        NULL,
+    },
+    0,
+    0,
+};
+
 static uint64_t hash_calc(const uint8_t *key, size_t len) {
     const uint8_t *end     = key + len;
     const uint8_t *endless = key + (len & 0xFFFFFFFC);
@@ -263,7 +274,8 @@ Cache ox_cache_create(size_t size, VALUE (*form)(const char *str, size_t len), b
     return c;
 }
 
-void ox_cache_free(Cache c) {
+void ox_cache_free(void *ptr) {
+    Cache    c = (Cache)ptr;
     uint64_t i;
 
     for (i = 0; i < c->size; i++) {
@@ -279,7 +291,8 @@ void ox_cache_free(Cache c) {
     free(c);
 }
 
-void ox_cache_mark(Cache c) {
+void ox_cache_mark(void *ptr) {
+    Cache    c = (Cache)ptr;
     uint64_t i;
 
 #if !HAVE_PTHREAD_MUTEX_INIT

--- a/ext/ox/cache.h
+++ b/ext/ox/cache.h
@@ -11,9 +11,11 @@
 
 struct _cache;
 
+extern const rb_data_type_t ox_cache_type;
+
 extern struct _cache *ox_cache_create(size_t size, VALUE (*form)(const char *str, size_t len), bool mark, bool locking);
-extern void           ox_cache_free(struct _cache *c);
-extern void           ox_cache_mark(struct _cache *c);
+extern void           ox_cache_free(void *ptr);
+extern void           ox_cache_mark(void *ptr);
 extern VALUE          ox_cache_intern(struct _cache *c, const char *key, size_t len, const char **keyp);
 
 #endif /* OX_CACHE_H */

--- a/ext/ox/intern.c
+++ b/ext/ox/intern.c
@@ -74,19 +74,19 @@ void ox_hash_init() {
 #endif
 
     ox_str_cache     = ox_cache_create(0, form_str, true, false);
-    ox_str_cache_obj = Data_Wrap_Struct(cache_class, ox_cache_mark, ox_cache_free, ox_str_cache);
+    ox_str_cache_obj = TypedData_Wrap_Struct(cache_class, &ox_cache_type, ox_str_cache);
     rb_gc_register_address(&ox_str_cache_obj);
 
     ox_sym_cache     = ox_cache_create(0, form_sym, true, false);
-    ox_sym_cache_obj = Data_Wrap_Struct(cache_class, ox_cache_mark, ox_cache_free, ox_sym_cache);
+    ox_sym_cache_obj = TypedData_Wrap_Struct(cache_class, &ox_cache_type, ox_sym_cache);
     rb_gc_register_address(&ox_sym_cache_obj);
 
     ox_attr_cache     = ox_cache_create(0, form_attr, false, false);
-    ox_attr_cache_obj = Data_Wrap_Struct(cache_class, ox_cache_mark, ox_cache_free, ox_attr_cache);
+    ox_attr_cache_obj = TypedData_Wrap_Struct(cache_class, &ox_cache_type, ox_attr_cache);
     rb_gc_register_address(&ox_attr_cache_obj);
 
     ox_id_cache     = ox_cache_create(0, form_id, false, false);
-    ox_id_cache_obj = Data_Wrap_Struct(cache_class, ox_cache_mark, ox_cache_free, ox_id_cache);
+    ox_id_cache_obj = TypedData_Wrap_Struct(cache_class, &ox_cache_type, ox_id_cache);
     rb_gc_register_address(&ox_id_cache_obj);
 }
 

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -18,6 +18,7 @@
 #include "ruby.h"
 #include "special.h"
 
+static void  mark_pi_cb(void *ptr);
 static void  read_instruction(PInfo pi);
 static void  read_doctype(PInfo pi);
 static void  read_comment(PInfo pi);
@@ -32,6 +33,17 @@ static char *read_10_uint64(char *b, uint64_t *up);
 static char *read_coded_chars(PInfo pi, char *text);
 static void  next_non_white(PInfo pi);
 static int   collapse_special(PInfo pi, char *str);
+
+static const rb_data_type_t ox_wrap_type = {
+    "Object",
+    {
+        mark_pi_cb,
+        NULL,
+        NULL,
+    },
+    0,
+    0,
+};
 
 /* This XML parser is a single pass, destructive, callback parser. It is a
  * single pass parse since it only make one pass over the characters in the
@@ -140,7 +152,7 @@ ox_parse(char *xml, size_t len, ParseCallbacks pcb, char **endp, Options options
     // initialize parse info
     helper_stack_init(&pi.helpers);
     // Protect against GC
-    wrap = Data_Wrap_Struct(rb_cObject, mark_pi_cb, NULL, &pi);
+    wrap = TypedData_Wrap_Struct(rb_cObject, &ox_wrap_type, &pi);
 
     err_init(&pi.err);
     pi.str        = xml;

--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -62,6 +62,17 @@ static Nv   hint_try_close(SaxDrive dr, const char *name);
 
 VALUE ox_sax_value_class = Qnil;
 
+const rb_data_type_t ox_sax_value_type = {
+    "Ox/Sax/Value",
+    {
+        NULL,
+        NULL,
+        NULL,
+    },
+    0,
+    0,
+};
+
 static VALUE protect_parse(VALUE drp) {
     parse((SaxDrive)drp);
 
@@ -256,7 +267,7 @@ static void sax_drive_init(SaxDrive dr, VALUE handler, VALUE io, SaxOptions opti
     dr->buf.dr = dr;
     stack_init(&dr->stack);
     dr->handler   = handler;
-    dr->value_obj = Data_Wrap_Struct(ox_sax_value_class, 0, 0, dr);
+    dr->value_obj = TypedData_Wrap_Struct(ox_sax_value_class, &ox_sax_value_type, dr);
     rb_gc_register_address(&dr->value_obj);
     dr->options = *options;
     dr->err     = 0;

--- a/ext/ox/sax.h
+++ b/ext/ox/sax.h
@@ -54,6 +54,8 @@ typedef struct _saxDrive {
 
 } *SaxDrive;
 
+extern const rb_data_type_t ox_sax_value_type;
+
 extern void ox_collapse_return(char *str);
 extern void ox_sax_parse(VALUE handler, VALUE io, SaxOptions options);
 extern void ox_sax_drive_cleanup(SaxDrive dr);

--- a/ext/ox/sax_as.c
+++ b/ext/ox/sax_as.c
@@ -106,8 +106,10 @@ static VALUE parse_xsd_time(const char *text) {
  * *return* value as an String.
  */
 static VALUE sax_value_as_s(VALUE self) {
-    SaxDrive dr = DATA_PTR(self);
+    SaxDrive dr;
     VALUE    rs;
+
+    TypedData_Get_Struct(self, struct _saxDrive, &ox_sax_value_type, dr);
 
     if ('\0' == *dr->buf.str) {
         return Qnil;
@@ -132,7 +134,9 @@ static VALUE sax_value_as_s(VALUE self) {
  * *return* value as an Symbol.
  */
 static VALUE sax_value_as_sym(VALUE self) {
-    SaxDrive dr = DATA_PTR(self);
+    SaxDrive dr;
+
+    TypedData_Get_Struct(self, struct _saxDrive, &ox_sax_value_type, dr);
 
     if ('\0' == *dr->buf.str) {
         return Qnil;
@@ -145,7 +149,9 @@ static VALUE sax_value_as_sym(VALUE self) {
  * *return* value as an Float.
  */
 static VALUE sax_value_as_f(VALUE self) {
-    SaxDrive dr = DATA_PTR(self);
+    SaxDrive dr;
+
+    TypedData_Get_Struct(self, struct _saxDrive, &ox_sax_value_type, dr);
 
     if ('\0' == *dr->buf.str) {
         return Qnil;
@@ -158,10 +164,13 @@ static VALUE sax_value_as_f(VALUE self) {
  * *return* value as an Fixnum.
  */
 static VALUE sax_value_as_i(VALUE self) {
-    SaxDrive    dr  = DATA_PTR(self);
-    const char *s   = dr->buf.str;
+    SaxDrive    dr;
+    const char *s;
     long        n   = 0;
     int         neg = 0;
+
+    TypedData_Get_Struct(self, struct _saxDrive, &ox_sax_value_type, dr);
+    s = dr->buf.str;
 
     if ('\0' == *s) {
         return Qnil;
@@ -190,9 +199,12 @@ static VALUE sax_value_as_i(VALUE self) {
  * *return* value as an Time.
  */
 static VALUE sax_value_as_time(VALUE self) {
-    SaxDrive    dr  = DATA_PTR(self);
-    const char *str = dr->buf.str;
+    SaxDrive    dr;
+    const char *str;
     VALUE       t;
+
+    TypedData_Get_Struct(self, struct _saxDrive, &ox_sax_value_type, dr);
+    str = dr->buf.str;
 
     if ('\0' == *str) {
         return Qnil;
@@ -212,7 +224,10 @@ static VALUE sax_value_as_time(VALUE self) {
  * *return* value as an boolean.
  */
 static VALUE sax_value_as_bool(VALUE self) {
-    return (0 == strcasecmp("true", ((SaxDrive)DATA_PTR(self))->buf.str)) ? Qtrue : Qfalse;
+    SaxDrive dr;
+
+    TypedData_Get_Struct(self, struct _saxDrive, &ox_sax_value_type, dr);
+    return (0 == strcasecmp("true", dr->buf.str)) ? Qtrue : Qfalse;
 }
 
 /* call-seq: empty()
@@ -220,7 +235,10 @@ static VALUE sax_value_as_bool(VALUE self) {
  * *return* true if the value is empty.
  */
 static VALUE sax_value_empty(VALUE self) {
-    return ('\0' == *((SaxDrive)DATA_PTR(self))->buf.str) ? Qtrue : Qfalse;
+    SaxDrive dr;
+
+    TypedData_Get_Struct(self, struct _saxDrive, &ox_sax_value_type, dr);
+    return ('\0' == *dr->buf.str) ? Qtrue : Qfalse;
 }
 
 /* Document-class: Ox::Sax::Value


### PR DESCRIPTION
When compile ox gem with Ruby 3.4-dev, it show the following deprecated messages:

```
../../../../ext/ox/builder.c:356:29: warning: 'rb_data_object_wrap_warning' is deprecated: by TypedData [-Wdeprecated-declarations]
  356 |         volatile VALUE rb = Data_Wrap_Struct(builder_class, NULL, builder_free, b);
      |                             ^
/Users/watson/.rbenv/versions/3.4-dev/include/ruby-3.4.0+0/ruby/internal/core/rdata.h:199:5: note: expanded from macro 'Data_Wrap_Struct'
  199 |     rb_data_object_wrap(                          \
      |     ^
/Users/watson/.rbenv/versions/3.4-dev/include/ruby-3.4.0+0/ruby/internal/core/rdata.h:363:31: note: expanded from macro 'rb_data_object_wrap'
  363 | #define rb_data_object_wrap   RUBY_MACRO_SELECT(rb_data_object_wrap_2, RUBY_UNTYPED_DATA_WARNING)
      |                               ^
/Users/watson/.rbenv/versions/3.4-dev/include/ruby-3.4.0+0/ruby/internal/core/rdata.h:50:35: note: expanded from macro 'RUBY_MACRO_SELECT'
   50 | #define RUBY_MACRO_SELECT(x, y)   RBIMPL_MACRO_SELECT(x, y)
      |                                   ^
/Users/watson/.rbenv/versions/3.4-dev/include/ruby-3.4.0+0/ruby/internal/core/rdata.h:49:35: note: expanded from macro 'RBIMPL_MACRO_SELECT'
   49 | #define RBIMPL_MACRO_SELECT(x, y) x ## y
      |                                   ^
<scratch space>:119:1: note: expanded from here
  119 | rb_data_object_wrap_1
      | ^
/Users/watson/.rbenv/versions/3.4-dev/include/ruby-3.4.0+0/ruby/internal/core/rdata.h:361:31: note: expanded from macro 'rb_data_object_wrap_1'
  361 | #define rb_data_object_wrap_1 rb_data_object_wrap_warning
      |                               ^
/Users/watson/.rbenv/versions/3.4-dev/include/ruby-3.4.0+0/ruby/internal/core/rdata.h:277:1: note: 'rb_data_object_wrap_warning' has been explicitly marked deprecated here
  277 | RBIMPL_ATTRSET_UNTYPED_DATA_FUNC()
      | ^
/Users/watson/.rbenv/versions/3.4-dev/include/ruby-3.4.0+0/ruby/internal/core/rdata.h:47:5: note: expanded from macro 'RBIMPL_ATTRSET_UNTYPED_DATA_FUNC'
   47 |     RBIMPL_ATTR_DEPRECATED(("by TypedData"))
      |     ^
/Users/watson/.rbenv/versions/3.4-dev/include/ruby-3.4.0+0/ruby/internal/attr/deprecated.h:36:53: note: expanded from macro 'RBIMPL_ATTR_DEPRECATED'
   36 | # define RBIMPL_ATTR_DEPRECATED(msg) __attribute__((__deprecated__ msg))
      |                                                     ^
```

This patch will suppress the deprecated messages.