### PR TITLE
Fix integer overflow with an oversized dump :indent option

### DIFF
--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -483,8 +483,19 @@ static VALUE set_def_opts(VALUE self, VALUE opts) {
 
     v = rb_hash_aref(opts, ox_indent_sym);
     if (Qnil != v) {
+        int indent;
+
         Check_Type(v, T_FIXNUM);
-        ox_default_options.indent = FIX2INT(v);
+        indent = FIX2INT(v);
+        // Bound the indent so that depth * indent (depth up to MAX_DEPTH) cannot
+        // overflow the int arithmetic in dump.c and smash the output buffer.
+        // Any negative value already means "tight, no newlines"; normalize it.
+        if (indent < 0) {
+            indent = -1;
+        } else if (OX_MAX_INDENT < indent) {
+            rb_raise(ox_parse_error_class, ":indent can be no larger than %d.\n", OX_MAX_INDENT);
+        }
+        ox_default_options.indent = indent;
     }
 
     v = rb_hash_aref(opts, trace_sym);
@@ -1178,10 +1189,20 @@ static void parse_dump_options(VALUE ropts, Options copts) {
         VALUE v;
 
         if (Qnil != (v = rb_hash_lookup(ropts, ox_indent_sym))) {
+            int indent;
+
             if (rb_cInteger != rb_obj_class(v) && T_FIXNUM != rb_type(v)) {
                 rb_raise(ox_parse_error_class, ":indent must be a Fixnum.\n");
             }
-            copts->indent = NUM2INT(v);
+            indent = NUM2INT(v);
+            // See load_default_options(): bound indent to avoid int overflow in
+            // the dump.c indent arithmetic (oj CVE-2026-54502 class of bug).
+            if (indent < 0) {
+                indent = -1;
+            } else if (OX_MAX_INDENT < indent) {
+                rb_raise(ox_parse_error_class, ":indent can be no larger than %d.\n", OX_MAX_INDENT);
+            }
+            copts->indent = indent;
         }
         if (Qnil != (v = rb_hash_lookup(ropts, trace_sym))) {
             if (rb_cInteger != rb_obj_class(v) && T_FIXNUM != rb_type(v)) {

--- a/ext/ox/ox.h
+++ b/ext/ox/ox.h
@@ -35,6 +35,11 @@ extern "C" {
 
 #define MAX_TEXT_LEN 4096
 
+/* Upper bound for the :indent dump option. Keeps depth * indent (depth is
+ * capped at the dump MAX_DEPTH of 1000) far below INT_MAX so the indent size
+ * arithmetic in dump.c cannot overflow and under-grow the output buffer. */
+#define OX_MAX_INDENT 16384
+
 #define SILENT 0
 #define TRACE 1
 #define DEBUG 2

--- a/test/dump_indent_test.rb
+++ b/test/dump_indent_test.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: Ox.dump(:indent) integer overflow -> output buffer overflow.
+#
+# :indent was taken as an unbounded int. For a nested element the indent size
+# arithmetic (depth * indent, then + overhead) overflowed int, causing the
+# output buffer grow() to be skipped and fill_indent() to write past it.
+# Oversized indents must now be rejected; valid ones must still work.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class DumpIndentTest < ::Test::Unit::TestCase
+  def test_oversized_indent_raises
+    [2**20 + 1, 2**30, 2**31 - 1].each do |ind|
+      assert_raise(Ox::ParseError) do
+        Ox.dump([[1]], indent: ind)
+      end
+    end
+  end
+
+  def test_valid_indent_still_works
+    assert_nothing_raised do
+      Ox.dump([[1]], indent: 4)
+      Ox.dump([1], indent: 16_384) # OX_MAX_INDENT, the maximum allowed
+      Ox.dump([[1]], indent: -1)   # negative == tight (no newlines)
+    end
+  end
+
+  def test_indent_actually_indents
+    out = Ox.dump([[1]], indent: 2)
+    assert(out.include?("\n"), 'indented dump should contain newlines')
+  end
+end


### PR DESCRIPTION
The `:indent` dump option is accepted as an unbounded `int`. For a nested element, `dump.c` computes the indent size as `depth * out->indent` and then `size = e->indent + 4 + margin_len` in `int` arithmetic.
A large `:indent` overflows that `int` to a negative value, so the output buffer's `grow()` guard is skipped and `fill_indent()` writes far past the buffer, corrupting the heap.
This is the same class of bug as the sibling `oj` gem's CVE-2026-54502.

## Root cause
```c
// dump.c
e.indent    = depth * out->indent;                 // int; can overflow
size_t size = e->indent + 4 + out->opts->margin_len; // int add, then widened
if (out->end - out->cur <= (long)size) grow(out, size); // guard skipped when negative
...
fill_indent(out, e->indent);                        // writes e->indent spaces
```
`:indent` is stored directly from `NUM2INT`/`FIX2INT` with no range check, so the caller controls the value that overflows.

## Reproduction
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'ox'
end

require 'ox'

Ox.dump([[1]], indent: 2**31 - 1)   # => heap corruption / crash before this fix
```
(Observed as `malloc(): corrupted top size` / SIGABRT.)

## Fix
Bound `:indent` at both option-parsing sites in `ox.c`. 
Negative values already mean "tight, no newlines", so they are normalized to `-1` (which also avoids a negative-side overflow); values above a sane maximum are rejected:

```c
indent = FIX2INT(v);
if (indent < 0)                  indent = -1;
else if (OX_MAX_INDENT < indent) rb_raise(ox_parse_error_class,
                                     ":indent can be no larger than %d.\n", OX_MAX_INDENT);
```

## Note / question on the cap
`OX_MAX_INDENT` is introduced as `16384`, chosen so that `depth * indent` (`depth` is already capped at the dump `MAX_DEPTH` of 1000) stays well below `INT_MAX`. 
That is the memory-safety requirement. If you'd prefer a smaller ceiling — which would also curb the large-but-valid allocation a big indent can request — just say the word and I'll change the constant. An alternative purely in `dump.c` (widen the size math to `size_t` and clamp the fill, as `builder.c` already does for its own indent) is also possible if you'd rather not add an option limit.
