### PR TITLE
Improve loading extension

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,9 +4,7 @@ require 'bundler/gem_tasks'
 require 'rake/extensiontask'
 require 'rake/testtask'
 
-Rake::ExtensionTask.new('ox') do |ext|
-  ext.lib_dir = 'lib/ox'
-end
+Rake::ExtensionTask.new('ox')
 
 task test_all: [:clean, :compile] do
   $stdout.flush

--- a/lib/ox.rb
+++ b/lib/ox.rb
@@ -76,8 +76,4 @@ require 'ox/bag'
 require 'ox/sax'
 
 # C extension
-begin
-  require_relative "ox.#{RbConfig::CONFIG['DLEXT']}"
-rescue LoadError
-  require 'ox/ox'
-end
+require_relative "ox.#{RbConfig::CONFIG['DLEXT']}"

--- a/lib/ox.rb
+++ b/lib/ox.rb
@@ -76,4 +76,4 @@ require 'ox/bag'
 require 'ox/sax'
 
 # C extension
-require_relative "ox.#{RbConfig::CONFIG['DLEXT']}"
+require "ox.#{RbConfig::CONFIG['DLEXT']}"


### PR DESCRIPTION
In RubyGems, we are [considering](https://github.com/rubygems/rubygems/issues/8921) to stop installing extensions into the lib directory of the installed gem.

If we made such change, this gem would break because it relies on the extension being present in the same directory as lib code.

This PR changes things to not make such assumption and instead rely on the `$LOAD_PATH`.