### PR TITLE
Fix stack buffer overflow on long class names in object mode

### DIFF
--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -143,7 +143,8 @@ static VALUE classname2class(const char *name, PInfo pi, VALUE base_class) {
     if (Qundef == (clas = slot_cache_get(ox_class_cache, name, &slot, 0))) {
         char        class_name[1024];
         char       *s;
-        const char *n = name;
+        char       *class_name_end = class_name + sizeof(class_name) - 1;
+        const char *n              = name;
 
         clas = rb_cObject;
         for (s = class_name; '\0' != *n; n++) {
@@ -159,6 +160,13 @@ static VALUE classname2class(const char *name, PInfo pi, VALUE base_class) {
                 }
                 s = class_name;
             } else {
+                if (class_name_end <= s) {
+                    // Guard the fixed-size stack buffer: an over-long class name
+                    // (from the attacker-controlled `c` attribute in object mode)
+                    // would otherwise overflow class_name[].
+                    set_error(&pi->err, "Invalid classname, too long", pi->str, pi->s);
+                    return Qundef;
+                }
                 *s++ = *n;
             }
         }

--- a/test/objload_classname_test.rb
+++ b/test/objload_classname_test.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: object-mode class name stack overflow.
+#
+# In mode: :object the `c` attribute of an object element is the class name and
+# is fully attacker controlled. classname2class() copied it into a fixed
+# char class_name[1024] without a bounds check, so a class name longer than
+# 1024 bytes smashed the stack. It must raise instead.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class ObjLoadClassnameTest < ::Test::Unit::TestCase
+  def test_over_long_classname_raises
+    xml = %(<o c="#{'A' * 5000}"><i a="@x">1</i></o>)
+    assert_raise(Ox::ParseError) do
+      Ox.load(xml, mode: :object, effort: :tolerant)
+    end
+  end
+
+  def test_boundary_classname_raises
+    # Just past the 1024-byte buffer.
+    xml = %(<o c="#{'A' * 1100}"><i a="@x">1</i></o>)
+    assert_raise(Ox::ParseError) do
+      Ox.load(xml, mode: :object, effort: :tolerant)
+    end
+  end
+
+  def test_short_undefined_class_still_raises_cleanly
+    # A normal short undefined class name must raise cleanly (NameError from
+    # the constant lookup), never crash.
+    assert_raise(NameError) do
+      Ox.load(%(<o c="NoSuchClassXYZ"><i a="@x">1</i></o>), mode: :object, effort: :strict)
+    end
+  end
+end


### PR DESCRIPTION
When loading with `mode: :object`, the `c` attribute of an object element is the name of the class to instantiate, and it is fully controlled by the (untrusted) XML input.
`classname2class` in `ext/ox/obj_load.c` copies that name into a fixed `char class_name[1024]` on the stack with no bounds check, so a class name longer than 1024 bytes overflows the buffer and crashes the process (SIGSEGV / stack-smashing abort).

## Root cause
The copy loop writes each character without ever checking the destination bound:

```c
char class_name[1024];
...
for (s = class_name; '\0' != *n; n++) {
    if (':' == *n) { ... s = class_name; }   // reset on "::"
    else { *s++ = *n; }                       // <-- no bound on s
}
*s = '\0';
```

`s` is only reset back to the start of `class_name` on a `::` separator, so a single segment longer than the buffer runs straight off the end of the array.

## Reproduction
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'ox'
end

require 'ox'

# In mode: :object the `c` attribute is the class name to instantiate and is
# fully controlled by the (untrusted) XML.
xml = %(<o c="#{'A' * 5000}"><i a="@x">1</i></o>)
Ox.load(xml, mode: :object, effort: :tolerant)   # => crashes (SIGSEGV) before this fix
```

## Fix
Bound the copy to the size of `class_name[]` and raise a parse error when a segment is too long, mirroring the existing `::`/error handling in the same loop:

```c
char *class_name_end = class_name + sizeof(class_name) - 1;
...
} else {
    if (class_name_end <= s) {
        set_error(&pi->err, "Invalid classname, too long", pi->str, pi->s);
        return Qundef;
    }
    *s++ = *n;
}
```

## Note
`mode: :object` deserialization instantiates arbitrary registered classes from the input and should be treated like `Marshal.load` — this patch removes the memory unsafety, but loading object-mode XML from untrusted sources remains inherently risky and is worth a documentation note. Happy to add one if you'd like.
