### PR TITLE
Fix build error with gcc 15

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -926,23 +926,23 @@ void ox_init_builder(VALUE ox) {
 #if RUBY_API_VERSION_CODE >= 30200
     rb_undef_alloc_func(builder_class);
 #endif
-    rb_define_module_function(builder_class, "new", builder_new, -1);
-    rb_define_module_function(builder_class, "file", builder_file, -1);
-    rb_define_module_function(builder_class, "io", builder_io, -1);
-    rb_define_method(builder_class, "instruct", builder_instruct, -1);
-    rb_define_method(builder_class, "comment", builder_comment, 1);
-    rb_define_method(builder_class, "doctype", builder_doctype, 1);
-    rb_define_method(builder_class, "element", builder_element, -1);
-    rb_define_method(builder_class, "void_element", builder_void_element, -1);
-    rb_define_method(builder_class, "text", builder_text, -1);
-    rb_define_method(builder_class, "cdata", builder_cdata, 1);
-    rb_define_method(builder_class, "raw", builder_raw, 1);
-    rb_define_method(builder_class, "pop", builder_pop, 0);
-    rb_define_method(builder_class, "close", builder_close, 0);
-    rb_define_method(builder_class, "to_s", builder_to_s, 0);
-    rb_define_method(builder_class, "line", builder_line, 0);
-    rb_define_method(builder_class, "column", builder_column, 0);
-    rb_define_method(builder_class, "pos", builder_pos, 0);
-    rb_define_method(builder_class, "indent", builder_get_indent, 0);
-    rb_define_method(builder_class, "indent=", builder_set_indent, 1);
+    rb_define_module_function(builder_class, "new", RUBY_METHOD_FUNC(builder_new), -1);
+    rb_define_module_function(builder_class, "file", RUBY_METHOD_FUNC(builder_file), -1);
+    rb_define_module_function(builder_class, "io", RUBY_METHOD_FUNC(builder_io), -1);
+    rb_define_method(builder_class, "instruct", RUBY_METHOD_FUNC(builder_instruct), -1);
+    rb_define_method(builder_class, "comment", RUBY_METHOD_FUNC(builder_comment), 1);
+    rb_define_method(builder_class, "doctype", RUBY_METHOD_FUNC(builder_doctype), 1);
+    rb_define_method(builder_class, "element", RUBY_METHOD_FUNC(builder_element), -1);
+    rb_define_method(builder_class, "void_element", RUBY_METHOD_FUNC(builder_void_element), -1);
+    rb_define_method(builder_class, "text", RUBY_METHOD_FUNC(builder_text), -1);
+    rb_define_method(builder_class, "cdata", RUBY_METHOD_FUNC(builder_cdata), 1);
+    rb_define_method(builder_class, "raw", RUBY_METHOD_FUNC(builder_raw), 1);
+    rb_define_method(builder_class, "pop", RUBY_METHOD_FUNC(builder_pop), 0);
+    rb_define_method(builder_class, "close", RUBY_METHOD_FUNC(builder_close), 0);
+    rb_define_method(builder_class, "to_s", RUBY_METHOD_FUNC(builder_to_s), 0);
+    rb_define_method(builder_class, "line", RUBY_METHOD_FUNC(builder_line), 0);
+    rb_define_method(builder_class, "column", RUBY_METHOD_FUNC(builder_column), 0);
+    rb_define_method(builder_class, "pos", RUBY_METHOD_FUNC(builder_pos), 0);
+    rb_define_method(builder_class, "indent", RUBY_METHOD_FUNC(builder_get_indent), 0);
+    rb_define_method(builder_class, "indent=", RUBY_METHOD_FUNC(builder_set_indent), 1);
 }

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -1377,22 +1377,22 @@ void Init_ox(void) {
 #endif
     Ox = rb_define_module("Ox");
 
-    rb_define_module_function(Ox, "default_options", get_def_opts, 0);
-    rb_define_module_function(Ox, "default_options=", set_def_opts, 1);
+    rb_define_module_function(Ox, "default_options", RUBY_METHOD_FUNC(get_def_opts), 0);
+    rb_define_module_function(Ox, "default_options=", RUBY_METHOD_FUNC(set_def_opts), 1);
 
-    rb_define_module_function(Ox, "parse_obj", to_obj, 1);
-    rb_define_module_function(Ox, "parse", to_gen, 1);
-    rb_define_module_function(Ox, "load", load_str, -1);
-    rb_define_module_function(Ox, "sax_parse", sax_parse, -1);
-    rb_define_module_function(Ox, "sax_html", sax_html, -1);
+    rb_define_module_function(Ox, "parse_obj", RUBY_METHOD_FUNC(to_obj), 1);
+    rb_define_module_function(Ox, "parse", RUBY_METHOD_FUNC(to_gen), 1);
+    rb_define_module_function(Ox, "load", RUBY_METHOD_FUNC(load_str), -1);
+    rb_define_module_function(Ox, "sax_parse", RUBY_METHOD_FUNC(sax_parse), -1);
+    rb_define_module_function(Ox, "sax_html", RUBY_METHOD_FUNC(sax_html), -1);
 
-    rb_define_module_function(Ox, "to_xml", to_xml, -1);
-    rb_define_module_function(Ox, "dump", dump, -1);
+    rb_define_module_function(Ox, "to_xml", RUBY_METHOD_FUNC(to_xml), -1);
+    rb_define_module_function(Ox, "dump", RUBY_METHOD_FUNC(dump), -1);
 
-    rb_define_module_function(Ox, "load_file", load_file, -1);
-    rb_define_module_function(Ox, "to_file", to_file, -1);
+    rb_define_module_function(Ox, "load_file", RUBY_METHOD_FUNC(load_file), -1);
+    rb_define_module_function(Ox, "to_file", RUBY_METHOD_FUNC(to_file), -1);
 
-    rb_define_module_function(Ox, "sax_html_overlay", sax_html_overlay, 0);
+    rb_define_module_function(Ox, "sax_html_overlay", RUBY_METHOD_FUNC(sax_html_overlay), 0);
 
     ox_init_builder(Ox);
 

--- a/ext/ox/sax_as.c
+++ b/ext/ox/sax_as.c
@@ -260,11 +260,11 @@ void ox_sax_define(void) {
     rb_undef_alloc_func(ox_sax_value_class);
 #endif
 
-    rb_define_method(ox_sax_value_class, "as_s", sax_value_as_s, 0);
-    rb_define_method(ox_sax_value_class, "as_sym", sax_value_as_sym, 0);
-    rb_define_method(ox_sax_value_class, "as_i", sax_value_as_i, 0);
-    rb_define_method(ox_sax_value_class, "as_f", sax_value_as_f, 0);
-    rb_define_method(ox_sax_value_class, "as_time", sax_value_as_time, 0);
-    rb_define_method(ox_sax_value_class, "as_bool", sax_value_as_bool, 0);
-    rb_define_method(ox_sax_value_class, "empty?", sax_value_empty, 0);
+    rb_define_method(ox_sax_value_class, "as_s", RUBY_METHOD_FUNC(sax_value_as_s), 0);
+    rb_define_method(ox_sax_value_class, "as_sym", RUBY_METHOD_FUNC(sax_value_as_sym), 0);
+    rb_define_method(ox_sax_value_class, "as_i", RUBY_METHOD_FUNC(sax_value_as_i), 0);
+    rb_define_method(ox_sax_value_class, "as_f", RUBY_METHOD_FUNC(sax_value_as_f), 0);
+    rb_define_method(ox_sax_value_class, "as_time", RUBY_METHOD_FUNC(sax_value_as_time), 0);
+    rb_define_method(ox_sax_value_class, "as_bool", RUBY_METHOD_FUNC(sax_value_as_bool), 0);
+    rb_define_method(ox_sax_value_class, "empty?", RUBY_METHOD_FUNC(sax_value_empty), 0);
 }


### PR DESCRIPTION
This patch will fix the following build errors when compiling ox with gcc 15.1:

Related to https://bugs.ruby-lang.org/issues/21286

```
PS C:\src\ox\ext\ox> gcc -v
Using built-in specs.
COLLECT_GCC=C:\Ruby34-x64\msys64\ucrt64\bin\gcc.exe
COLLECT_LTO_WRAPPER=C:/Ruby34-x64/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/15.1.0/lto-wrapper.exe
Target: x86_64-w64-mingw32
Configured with: ../gcc-15.1.0/configure --prefix=/ucrt64 --with-local-prefix=/ucrt64/local --with-native-system-header-dir=/ucrt64/include --libexecdir=/ucrt64/lib --enable-bootstrap --enable-checking=release --with-arch=nocona --with-tune=generic --enable-mingw-wildcard --enable-languages=c,lto,c++,fortran,ada,objc,obj-c++,jit --enable-shared --enable-static --enable-libatomic --enable-threads=posix --enable-graphite --enable-fully-dynamic-string --enable-libstdcxx-backtrace=yes --enable-libstdcxx-filesystem-ts --enable-libstdcxx-time --disable-libstdcxx-pch --enable-lto --enable-libgomp --disable-libssp --disable-multilib --disable-rpath --disable-win32-registry --disable-nls --disable-werror --disable-symvers --with-libiconv --with-system-zlib --with-gmp=/ucrt64 --with-mpfr=/ucrt64 --with-mpc=/ucrt64 --with-isl=/ucrt64 --with-pkgversion='Rev1, Built by MSYS2 project' --with-bugurl=https://github.com/msys2/MINGW-packages/issues --with-gnu-as --with-gnu-ld --disable-libstdcxx-debug --enable-plugin --with-boot-ldflags=-static-libstdc++ --with-stage1-ldflags=-static-libstdc++
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 15.1.0 (Rev1, Built by MSYS2 project)


PS C:\src\ox\ext\ox> make
generating ox-x64-mingw-ucrt.def
compiling base64.c
compiling builder.c
builder.c: In function 'ox_init_builder':
builder.c:929:53: error: passing argument 3 of 'rb_define_module_function' from incompatible pointer type [-Wincompatible-pointer-types]
  929 |     rb_define_module_function(builder_class, "new", builder_new, -1);
      |                                                     ^~~~~~~~~~~
      |                                                     |
      |                                                     VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
In file included from C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/anyargs.h:78,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby/ruby.h:27,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby.h:38,
                 from buf.h:34,
                 from builder.c:11:
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:112:70: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
  112 | void rb_define_module_function(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                              ~~~~~~~~^~~~~~~~~~~~~~
builder.c:343:14: note: 'builder_new' declared here
  343 | static VALUE builder_new(int argc, VALUE *argv, VALUE self) {
      |              ^~~~~~~~~~~
builder.c:930:54: error: passing argument 3 of 'rb_define_module_function' from incompatible pointer type [-Wincompatible-pointer-types]
  930 |     rb_define_module_function(builder_class, "file", builder_file, -1);
      |                                                      ^~~~~~~~~~~~
      |                                                      |
      |                                                      VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:112:70: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
  112 | void rb_define_module_function(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                              ~~~~~~~~^~~~~~~~~~~~~~
builder.c:389:14: note: 'builder_file' declared here
  389 | static VALUE builder_file(int argc, VALUE *argv, VALUE self) {
      |              ^~~~~~~~~~~~
builder.c:931:52: error: passing argument 3 of 'rb_define_module_function' from incompatible pointer type [-Wincompatible-pointer-types]
  931 |     rb_define_module_function(builder_class, "io", builder_io, -1);
      |                                                    ^~~~~~~~~~
      |                                                    |
      |                                                    VALUE (*)(int,  VALUE *, VALUE) {aka long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)}
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/method.h:112:70: note: expected 'VALUE (*)(void)' {aka 'long long unsigned int (*)(void)'} but argument is of type 'VALUE (*)(int,  VALUE *, VALUE)' {aka 'long long unsigned int (*)(int,  long long unsigned int *, long long unsigned int)'}
  112 | void rb_define_module_function(VALUE klass, const char *mid, VALUE (*func)(ANYARGS), int arity);
      |                                                              ~~~~~~~~^~~~~~~~~~~~~~
builder.c:442:14: note: 'builder_io' declared here
  442 | static VALUE builder_io(int argc, VALUE *argv, VALUE self) {
      |              ^~~~~~~~~~

...(snip)...
```