### PR TITLE
Prevent stack buffer overflow in collapse_special

### DIFF
--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -1146,7 +1146,7 @@ static int collapse_special(PInfo pi, char *str) {
                             return EDOM;
                         }
                         if (kend <= k) {
-                            k = key;
+                            k = key+1; // because k-- follows
                             break;
                         }
                         *k++ = *s;

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -567,6 +567,14 @@ class Func < Test::Unit::TestCase
     end
   end
 
+  def test_escape_too_long
+    Ox.default_options = $ox_object_options
+    xml = %{<?xml encoding="UTF-8"?><top name="&0123456789ABCDE;"/>}
+    assert_raise(Ox::ParseError) do
+      Ox.parse(xml).root
+    end
+  end
+
   def test_escape_open_close_tag_names
     Ox.default_options = $ox_object_options
     b = Ox::Builder.new


### PR DESCRIPTION
Prevent invalid pointer value when `collapse_special` parses too long an entity.
    
Simply resets the `k` pointer to `key+1` to use the following code as expected.

Fixes https://github.com/ohler55/ox/issues/393