### PR TITLE
Speed up Ox.dump string and indent writing

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -179,8 +179,9 @@ inline static void fill_indent(Out out, int cnt) {
             memcpy(out->cur, out->opts->margin, out->opts->margin_len);
             out->cur += out->opts->margin_len;
         }
-        for (; 0 < cnt; cnt--) {
-            *out->cur++ = ' ';
+        if (0 < cnt) {
+            memset(out->cur, ' ', cnt);
+            out->cur += cnt;
         }
     }
 }

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -77,6 +77,12 @@ static int is_xml_friendly(const uchar *str, int len, const char *table);
 
 static const char hex_chars[17] = "0123456789abcdef";
 
+#define APPEND_CHARS(buffer, chars, size) \
+    {                                     \
+        memcpy(buffer, chars, size);      \
+        buffer += size;                   \
+    }
+
 // The : character is equivalent to 10. Used for replacement characters up to 10
 // characters long such as '&#x10FFFF;'.
 static const char xml_friendly_chars[257] = "\
@@ -337,46 +343,22 @@ inline static void dump_str_value(Out out, const char *value, size_t size, const
     if (out->end - out->cur <= (long)xsize) {
         grow(out, xsize);
     }
+    if (xsize == size) {
+        memcpy(out->cur, value, size);
+        out->cur += size;
+        *out->cur = '\0';
+        return;
+    }
     for (; 0 < size; size--, value++) {
         if ('1' == table[(uchar)*value]) {
             *out->cur++ = *value;
         } else {
             switch (*value) {
-            case '"':
-                *out->cur++ = '&';
-                *out->cur++ = 'q';
-                *out->cur++ = 'u';
-                *out->cur++ = 'o';
-                *out->cur++ = 't';
-                *out->cur++ = ';';
-                break;
-            case '&':
-                *out->cur++ = '&';
-                *out->cur++ = 'a';
-                *out->cur++ = 'm';
-                *out->cur++ = 'p';
-                *out->cur++ = ';';
-                break;
-            case '\'':
-                *out->cur++ = '&';
-                *out->cur++ = 'a';
-                *out->cur++ = 'p';
-                *out->cur++ = 'o';
-                *out->cur++ = 's';
-                *out->cur++ = ';';
-                break;
-            case '<':
-                *out->cur++ = '&';
-                *out->cur++ = 'l';
-                *out->cur++ = 't';
-                *out->cur++ = ';';
-                break;
-            case '>':
-                *out->cur++ = '&';
-                *out->cur++ = 'g';
-                *out->cur++ = 't';
-                *out->cur++ = ';';
-                break;
+            case '"': APPEND_CHARS(out->cur, "&quot;", 6); break;
+            case '&': APPEND_CHARS(out->cur, "&amp;", 5); break;
+            case '\'': APPEND_CHARS(out->cur, "&apos;", 6); break;
+            case '<': APPEND_CHARS(out->cur, "&lt;", 4); break;
+            case '>': APPEND_CHARS(out->cur, "&gt;", 4); break;
             default:
                 // Must be one of the invalid characters.
                 if (StrictEffort == out->opts->effort) {


### PR DESCRIPTION
## Summary

Two small, behaviour-preserving optimizations to the object-mode dumper (`ext/ox/dump.c`), ported from equivalent changes already in oj. Only `ext/ox/dump.c` is touched.

1. **`dump_str_value`: whole-string and entity `memcpy`** (oj [b464ed6](https://github.com/ohler55/oj/commit/b464ed6), [f36a97b](https://github.com/ohler55/oj/commit/f36a97b)). The function copied a string one byte at a time even when nothing needed XML escaping, and emitted each entity reference (`&quot;` etc.) byte by byte. It now `memcpy`s the whole string when `xml_str_len()` reports no expansion, and writes entity references through a `memcpy`-based `APPEND_CHARS` macro. The fast path is conservative: `xml_str_len()` measures with the strictest table (`xml_friendly_chars`), whose escape set is a superset of `xml_quote_chars` and `xml_element_chars`, so "no expansion" under it implies nothing needs escaping under the actual table. Invalid-character handling (`:strict` raise / `allow_invalid` / `:invalid_replace`) is untouched.

2. **`fill_indent`: `memset`** (oj [d9db8c6](https://github.com/ohler55/oj/commit/d9db8c6)). The indent spaces were written one byte at a time; they are now filled with a single `memset`, guarded on `cnt > 0` so the `cnt <= 0` no-op is unchanged. (`ext/ox/builder.c` already uses this `memcpy`/entity idiom; this brings the older `dump.c` writer in line.)

## Benchmark

- CPU: Intel Core Ultra 9 275HX
- OS: Linux 7.1.2 (x86_64)
- Compiler: gcc 16.1.1
- Ruby: 4.0.5

```ruby
# frozen_string_literal: true
require 'benchmark/ips'
require 'ox'

Ox.default_options = { mode: :object }

ascii = 'Hello, World! This is a plain ASCII payload without any markup. ' * 4
utf8 = 'あいうえお日本語のテキストデータサンプル' * 6
esc = '<a>&"' * 40
esc_few = ('a' * 500) + '&'
mixed = {
  'name'   => 'Widget Co',
  :sym     => :example,
  'nums'   => (1..20).to_a,
  'nested' => { 'child' => { 'leaf' => 'value', 'list' => %w[alpha beta gamma] } },
  'desc'   => 'A moderately long description string without escapes here.',
  'flag'   => true,
}

Benchmark.ips do |x|
  x.config(warmup: 2, time: 5)
  x.report('dump ascii')   { Ox.dump(ascii) }
  x.report('dump utf8')    { Ox.dump(utf8) }
  x.report('dump esc')     { Ox.dump(esc) }
  x.report('dump esc-few') { Ox.dump(esc_few) }
  x.report('dump mixed')   { Ox.dump(mixed) }
  x.report('dump indent8') { Ox.dump(mixed, indent: 8) }
  x.compare!
end
```

| case         | before (i/s) | after (i/s) | speedup |
|--------------|-------------:|------------:|:-------:|
| dump ascii   |     3.343 M  |    3.804 M  | 1.14x   |
| dump utf8    |     2.803 M  |    3.048 M  | 1.09x   |
| dump esc     |     2.430 M  |    3.892 M  | 1.60x   |
| dump esc-few |     2.232 M  |    2.412 M  | 1.08x   |
| dump mixed   |     1.259 M  |    1.389 M  | 1.10x   |
| dump indent8 |     0.854 M  |    1.161 M  | 1.36x   |
