### PR TITLE
Prevents dynamic-stack-buffer-overflow in read_coded_chars

### DIFF
--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -1040,6 +1040,10 @@ static char *read_coded_chars(PInfo pi, char *text) {
 
     for (b = buf, s = pi->s; b < end; b++, s++) {
         *b = *s;
+        if ('\0' == *s) {
+            set_error(&pi->err, "Not terminated coded char.", pi->str, pi->s);
+            return NULL;
+        }
         if (';' == *s) {
             *(b + 1) = '\0';
             blen     = b - buf;

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -609,7 +609,15 @@ class Func < Test::Unit::TestCase
     end
   end
 
-  def test_escape_too_long
+  def test_escape_truncated
+    Ox.default_options = $ox_object_options
+    xml = %{<top>&</top>}
+    assert_raise(Ox::ParseError) do
+      Ox.parse(xml)
+    end
+  end
+
+  def test_escape_too_long_in_attribute
     Ox.default_options = $ox_object_options
     xml = %{<?xml encoding="UTF-8"?><top name="&0123456789ABCDE;"/>}
     assert_raise(Ox::ParseError) do


### PR DESCRIPTION
* Stops read_coded_chars on EOS

Fixes https://github.com/ohler55/ox/issues/408
