### PR TITLE
Prevents stack-buffer-overflow in ox_sax_collapse_special

### DIFF
--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -1496,7 +1496,11 @@ int ox_sax_collapse_special(SaxDrive dr, char *str, long pos, long line, long co
                     c = '&';
                 } else {
                     b = bn;
-                    s = s2 + 1;
+                    if ('\0' != *s2) {
+                        s = s2 + 1;
+                    } else {
+                        s = s2;
+                    }
                     continue;
                 }
             }

--- a/test/sax/sax_test.rb
+++ b/test/sax/sax_test.rb
@@ -187,6 +187,39 @@ encoding = "UTF-8" ?>},
                   ])
   end
 
+  def test_sax_instruct_too_long
+    Ox.default_options = $ox_sax_options
+
+    parse_compare("<?bad #{'a' * 5000}",
+                   [
+                     [:instruct, "bad"],
+                     [:error, "processing instruction content too large", 1, 4102],
+                     [:error, "Not Terminated: document not terminated", 1, 5006],
+                     [:error, "Not Terminated: error reading token", 1, 5006],
+                     [:error, "Not Terminated: instruction not terminated", 1, 5006],
+                     [:end_instruct, "bad"]
+                   ])
+  end
+
+  # See releted github issue:
+  def test_sax_instruct_too_long_ended_by_entity
+    Ox.default_options = $ox_sax_options
+
+    size = 4087
+    # The entity must be the last characters of an content with invalid attribute longer than 4096 bytes
+    content = "foo #{'a' * size} &lt;overflow"
+    parse_compare("<?bad #{content}",
+                   [
+                     [:instruct, "bad"],
+                     [:error, "processing instruction content too large", 1, 4102],
+                     [:text, "foo #{'a' * size} <"],
+                     [:end_instruct, "bad"],
+                     [:error, "Not Terminated: text not terminated", 1, 19],
+                     [:text, "overflow"]
+                   ]
+                 )
+  end
+
   def test_sax_element_simple
     Ox.default_options = $ox_sax_options
     parse_compare(%{<top/>},


### PR DESCRIPTION
* Backwards s2 EOS is detected when parsing an entity key
* Reproduces special condition with overflowed instruction

Fixes https://github.com/ohler55/ox/issues/405