### PR TITLE
Interrupt SAX read_instruction when content overflows dedicated buffer

### DIFF
--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -364,7 +364,12 @@ static void parse(SaxDrive dr) {
         if ('<' == c) {
             c = buf_get(&dr->buf);
             switch (c) {
-            case '?': /* instructions (xml or otherwise) */ c = read_instruction(dr); break;
+            case '?': /* instructions (xml or otherwise) */
+                c = read_instruction(dr);
+                if ('\0' == c) {
+                    goto DONE;
+                }
+                break;
             case '!': /* comment or doctype */
                 buf_protect(&dr->buf);
                 c = buf_get(&dr->buf);
@@ -489,11 +494,12 @@ DONE:
 
 static void read_content(SaxDrive dr, char *content, size_t len) {
     char  c;
-    char *end = content + len;
+    char *start = content;
+    char *end   = content + len;
 
     while ('\0' != (c = buf_get(&dr->buf))) {
         if (end <= content) {
-            *content = '\0';
+            *start = '\0';
             ox_sax_drive_error(dr, "processing instruction content too large");
             return;
         }
@@ -537,7 +543,13 @@ static char read_instruction(SaxDrive dr) {
     pos  = dr->buf.pos;
     line = dr->buf.line;
     col  = dr->buf.col;
+
     read_content(dr, content, sizeof(content) - 1);
+    if (*content == '\0') {
+        // Content should not be read
+        return '\0';
+    }
+
     coff = (int)(dr->buf.tail - dr->buf.head);
     buf_reset(&dr->buf);
     dr->err = 0;

--- a/test/sax/sax_test.rb
+++ b/test/sax/sax_test.rb
@@ -187,6 +187,30 @@ encoding = "UTF-8" ?>},
                   ])
   end
 
+  def test_sax_instruct_too_long
+    Ox.default_options = $ox_sax_options
+
+    parse_compare("<?bad #{'a' * 5000}",
+                   [
+                     [:instruct, 'bad'],
+                     [:error, 'processing instruction content too large', 1, 4102]
+                   ])
+  end
+
+  # See releted github issue:
+  def test_sax_instruct_too_long_ended_by_entity
+    Ox.default_options = $ox_sax_options
+
+    size = 4087
+    # The entity must be the last characters of an content with invalid attribute longer than 4096 bytes
+    content = "foo #{'a' * size} &lt;overflow"
+    parse_compare("<?bad #{content}",
+                   [
+                     [:instruct, 'bad'],
+                     [:error, 'processing instruction content too large', 1, 4102]
+                   ])
+  end
+
   def test_sax_element_simple
     Ox.default_options = $ox_sax_options
     parse_compare(%{<top/>},


### PR DESCRIPTION
* Detect overflowed buffer in read_content by returning '\0' content
* Interrupt read_instruction when content is '\0' / empty
* Goto DONE in parse when read_instruction returns '\0'.

Could improve https://github.com/ohler55/ox/issues/405