### PR TITLE
Invokes set_error with current pointer in read_delimited on EOS

### DIFF
--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -364,7 +364,8 @@ static void read_delimited(PInfo pi, char end) {
     if ('"' == end || '\'' == end) {
         for (c = *pi->s++; end != c; c = *pi->s++) {
             if ('\0' == c) {
-                set_error(&pi->err, "invalid format, dectype not terminated", pi->str, pi->s);
+                pi->s--;
+                set_error(&pi->err, "invalid format, doctype not terminated", pi->str, pi->s);
                 return;
             }
         }
@@ -375,7 +376,10 @@ static void read_delimited(PInfo pi, char end) {
                 return;
             }
             switch (c) {
-            case '\0': set_error(&pi->err, "invalid format, dectype not terminated", pi->str, pi->s); return;
+            case '\0':
+                pi->s--;
+                set_error(&pi->err, "invalid format, doctype not terminated", pi->str, pi->s);
+                return;
             case '"': read_delimited(pi, c); break;
             case '\'': read_delimited(pi, c); break;
             case '[': read_delimited(pi, ']'); break;

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -468,6 +468,16 @@ class Func < Test::Unit::TestCase
     assert_equal(%{Objects [<!ELEMENT Objects (RentObjects)><!ENTITY euml "&#235;"><!ENTITY Atilde "&#195;">]}, doc.nodes[0].value)
   end
 
+  def test_truncated_dtd
+    Ox.default_options = $ox_object_options
+    xml = %{<!DOCTYPE s SYSTEM \"ox.dtd\"}
+    ('<!DOCTYPE'.length..xml.length).each do |partial_length|
+      assert_raise(Ox::ParseError) do
+        Ox.parse(xml[0..partial_length])
+      end
+    end
+  end
+
   def test_quote_value
     Ox.default_options = $ox_object_options
     xml = %{<top name="Pete"/>}


### PR DESCRIPTION
Tests 'all' truncated DOCTYPE forms

Fixes https://github.com/ohler55/ox/issues/401