### PR TITLE
Prevent dynamic-stack-buffer-overflow in read_element when document not terminated

### DIFF
--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -579,7 +579,7 @@ static char *read_element(PInfo pi) {
             c = *pi->s++;
             if ('\0' == c) {
                 attr_stack_cleanup(&attrs);
-                set_error(&pi->err, "invalid format, document not terminated", pi->str, pi->s);
+                set_error(&pi->err, "invalid format, document not terminated", pi->str, pi->s - 1);
                 return 0;
             }
             if ('<' == c) {

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -295,6 +295,14 @@ class Func < Test::Unit::TestCase
     end
   end
 
+  def test_not_closed_element
+    Ox.default_options = $ox_object_options
+    xml = %{<top>}
+    assert_raise(Ox::ParseError) do
+      Ox.load(xml)
+    end
+  end
+
   def test_xml_instruction_format
     Ox.default_options = $ox_object_options
     xml = %{<?xml version="1.0" ?>


### PR DESCRIPTION
Fixes set_error in read_element when document not terminated

Invokes set_error with corrected current pointer because of previous pi->s++

Fixes https://github.com/ohler55/ox/issues/397