### PR TITLE
Fix LoadError on Ruby 3.4+

### DIFF
--- a/lib/ox.rb
+++ b/lib/ox.rb
@@ -77,7 +77,7 @@ require 'ox/sax'
 
 # C extension
 begin
-  require_relative 'ox.so'
+  require_relative "ox.#{RbConfig::CONFIG['DLEXT']}"
 rescue LoadError
   require 'ox/ox'
 end


### PR DESCRIPTION
### Summary

Fix `LoadError` (cannot load such file -- ox/ox) when requiring the `ox` native extension on Ruby 3.4+.

### Background

In Ruby 3.4, `require_relative` and absolute-path `require` no longer perform file extension expansion.  
This means that `require_relative 'ox.so'` will fail if the actual file is named differently (e.g., `ox.bundle` on macOS).

This behavior was changed as part of internal performance improvements in Ruby 3.4:
- [ruby/ruby PR #12562](https://github.com/ruby/ruby/pull/12562) (require performance improvement for absolute paths)

### What I changed

- Replaced `require_relative 'ox.so'` with `require_relative "ox.#{RbConfig::CONFIG['DLEXT']}"`, which dynamically selects the correct native extension based on the platform.
- This ensures Ruby can load the correct native extension (`.so`, `.bundle`, `.dll`, etc.) regardless of environment.

### Compatibility

- ✅ Ruby 3.3 and earlier: No change in behavior (backward compatible)
- ✅ Ruby 3.4+: Fixes `LoadError` when loading the `ox` native extension

