### PR TITLE
Fix buffer overflow in the SAX parser's IO read callbacks

### DIFF
--- a/ext/ox/sax_buf.c
+++ b/ext/ox/sax_buf.c
@@ -133,14 +133,22 @@ static VALUE partial_io_cb(VALUE rbuf) {
     VALUE  args[1];
     VALUE  rstr;
     char  *str;
+    size_t max = (size_t)(buf->end - buf->tail);
     size_t cnt;
 
-    args[0] = ULONG2NUM(buf->end - buf->tail);
+    args[0] = ULONG2NUM(max);
     rstr    = rb_funcall2(buf->in.io, ox_readpartial_id, 1, args);
     str     = StringValuePtr(rstr);
-    cnt     = strlen(str);
+    // Clamp to the space actually requested. A misbehaving IO can return more
+    // than max bytes; copying it unclamped overflows the buffer (which starts
+    // on the C stack). Use the real byte length, not strlen(), so an embedded
+    // NUL does not cause a short copy that still leaves a longer string.
+    cnt = (size_t)RSTRING_LEN(rstr);
+    if (cnt > max) {
+        cnt = max;
+    }
     // printf("*** read partial %lu bytes, str: '%s'\n", cnt, str);
-    strcpy(buf->tail, str);
+    memcpy(buf->tail, str, cnt);
     buf->read_end = buf->tail + cnt;
 
     return Qtrue;
@@ -151,14 +159,19 @@ static VALUE io_cb(VALUE rbuf) {
     VALUE  args[1];
     VALUE  rstr;
     char  *str;
+    size_t max = (size_t)(buf->end - buf->tail);
     size_t cnt;
 
-    args[0] = ULONG2NUM(buf->end - buf->tail);
+    args[0] = ULONG2NUM(max);
     rstr    = rb_funcall2(buf->in.io, ox_read_id, 1, args);
     str     = StringValuePtr(rstr);
-    cnt     = strlen(str);
+    // See partial_io_cb: clamp to the requested size to prevent overflow.
+    cnt = (size_t)RSTRING_LEN(rstr);
+    if (cnt > max) {
+        cnt = max;
+    }
     // printf("*** read %lu bytes, str: '%s'\n", cnt, str);
-    strcpy(buf->tail, str);
+    memcpy(buf->tail, str, cnt);
     buf->read_end = buf->tail + cnt;
 
     return Qtrue;

--- a/test/sax_io_overflow_test.rb
+++ b/test/sax_io_overflow_test.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: SAX IO callback buffer overflow.
+#
+# Ox.sax_parse accepts any object responding to read()/readpartial(). The IO
+# callbacks in sax_buf.c must clamp the returned data to the number of bytes
+# they requested; otherwise a misbehaving IO that returns more than asked for
+# overflows the parser buffer (which starts on the C stack).
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'stringio'
+require 'ox'
+
+class SaxIoOverflowTest < ::Test::Unit::TestCase
+  class NullSax < ::Ox::Sax
+    def start_element(_n); end
+    def end_element(_n); end
+    def text(_t); end
+    def attr(_n, _v); end
+    def error(_m, _l, _c); end
+  end
+
+  # IO that ignores the requested size and returns far more than asked for.
+  class OverIO
+    def initialize(payload)
+      @payload = payload
+      @sent = false
+    end
+
+    def read(_max)
+      return nil if @sent
+
+      @sent = true
+      @payload
+    end
+
+    def readpartial(_max)
+      raise EOFError if @sent
+
+      @sent = true
+      @payload
+    end
+  end
+
+  def test_over_long_read_does_not_overflow
+    big = "<r>#{'A' * 200_000}</r>"
+    assert_nothing_raised do
+      Ox.sax_parse(NullSax.new, OverIO.new(big.dup))
+    end
+  end
+
+  def test_well_behaved_stringio_still_parses
+    big = "<r>#{'A' * 200_000}</r>"
+    assert_nothing_raised do
+      Ox.sax_parse(NullSax.new, StringIO.new(big.dup))
+    end
+  end
+end


### PR DESCRIPTION
`Ox.sax_parse` accepts any object that responds to `read`/`readpartial` as its input.
The two IO read callbacks in `ext/ox/sax_buf.c` ask the IO for a specific number of bytes but then copy back **whatever length the IO returns**, 
with an unclamped `strcpy`. An IO whose `read`/`readpartial` returns more bytes than requested overflows the parser buffer.

Because the buffer (`struct _buf`, member `char base[0x1000]`) lives inside `struct _saxDrive`,
which is a **stack local of `ox_sax_parse`**, this is a stack buffer overflow and crashes the process (SIGSEGV / stack-smashing abort).

## Root cause
`partial_io_cb` and `io_cb` compute the request size correctly but ignore it when
copying:

```c
args[0] = ULONG2NUM(buf->end - buf->tail);          // request N bytes
rstr    = rb_funcall2(buf->in.io, ox_read_id, 1, args);
str     = StringValuePtr(rstr);
cnt     = strlen(str);
strcpy(buf->tail, str);                             // <-- no clamp to N
buf->read_end = buf->tail + cnt;
```

Note that `read_from_str` (the String input path) already clamps (`if (max < cnt) cnt = max;`); the IO callbacks were the asymmetric case that did not.

## Reproduction
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'ox'
end

require 'ox'

class H < Ox::Sax
  def start_element(_); end
  def end_element(_); end
end

# An IO that ignores the requested size and returns far more than asked for.
io = Object.new
payload = ('<r>' + ('A' * 200_000) + '</r>').dup
sent = false
io.define_singleton_method(:read) { |_max| sent ? nil : (sent = true; payload) }

Ox.sax_parse(H.new, io)   # => crashes (SIGSEGV) before this fix
```

## Fix
Clamp the copy to the number of bytes that were actually requested, and use `RSTRING_LEN` instead of `strlen` so an embedded NUL in the returned data does not cause a short copy:

```c
size_t max = (size_t)(buf->end - buf->tail);
...
cnt = (size_t)RSTRING_LEN(rstr);
if (cnt > max) { cnt = max; }
memcpy(buf->tail, str, cnt);
```

There is `BUF_PAD` (4 bytes) of headroom past `buf->end`, and `ox_sax_buf_read` writes the trailing `'\0'` at `read_end`, so `cnt == max` is safe.
A contract-violating IO now has its excess bytes dropped instead of corrupting memory.

## Note
The fix drops any bytes an IO returns beyond the requested size (the safe choice for a misbehaving IO).
If you would prefer to signal that contract violation with `rb_raise` instead, I'm happy to adjust.
