### PR TITLE
Prevent dynamic-stack-buffer-overflow in read_element

### DIFF
--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -701,6 +701,11 @@ static char *read_element(PInfo pi) {
                 read_text(pi);
                 /*read_reduced_text(pi); */
 
+                if (err_has(&pi->err)) {
+                    attr_stack_cleanup(&attrs);
+                    return 0;
+                }
+
                 /* to exit read_text with no errors the next character must be < */
                 if ('/' == *(pi->s + 1) &&
                     0 == ((TolerantEffort == pi->options->effort) ? strncasecmp(ename, pi->s + 2, elen)
@@ -734,7 +739,10 @@ static void read_text(PInfo pi) {
             done = 1;
             pi->s--;
             break;
-        case '\0': set_error(&pi->err, "invalid format, document not terminated", pi->str, pi->s); return;
+        case '\0':
+            pi->s--;
+            set_error(&pi->err, "invalid format, document not terminated", pi->str, pi->s);
+            return;
         default:
             if (end <= (b + (('&' == c) ? 7 : 0))) { /* extra 8 for special just in case it is sequence of bytes */
                 unsigned long size;

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -303,6 +303,14 @@ class Func < Test::Unit::TestCase
     end
   end
 
+  def test_not_closed_element_with_text
+    Ox.default_options = $ox_object_options
+    xml = %{<top>a}
+    assert_raise(Ox::ParseError) do
+      Ox.load(xml)
+    end
+  end
+
   def test_xml_instruction_format
     Ox.default_options = $ox_object_options
     xml = %{<?xml version="1.0" ?>


### PR DESCRIPTION
Prevent dynamic-stack-buffer-overflow in read_text when element is not closed with text

* Backward pi->s pointer in read_text when XML is ended
* Test error in read_element after read_text to abort read if needed

Fixes https://github.com/ohler55/ox/issues/399