### PR TITLE
Fixes set_error in read_element when attribute '=' is not found

### DIFF
--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -535,6 +535,7 @@ static char *read_element(PInfo pi) {
                     break;
                 } else {
                     attr_stack_cleanup(&attrs);
+                    pi->s--;
                     set_error(&pi->err, "invalid format, no attribute value", pi->str, pi->s);
                     return 0;
                 }

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -647,6 +647,14 @@ class Func < Test::Unit::TestCase
     assert_equal('Pete', doc.attributes[:name])
   end
 
+  def test_attribute_no_equal_but_white_space
+    Ox.default_options = $ox_generic_options
+    xml = %{<top name }
+    assert_raise(Ox::ParseError) do
+      Ox.load(xml)
+    end
+  end
+
   def test_skip_none
     Ox.default_options = $ox_object_options
     xml = %{<top>  Pete\r  Ohler <b>P</b> <b>O</b></top>}


### PR DESCRIPTION
Backwards pi->s pointer before invoking set_error

Fixes https://github.com/ohler55/ox/issues/403