### PR TITLE
Suppress "old style definition" warning

### DIFF
--- a/ext/ox/intern.c
+++ b/ext/ox/intern.c
@@ -67,7 +67,7 @@ static VALUE form_id(const char *str, size_t len) {
     return (VALUE)rb_intern3(str, len, rb_utf8_encoding());
 }
 
-void ox_hash_init() {
+void ox_hash_init(void) {
     VALUE cache_class = rb_define_class_under(Ox, "Cache", rb_cObject);
 #if RUBY_API_VERSION_CODE >= 30200
     rb_undef_alloc_func(cache_class);

--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -234,7 +234,7 @@ static unsigned long get_id_from_attrs(PInfo pi, Attr a) {
     return 0;
 }
 
-static CircArray circ_array_new() {
+static CircArray circ_array_new(void) {
     CircArray ca;
 
     ca       = ALLOC(struct _circArray);

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -1363,7 +1363,7 @@ static VALUE cache8_test(VALUE self) {
 }
 #endif
 
-void Init_ox() {
+void Init_ox(void) {
 #if HAVE_RB_EXT_RACTOR_SAFE
     rb_ext_ractor_safe(true);
 #endif

--- a/ext/ox/sax_as.c
+++ b/ext/ox/sax_as.c
@@ -246,7 +246,7 @@ static VALUE sax_value_empty(VALUE self) {
  * Values in the SAX callbacks. They can be converted to various different
  * types. with the _as_x()_ methods.
  */
-void ox_sax_define() {
+void ox_sax_define(void) {
 #if 0
     ox = rb_define_module("Ox");
 #if RUBY_API_VERSION_CODE >= 30200

--- a/ext/ox/sax_hint.c
+++ b/ext/ox/sax_hint.c
@@ -153,7 +153,7 @@ static struct _hint html_hint_array[] = {
 };
 static struct _hints html_hints = {"HTML", html_hint_array, sizeof(html_hint_array) / sizeof(*html_hint_array)};
 
-Hints ox_hints_html() {
+Hints ox_hints_html(void) {
     return &html_hints;
 }
 

--- a/ext/ox/special.c
+++ b/ext/ox/special.c
@@ -367,7 +367,7 @@ static Slot cache_get(const char *key) {
     return NULL;
 }
 
-static void cache_init() {
+static void cache_init(void) {
     Slot e = entities;
 
     memset(&entity_cache, 0, sizeof(struct _cache));


### PR DESCRIPTION
This patch will suppress following warning message when compile ox with gcc

```
$ cd ext/ox
$ ruby extconf.rb
$ make
...
intern.c: In function 'ox_hash_init':
intern.c:70:6: warning: old-style function definition [-Wold-style-definition]
   70 | void ox_hash_init() {
      |      ^~~~~~~~~~~~
...
```