### PR TITLE
Add ruby 3.4 to the CI matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,7 @@ jobs:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby:
           - head
+          - '3.4'
           - '3.3'
           - '3.2'
           - '3.1'


### PR DESCRIPTION
The 'head' version in the matrix points to Ruby 3.5, so 3.4 is missing.
This PR should fix it