### PR TITLE
Fix xml_str_len returning ~49x the escaped length

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -94,8 +94,9 @@ static const char xml_element_chars[257] = "\
 
 inline static size_t xml_str_len(const unsigned char *str, size_t len, const char *table) {
     size_t size = 0;
+    size_t i    = len;
 
-    for (; 0 < len; str++, len--) {
+    for (; 0 < i; str++, i--) {
         size += table[*str];
     }
     return size - len * (size_t)'0';

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -84,18 +84,9 @@ static const char hex_chars[17] = "0123456789abcdef";
         buffer += size;                   \
     }
 
-// The : character is equivalent to 10. Used for replacement characters up to 10
-// characters long such as '&#x10FFFF;'.
-static const char xml_friendly_chars[257] = "\
-:::::::::11::1::::::::::::::::::\
-11611156111111111111111111114141\
-11111111111111111111111111111111\
-11111111111111111111111111111111\
-11111111111111111111111111111111\
-11111111111111111111111111111111\
-11111111111111111111111111111111\
-11111111111111111111111111111111";
-
+// Each table below maps a byte to the length of its escaped form, held as an ASCII digit so that
+// xml_str_len() can sum the entries directly. The : character is equivalent to 10, used for replacement
+// characters up to 10 characters long such as '&#x10FFFF;'.
 static const char xml_quote_chars[257] = "\
 :::::::::11::1::::::::::::::::::\
 11611151111111111111111111114141\
@@ -127,9 +118,10 @@ inline static int is_xml_friendly(const uchar *str, int len, const char *table) 
 
 inline static size_t xml_str_len(const uchar *str, size_t len, const char *table) {
     size_t size = 0;
+    size_t i    = len;
 
-    for (; 0 < len; str++, len--) {
-        size += xml_friendly_chars[*str];
+    for (; 0 < i; str++, i--) {
+        size += table[*str];
     }
     return size - len * (size_t)'0';
 }


### PR DESCRIPTION
## Summary

`xml_str_len()` reports how long a string becomes once XML-escaped. It sums the per-byte escaped sizes held in a table that stores them as ASCII digits (`'1'`, `'4'`, `'5'`, `'6'`, `':'`), then turns that total into a number by subtracting `len * '0'` at the end. It used its own `len` argument as the loop counter, so `len` was always `0` by the time the subtraction ran and the function returned the raw sum of the ASCII codes instead. For text that needs no escaping `'1'` is `0x31`, so the result was 49x the real length.

Two things fell out of that.

1. **The `memcpy` fast path never ran.** `dump_str_value()` in `ext/ox/dump.c` and `append_string()` in `ext/ox/builder.c` skip the per-byte escape loop and `memcpy` the whole string when the escaped length equals the input length. With the inflated value that comparison could never hold for a non-empty string, so every string took the slow path. In `builder.c` the fast path has been dead since it was introduced in [466fd48](https://github.com/ohler55/ox/commit/466fd48) (April 2016); in `dump.c` since it was introduced in #416.

2. **`grow()` over-reserved ~49x.** `dump_str_value()` passes the same value to `grow(out, xsize)`, so `Ox.dump` reserved roughly 49x the buffer it needed. A document holding one 10 MB escape-free text node asked `grow()` for 513.8 MB instead of 10.5 MB.

The fix keeps the original `len` and counts a separate loop variable down.

`dump.c`'s copy additionally ignored its `table` argument and always indexed `xml_friendly_chars`. That was a deliberate choice in #416, described there as conservative: `xml_friendly_chars` escapes a superset of what the other tables escape, so "nothing expands" under it implies nothing expands under the real table. It is unnecessary, because `dump_str_value()`'s escape loop keys off the very table it is passed, so measuring with that table is exactly consistent. It also costs fast-path coverage, since element text containing `"` or `'` expands under `xml_friendly_chars` but not under `xml_element_chars`. It now indexes the `table` argument. `xml_friendly_chars` is then unused in `dump.c` and is removed; `builder.c` already keeps its copy under `#if 0`.

Only `ext/ox/dump.c` and `ext/ox/builder.c` are touched.

## Benchmark

- CPU: Intel Core Ultra 9 275HX
- OS: Linux 7.1.3 (x86_64)
- Compiler: gcc 16.1.1
- Ruby: 4.0.5

```ruby
require 'benchmark/ips'
require 'ox'

TEXT = ('Lorem ipsum dolor sit amet ' * 35)[0, 900]  # nothing to escape
QUOT = (%(he said "hi" and 'bye' ) * 40)[0, 900]     # only " and ', which element text never escapes
ESC  = (['a<b>c&d"e', "f'g"].join * 100)[0, 900]     # < > & really do expand

def doc(text)
  d = Ox::Document.new(version: '1.0')
  r = Ox::Element.new('root')
  200.times { |i| e = Ox::Element.new("item#{i}"); e['id'] = i.to_s; e << text; r << e }
  d << r
  d
end

def build(text)
  Ox::Builder.new do |b|
    b.element('root') { 200.times { |i| b.element("item#{i}", 'id' => i.to_s) { b.text(text) } } }
  end
end

clean = doc(TEXT)
quotes = doc(QUOT)
escaped = doc(ESC)

Benchmark.ips do |x|
  x.config(warmup: 2, time: 5)
  x.report('dump clean')      { Ox.dump(clean) }
  x.report('dump quotes')     { Ox.dump(quotes) }
  x.report('dump escaped')    { Ox.dump(escaped) }
  x.report('builder clean')   { build(TEXT) }
  x.report('builder escaped') { build(ESC) }
  x.compare!
end
```

| case            | before (i/s) | after (i/s) | speedup |
|-----------------|-------------:|------------:|:-------:|
| dump clean      |      7.20 k  |    17.96 k  | 2.49x   |
| dump quotes     |      7.24 k  |    17.74 k  | 2.45x   |
| dump escaped    |      4.30 k  |     4.01 k  | 0.93x   |
| builder clean   |      4.36 k  |    10.37 k  | 2.38x   |
| builder escaped |      1.96 k  |     1.96 k  | 1.00x   |

`dump quotes` is what the `table` argument buys: `"` and `'` are not escaped in element text, so those strings can now take the fast path too.

`dump escaped` regresses. The table above shows 0.93x; a lower-noise best-of-N wall-clock timing puts it nearer 3-5%, and the numbers here are medians of five interleaved runs per build, since a single `benchmark-ips` run per build compares across processes and drifts by several percent on cases that did not actually move. The regression is not a cost in the byte loop — fixing `len` alone, leaving the hardcoded table in place, reproduces it exactly. It comes from no longer over-allocating. `grow()` doubles capacity whenever the space left is `<=` the requested length, so the old inflated request kept ~45 KB of headroom and reallocated while the buffer was about a third full, while the correct request lets the buffer fill up almost completely first. Instrumenting `grow()` on the `dump escaped` document gives the same call count (3) and the same final capacity (522600) either way, but `realloc` copies 453 KB per dump instead of 322 KB. The effect scales with how much stale headroom the old length reserved, which is proportional to the length of each individual string, and documents that fit in the initial 65325-byte buffer never call `grow()` at all and are unaffected.

Against that, peak virtual memory attributable to dumping one 10 MB escape-free text node drops from ~500 MB to ~20 MB. Peak RSS barely moves, because the over-allocated pages were reserved but never written.

## Notes

Output is byte-for-byte unchanged. The fast path and the escape loop write the same bytes by construction, and this was verified across `Ox.dump` and `Ox::Builder` over escape-free text, every escapable character in both element and attribute context, all 256 single-byte values, the empty string, embedded NULs, multibyte UTF-8, control characters under each `:effort` and `:invalid_replace` setting, object-mode `String`s and `Symbol`s, comments, doctypes and CDATA, and `Ox::Builder`'s `line`/`column`/`pos` counters, whose fast-path `strchr` bookkeeping runs here for the first time.

`grow()` is still handed a length that is never smaller than what the escape loop goes on to write: an invalid byte is budgeted `':' - '0'` == 10, against at most 8 bytes for `&#x00NN;` and at most 10 for `:invalid_replace`.

`dump.c` and `builder.c` compile with no new warnings. Removing `xml_friendly_chars` is what keeps that true, since leaving the now-unused table in place raises `-Wunused-const-variable`.
