### PR TITLE
Support Ruby 4.0 Ractor

### DIFF
--- a/examples/sax_ractor.rb
+++ b/examples/sax_ractor.rb
@@ -39,12 +39,13 @@ class Saxtor < Ox::Sax
   end
 
   # Set up our parsing environment and open a file handle for our XML.
-  def initialize(parent, haystack)
+  def initialize(parent, haystack, port = nil)
     super()
     @parse_stack = [] # Track our current Element as we parse.
     @parent = parent # `Ractor` that instantiated us.
     @haystack = File.open(haystack, File::Constants::RDONLY)
     @haystack.advise(:sequential)
+    @port = port
   end
 
   # Stratch `Struct`.
@@ -116,7 +117,7 @@ class Saxtor < Ox::Sax
     )
 
     # Let our parent `#take` our needle-equivalent `CYO`, or `nil`.
-    Ractor.yield(@out)
+    @port ? @port.send(@out) : Ractor.yield(@out)
   end # def awen
 end # class Saxtor
 
@@ -161,18 +162,19 @@ needles = ARGV[1...]
 puts 'Parallel Ractors'
 # Create one `Ractor` for every given media-type argument
 moo = ['Heifer', 'Cow', 'Bull', 'Steer'].tally
+port = defined?(Ractor::Port) ? Ractor::Port.new : nil
 head_count = needles.size - 1
 herd = (0..head_count).map do
   # Give our worker `Ractor` a name, otherwise its `#name` will return `nil`.
   individual = moo.keys.sample
   moo[individual] += 1
-  Ractor.new(haystack, name: "#{individual} #{moo[individual] - 1}") do |haystack|
+  Ractor.new(haystack, port, name: "#{individual} #{moo[individual] - 1}") do |haystack, port|
     # Initialize an `Ox::Sax` handler for our given source file.
-    handler = Saxtor.new(Ractor.current, haystack)
+    handler = Saxtor.new(Ractor.current, haystack, port)
 
     # Now we can `#send` a needle to this `Ractor` and make it search the haystack!
     while ietf_string = Ractor.receive
-      Ractor.yield(handler.awen(ietf_string))
+      port ? port.send(handler.awen(ietf_string)) : Ractor.yield(handler.awen(ietf_string))
     end
   end
 end
@@ -184,7 +186,7 @@ end
 # rubocop:disable Lint/AmbiguousBlockAssociation
 # rubocop:disable Style/BlockDelimiters
 pp (0..head_count).map {
-  [herd[_1], herd[_1].take]
+  [herd[_1], port ? port.receive : herd[_1].take]
 }.map {
   "#{_1.name} gave us #{_2 || 'nothing'}"
 }
@@ -194,12 +196,13 @@ pp (0..head_count).map {
 # Hotdog Style.
 puts
 puts 'Serial Ractor'
+port = defined?(Ractor::Port) ? Ractor::Port.new : nil
 # Create a single `Ractor` and send every media-type to it in series.
-only_one_ox = Ractor.new(haystack, name: 'ONLY ONE OX') do |haystack|
-  handler = Saxtor.new(Ractor.current, haystack)
+only_one_ox = Ractor.new(haystack, port, name: 'ONLY ONE OX') do |haystack, port|
+  handler = Saxtor.new(Ractor.current, haystack, port)
   while ietf_string = Ractor.receive
     handler.awen(ietf_string)
   end
 end
 (0..head_count).each { only_one_ox.send(needles[_1]) }
-pp "#{only_one_ox.name} gave us #{(0..head_count).map { only_one_ox.take }}"
+pp "#{only_one_ox.name} gave us #{(0..head_count).map { port ? port.receive : only_one_ox.take }}"


### PR DESCRIPTION
Since Ruby 4.0, it has breaking changes in Ractor.
Ref. https://bugs.ruby-lang.org/issues/21262

sax_ractor.rb does not work with Ruby 4.0.
This PR will fix to work expectedly with Ruby 4.0.

### Before
```
$ ruby -v sax_ractor.rb /usr/share/mime/packages/freedesktop.org.xml image/jpeg font/ttf application/xhtml+xml image/x-pic
ruby 4.0.0dev (2025-11-22T16:48:13Z master dd489ee9c4) +PRISM [x86_64-linux]
Parallel Ractors
sax_ractor.rb:187:in 'block in <main>': undefined method 'take' for an instance of Ractor (NoMethodError)

  [herd[_1], herd[_1].take]
                     ^^^^^
        from sax_ractor.rb:186:in 'Range#each'
        from sax_ractor.rb:186:in 'Enumerable#map'
        from sax_ractor.rb:186:in '<main>'
double free or corruption (fasttop)
[1]    112557 IOT instruction (core dumped)  ruby -v sax_ractor.rb /usr/share/mime/packages/freedesktop.org.xml image/jpeg

```

### After
```
$ ruby -v sax_ractor.rb /usr/share/mime/packages/freedesktop.org.xml image/jpeg font/ttf application/xhtml+xml image/x-pic
ruby 4.0.0dev (2025-11-22T16:48:13Z master dd489ee9c4) +PRISM [x86_64-linux]
Parallel Ractors
["Steer 1 gave us TrueType-skriftipe (font/ttf) [.ttf]",
 "Bull 1 gave us #<Ractor::Port:0x0000150dc609e0c8>",
 "Heifer 1 gave us JPEG-beeld (image/jpeg) [.jpg,.jpeg,.jpe,.jfif]",
 "Bull 2 gave us #<Ractor::Port:0x0000150dc609e0c8>"]

Serial Ractor
"ONLY ONE OX gave us [#<CYO JPEG-beeld (image/jpeg) [.jpg,.jpeg,.jpe,.jfif]>, #<CYO TrueType-skriftipe (font/ttf) [.ttf]>, #<CYO XHTML-bladsy (application/xhtml+xml) [.xhtml,.xht,.html,.htm]>, #<CYO XHTML-bladsy (application/xhtml+xml) [.xhtml,.xht,.html,.htm]>]"
```