### PR TITLE
Simplify the use of AddressSanitizer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ end
 def run(command)
   if ENV['OX_ASAN']
     @ld_preload ||= `gcc -print-file-name=libasan.so`.strip
-    command = "LD_PRELOAD=#{@ld_preload} #{command}"
+    command = "LD_PRELOAD=#{@ld_preload} ASAN_OPTIONS=detect_leaks=0 #{command}"
   end
   system command
 end

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,14 @@ Rake::ExtensionTask.new('ox') do |ext|
   ext.lib_dir = 'lib/ox'
 end
 
+def run(command)
+  if ENV['OX_ASAN']
+    @ld_preload ||= `gcc -print-file-name=libasan.so`.strip
+    command = "LD_PRELOAD=#{@ld_preload} #{command}"
+  end
+  system command
+end
+
 task test_all: [:clean, :compile] do
   $stdout.flush
   exitcode = 0
@@ -17,11 +25,15 @@ task test_all: [:clean, :compile] do
 
   $stdout.syswrite "\n#{'#' * 90}\n#{cmds}\n"
   Bundler.with_original_env do
-    status = system(cmds)
+    status = run(cmds)
   end
   exitcode = 1 unless status
 
-  Rake::Task['test'].invoke
+  unless ENV['OX_ASAN']
+    Rake::Task['test'].invoke
+  else
+    run('rake test')
+  end
   exit(1) if exitcode == 1
 end
 

--- a/contrib/parse_dryrun.rb
+++ b/contrib/parse_dryrun.rb
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Parse the given file using either Ox.parse or Ox.sax_parse
+
+require 'ox'
+
+class MyHandler < Ox::Sax
+  def initialize
+    @line = nil
+    @column = nil
+  end
+
+  def error(message, line, column); end
+  def start_element(name); end
+  def attr(name, str); end
+  def attr_value(name, value); end
+  def end_element(name); end
+  def text(str); end
+  def value(value); end
+  def instruct(target); end
+  def doctype(value); end
+  def comment(value); end
+  def cdata(value); end
+end
+
+@sax_mode = (ARGV.first == '--sax' && ARGV.shift)
+def sax_mode?
+  @sax_mode
+end
+
+# Support - filename to use stdin
+def open(&block)
+  if ARGV.first == '-'
+    block.call $stdin
+  else
+    File.open ARGV.first, 'r', &block
+  end
+end
+
+open do |file|
+  begin
+    if sax_mode?
+      Ox.sax_parse MyHandler.new, file
+    else
+      Ox.parse file.read
+    end
+  rescue Ox::ParseError, EncodingError => e
+    puts e.inspect
+  end
+end

--- a/contrib/parse_dryrun.sh
+++ b/contrib/parse_dryrun.sh
@@ -13,6 +13,8 @@ if [ -z "$OX_ASAN" ]; then
 fi
 
 if [ -n "$OX_ASAN" ]; then
+    # Hide leaks detection as recommended for Ruby VM
+    export ASAN_OPTIONS=detect_leaks=0
     export LD_PRELOAD=`gcc -print-file-name=libasan.so`
 fi
 

--- a/contrib/parse_dryrun.sh
+++ b/contrib/parse_dryrun.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+# Run parse_dryrun with required environment when AddressSanitizer is enabled
+
+command="bundle exec ruby"
+
+# Detect if extension has been compiled with AddressSanitizer
+if [ -z "$OX_ASAN" ]; then
+    root_dir=`dirname $0`/..
+    if ldd $root_dir/lib/ox/ox.so | grep -q asan; then
+        OX_ASAN=true
+    fi
+fi
+
+if [ -n "$OX_ASAN" ]; then
+    export LD_PRELOAD=`gcc -print-file-name=libasan.so`
+fi
+
+exec $command `dirname $0`/parse_dryrun.rb $@

--- a/ext/ox/extconf.rb
+++ b/ext/ox/extconf.rb
@@ -32,6 +32,16 @@ CONFIG['warnflags'].slice!(/ -Wsuggest-attribute=format/)
 CONFIG['warnflags'].slice!(/ -Wdeclaration-after-statement/)
 CONFIG['warnflags'].slice!(/ -Wmissing-noreturn/)
 
+if ENV['OX_ASAN'] || ENV['OX_DEBUG']
+  CONFIG["optflags"] = "-O0"
+  CONFIG["debugflags"] = "-ggdb3"
+end
+
+if ENV['OX_ASAN']
+  $LDFLAGS << " -fsanitize=address"
+  $CFLAGS << " -fsanitize=address"
+end
+
 have_func('rb_ext_ractor_safe', 'ruby.h')
 have_func('pthread_mutex_init')
 have_func('rb_enc_interned_str')


### PR DESCRIPTION
Use AddressSanitizer when `OX_ASAN` is defined

- Compile the ox extension with debug and -fsanitize=address
- Enable libasan via LD_PRELOAD in rake task
- Use ASAN_OPTIONS to disable leak detections

Examples:

```shell
OX_ASAN=true rake clean compile
OX_ASAN=true rake test_all
``` 

Provides a small command line `./contrib/parse_dryrun.sh` to test parsing a given file:

- Support/detect AddressSanitizer
- Support Ox.parse (by default) and Ox.sax_parse (with the `--sax` option)
- Support stdin usage with `-`
    
Examples:

```shell
./contrib/parse_dryrun.sh misc/sample.xml
./contrib/parse_dryrun.sh --sax misc/sample.xml
curl -L <URL> | ./contrib/parse_dryrun.sh -
OX_ASAN=true rake clean compile && ./contrib/parse_dryrun.sh --sax misc/sample.xml
```
