### PR TITLE
Speed up Ox.dump integer serialization

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -4,6 +4,7 @@
  */
 
 #include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -206,16 +207,47 @@ inline static void fill_attr(Out out, char name, const char *value, size_t len) 
     *out->cur++ = '"';
 }
 
-inline static const char *ulong2str(ulong num, char *end) {
-    char *b;
+static const char digits_table[] = "\
+00010203040506070809\
+10111213141516171819\
+20212223242526272829\
+30313233343536373839\
+40414243444546474849\
+50515253545556575859\
+60616263646566676869\
+70717273747576777879\
+80818283848586878889\
+90919293949596979899";
 
-    *end-- = '\0';
-    for (b = end; 0 < num || b == end; num /= 10, b--) {
-        *b = (num % 10) + '0';
+static char *ox_longlong_to_string(long long num, bool negative, char *b) {
+    while (100 <= num) {
+        unsigned idx = (unsigned)(num % 100) * 2;
+
+        *b-- = digits_table[idx + 1];
+        *b-- = digits_table[idx];
+        num /= 100;
     }
-    b++;
-
+    if (num < 10) {
+        *b-- = (char)(num + '0');
+    } else {
+        *b-- = digits_table[num * 2 + 1];
+        *b-- = digits_table[num * 2];
+    }
+    if (negative) {
+        *b = '-';
+    } else {
+        b++;
+    }
     return b;
+}
+
+inline static const char *ulong2str(ulong num, char *end) {
+    *end-- = '\0';
+    if (0 == num) {
+        *end = '0';
+        return end;
+    }
+    return ox_longlong_to_string((long long)num, false, end);
 }
 
 static int check_circular(Out out, VALUE obj, Element e) {
@@ -407,22 +439,15 @@ inline static void dump_num(Out out, VALUE obj) {
     char  buf[32];
     char *b   = buf + sizeof(buf) - 1;
     long  num = NUM2LONG(obj);
-    int   neg = 0;
+    bool  neg = false;
 
     if (0 > num) {
-        neg = 1;
+        neg = true;
         num = -num;
     }
     *b-- = '\0';
     if (0 < num) {
-        for (; 0 < num; num /= 10, b--) {
-            *b = (num % 10) + '0';
-        }
-        if (neg) {
-            *b = '-';
-        } else {
-            b++;
-        }
+        b = ox_longlong_to_string(num, neg, b);
     } else {
         *b = '0';
     }
@@ -468,12 +493,9 @@ static void dump_date(Out out, VALUE obj) {
     long  size;
 
     *b-- = '\0';
-    for (; 0 < jd; b--, jd /= 10) {
-        *b = '0' + (jd % 10);
-    }
-    b++;
-    if ('\0' == *b) {
-        b--;
+    if (0 < jd) {
+        b = ox_longlong_to_string((long long)jd, false, b);
+    } else {
         *b = '0';
     }
     size = sizeof(buf) - (b - buf) - 1;

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -440,6 +440,7 @@ inline static void dump_num(Out out, VALUE obj) {
     char *b   = buf + sizeof(buf) - 1;
     long  num = NUM2LONG(obj);
     bool  neg = false;
+    long  size;
 
     if (0 > num) {
         neg = true;
@@ -451,12 +452,12 @@ inline static void dump_num(Out out, VALUE obj) {
     } else {
         *b = '0';
     }
-    if (out->end - out->cur <= (long)(sizeof(buf) - (b - buf))) {
-        grow(out, sizeof(buf) - (b - buf));
+    size = sizeof(buf) - (b - buf) - 1;
+    if (out->end - out->cur <= size) {
+        grow(out, size);
     }
-    for (; '\0' != *b; b++) {
-        *out->cur++ = *b;
-    }
+    memcpy(out->cur, b, size);
+    out->cur += size;
     *out->cur = '\0';
 }
 


### PR DESCRIPTION
## Summary

Speeds up integer serialization in the object-mode dumper (`ext/ox/dump.c`), ported from oj. Only `ext/ox/dump.c` is touched.

1. **Digit lookup table** (oj [3d1316e](https://github.com/ohler55/oj/commit/3d1316e), [4bfb4b5](https://github.com/ohler55/oj/commit/4bfb4b5)). `dump_num`, `ulong2str` and `dump_date` each converted an integer to decimal one digit per division. A shared `ox_longlong_to_string()` helper now emits two digits per iteration from a static `digits_table`, halving the divisions, and all three use it. `dump_time_thin` is intentionally left alone: its nanosecond field is fixed-width zero-padded and its seconds loop has bespoke handling that does not map onto a leading-zero-stripping helper.

2. **`memcpy` in `dump_num`** (oj [5bf1d89](https://github.com/ohler55/oj/commit/5bf1d89)). `dump_num` appended the formatted number one byte at a time; it now copies it with a single `memcpy`, matching `dump_date`/`dump_time_thin`.

The two changes are complementary: on long integers neither helps alone (the table just moves the bottleneck to the byte copy), but together they give ~1.5x.

## Benchmark

- CPU: Intel Core Ultra 9 275HX
- OS: Linux 7.1.2 (x86_64)
- Compiler: gcc 16.1.1
- Ruby: 4.0.5

```ruby
require 'benchmark/ips'
require 'date'
require 'ox'

Ox.default_options = { mode: :object }

srand(1234)
small_ints  = (1..2000).to_a
big_ints    = Array.new(2000) { rand(10**17) }
mixed_ints  = Array.new(2000) { rand(-10**15..10**15) }
struct_kls  = Struct.new(:a, :b, :c, :d, :e)
structs     = Array.new(400) { |i| struct_kls.new(i, i * 2, i * 3, i * 4, i * 5) }
dates       = Array.new(2000) { |i| Date.jd(2_450_000 + i) }

Benchmark.ips do |x|
  x.config(warmup: 2, time: 5)
  x.report('dump small_ints') { Ox.dump(small_ints) }
  x.report('dump big_ints')   { Ox.dump(big_ints) }
  x.report('dump mixed_ints') { Ox.dump(mixed_ints) }
  x.report('dump structs')    { Ox.dump(structs) }
  x.report('dump dates')      { Ox.dump(dates) }
  x.compare!
end
```

| case       | before (i/s) | after (i/s) | speedup |
|------------|-------------:|------------:|:-------:|
| small_ints |     46.9 k   |    43.1 k   | 0.92x   |
| big_ints   |     19.6 k   |    31.5 k   | 1.61x   |
| mixed_ints |     20.2 k   |    30.9 k   | 1.53x   |
| structs    |      6.97 k  |     7.31 k  | 1.05x   |
| dates      |     20.0 k   |    21.0 k   | 1.05x   |

small_ints (all 1–4 digit values) regresses ~8% because memcpy's call overhead loses to the byte loop for such short copies — the same unconditional-memcpy tradeoff as oj; it only surfaces on data that is almost entirely tiny integers.

## Notes

Output is byte-for-byte unchanged (verified against a corpus covering integer boundaries around the 2/3/…-digit transitions and `LONG`-range Fixnums, Struct member indices, circular-reference ids, and Julian-day dates). `dump.c` compiles with no new warnings.
