### PR TITLE
Suppress "warning: 'strncpy' specified bound depends on the length of the source argument"

### DIFF
--- a/ext/ox/sax_buf.c
+++ b/ext/ox/sax_buf.c
@@ -198,7 +198,7 @@ static int read_from_str(Buf buf) {
     if (max < cnt) {
         cnt = max;
     }
-    strncpy(buf->tail, buf->in.str, cnt);
+    memcpy(buf->tail, buf->in.str, cnt);
     s   = buf->tail + cnt - 1;
     *s  = '\0';
     cnt = s - buf->tail;


### PR DESCRIPTION
This patch will suppress the following warning with compiling gcc:

```
sax_buf.c: In function 'read_from_str':
sax_buf.c:201:5: warning: 'strncpy' specified bound depends on the length of the source argument [-Wstringop-truncation]
  201 |     strncpy(buf->tail, buf->in.str, cnt);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sax_buf.c:197:11: note: length computed here
  197 |     cnt = strlen(buf->in.str) + 1;
      |           ^~~~~~~~~~~~~~~~~~~
```

If strncpy is used, we should pass count argument as a value of source boundary.

In this case, it might be `strncpy(buf->tail, buf->in.str, max);`

This patch will use `memcpy` instead becaseu copied length is already known.

Ref. https://stackoverflow.com/a/56782476