### PR TITLE
Prevent stack buffer overflow in ox sax parse

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,13 +19,15 @@ end
 task test_all: [:clean, :compile] do
   $stdout.flush
   exitcode = 0
-  status = 0
+  status = true
 
-  cmds = 'bundle exec ruby test/tests.rb -v'
+  %w[test/tests.rb test/sax/sax_test.rb].each do |test|
+    cmds = "bundle exec ruby #{test} -v"
 
-  $stdout.syswrite "\n#{'#' * 90}\n#{cmds}\n"
-  Bundler.with_original_env do
-    status = run(cmds)
+    $stdout.syswrite "\n#{'#' * 90}\n#{cmds}\n"
+    Bundler.with_original_env do
+      status = status && run(cmds)
+    end
   end
   exitcode = 1 unless status
 

--- a/ext/ox/sax_buf.c
+++ b/ext/ox/sax_buf.c
@@ -69,7 +69,7 @@ void ox_sax_buf_init(Buf buf, VALUE io) {
 }
 
 int ox_sax_buf_read(Buf buf) {
-    int    err;
+    int  err;
     long shift = 0;
 
     // if there is not much room to read into, shift or realloc a larger buffer.

--- a/ext/ox/sax_buf.c
+++ b/ext/ox/sax_buf.c
@@ -70,7 +70,7 @@ void ox_sax_buf_init(Buf buf, VALUE io) {
 
 int ox_sax_buf_read(Buf buf) {
     int    err;
-    size_t shift = 0;
+    long shift = 0;
 
     // if there is not much room to read into, shift or realloc a larger buffer.
     if (buf->head < buf->tail && 4096 > buf->end - buf->tail) {

--- a/test/sax/sax_test.rb
+++ b/test/sax/sax_test.rb
@@ -591,6 +591,16 @@ encoding = "UTF-8" ?>},
                     [:end_element, :top]
                   ])
   end
+
+  def test_sax_no_tag_only_text
+    Ox.default_options = $ox_sax_options
+    parse_compare(%{no tag, only text},
+                  [
+                    [:error, 'Not Terminated: text not terminated', 0, 17],
+                    [:text, 'no tag, only text']
+                  ])
+  end
+
   # TBD invalid chacters in text
 
   def test_sax_doctype

--- a/test/sax/sax_test.rb
+++ b/test/sax/sax_test.rb
@@ -17,11 +17,6 @@ require 'optparse'
 require 'ox'
 
 require 'helpers'
-# require 'smart_test'
-
-opts = OptionParser.new
-opts.on('-h', '--help', 'Show this display') { puts opts; Process.exit!(0) }
-opts.parse(ARGV)
 
 $ox_sax_options = {
   encoding: nil,


### PR DESCRIPTION
Fixes `shift` type in `ox_sax_buf_read`.
    
The shift variable can't be negative if `size_t` is used. It seems to prevent realloc logic from working as expected.

Fixes https://github.com/ohler55/ox/issues/395

A second commit includes SAX tests in the `test_all` rake task. And removes `OptionParser` from `sax_tests.rb` to allow normal usage.