### PR TITLE
Prevents dynamic-stack-buffer-overflow in read_instruction

### DIFF
--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -302,6 +302,11 @@ DONE:
             }
             end = pi->s;
             next_non_white(pi);
+            if ('\0' == *pi->s) {
+                attr_stack_cleanup(&attrs);
+                set_error(&pi->err, "invalid format, processing instruction not terminated", pi->str, pi->s);
+                return;
+            }
             if ('=' != *pi->s++) {
                 attrs_ok = false;
                 break;

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -320,6 +320,14 @@ class Func < Test::Unit::TestCase
     assert_equal('Test', loaded);
   end
 
+  def test_xml_instruction_invalid
+    Ox.default_options = $ox_object_options
+    xml = %{<?xml foo="?>" bar }
+    assert_raise(Ox::ParseError) do
+      Ox.load(xml)
+    end
+  end
+
   def test_dump_invalid_character
     assert_raise(Ox::SyntaxError) { Ox.dump("foo\x19bar") }
   end


### PR DESCRIPTION
Stops read_instruction attribute parsing on EOS

* Detect EOS between name token and '='

Fixes https://github.com/ohler55/ox/issues/410