### PR TITLE
Fix GC crash from a stack PInfo wrapper left dangling on a raised parse

### DIFF
--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -676,12 +676,37 @@ static VALUE set_def_opts(VALUE self, VALUE opts) {
  * - +xml+ [String] XML String in optimized Object format.
  * *return* [Object] deserialized Object.
  */
+// Arguments for an object-mode parse that runs with GC disabled.
+struct _objParse {
+    char   *xml;
+    size_t  len;
+    Options options;
+    Err     err;
+};
+
+static VALUE obj_parse_body(VALUE argsv) {
+    struct _objParse *args = (struct _objParse *)argsv;
+
+    return ox_parse(args->xml, args->len, ox_obj_callbacks, 0, args->options, args->err);
+}
+
+// rb_gc_disable() returns Qtrue when GC was already disabled. Only re-enable
+// when this call is the one that disabled it. Runs even if the parse raised.
+static VALUE obj_parse_reenable(VALUE was_disabled) {
+    if (Qtrue != was_disabled) {
+        rb_gc_enable();
+    }
+    return Qnil;
+}
+
 static VALUE to_obj(VALUE self, VALUE ruby_xml) {
-    char           *xml, *x;
-    size_t          len;
-    VALUE           obj;
-    struct _options options = ox_default_options;
-    struct _err     err;
+    char            *xml, *x;
+    size_t           len;
+    VALUE            obj;
+    VALUE            was_disabled;
+    struct _options  options = ox_default_options;
+    struct _err      err;
+    struct _objParse args;
 
     err_init(&err);
     Check_Type(ruby_xml, T_STRING);
@@ -694,13 +719,16 @@ static VALUE to_obj(VALUE self, VALUE ruby_xml) {
         xml = ALLOCA_N(char, len);
     }
     memcpy(xml, x, len);
-    rb_gc_disable();
-    obj = ox_parse(xml, len - 1, ox_obj_callbacks, 0, &options, &err);
+    args.xml     = xml;
+    args.len     = len - 1;
+    args.options = &options;
+    args.err     = &err;
+    was_disabled = rb_gc_disable();
+    obj          = rb_ensure(obj_parse_body, (VALUE)&args, obj_parse_reenable, was_disabled);
     if (SMALL_XML < len) {
         xfree(xml);
     }
     RB_GC_GUARD(obj);
-    rb_gc_enable();
     if (err_has(&err)) {
         ox_err_raise(&err);
     }
@@ -872,12 +900,15 @@ static VALUE load(char *xml, size_t len, int argc, VALUE *argv, VALUE self, VALU
     }
     xml = defuse_bom(xml, &options);
     switch (options.mode) {
-    case ObjMode:
-        rb_gc_disable();
-        obj = ox_parse(xml, len, ox_obj_callbacks, 0, &options, err);
+    case ObjMode: {
+        struct _objParse args = {xml, len, &options, err};
+        VALUE            was_disabled;
+
+        was_disabled = rb_gc_disable();
+        obj          = rb_ensure(obj_parse_body, (VALUE)&args, obj_parse_reenable, was_disabled);
         RB_GC_GUARD(obj);
-        rb_gc_enable();
         break;
+    }
     case GenMode: obj = ox_parse(xml, len, ox_gen_callbacks, 0, &options, err); break;
     case LimMode: obj = ox_parse(xml, len, ox_limited_callbacks, 0, &options, err); break;
     case HashMode:

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -137,12 +137,107 @@ static void mark_pi_cb(void *ptr) {
     }
 }
 
+// State shared between the parse body and its ensure block. Bundled so the
+// whole parse can run under rb_ensure and clean up even when a callback raises.
+typedef struct _parseCtx {
+    PInfo  pi;
+    char **endp;
+    Err    err;
+    VALUE  wrap;
+    int    block_given;
+} *ParseCtx;
+
+static VALUE ox_parse_body(VALUE ctxv) {
+    ParseCtx ctx         = (ParseCtx)ctxv;
+    PInfo    pi          = ctx->pi;
+    char   **endp        = ctx->endp;
+    Err      err         = ctx->err;
+    int      block_given = ctx->block_given;
+    int      body_read   = 0;
+
+    while (1) {
+        next_non_white(pi);  // skip white space
+        if ('\0' == *pi->s) {
+            break;
+        }
+        if (body_read && 0 != endp) {
+            *endp = pi->s;
+            break;
+        }
+        if ('<' != *pi->s) {  // all top level entities start with <
+            set_error(err, "invalid format, expected <", pi->str, pi->s);
+            return Qnil;
+        }
+        pi->s++;  // past <
+        switch (*pi->s) {
+        case '?':  // processing instruction
+            pi->s++;
+            read_instruction(pi);
+            break;
+        case '!':  // comment or doctype
+            pi->s++;
+            if ('\0' == *pi->s) {
+                set_error(err, "invalid format, DOCTYPE or comment not terminated", pi->str, pi->s);
+                return Qnil;
+            } else if ('-' == *pi->s) {
+                pi->s++;  // skip -
+                if ('-' != *pi->s) {
+                    set_error(err, "invalid format, bad comment format", pi->str, pi->s);
+                    return Qnil;
+                } else {
+                    pi->s++;  // skip second -
+                    read_comment(pi);
+                }
+            } else if ((TolerantEffort == pi->options->effort) ? 0 == strncasecmp("DOCTYPE", pi->s, 7)
+                                                               : 0 == strncmp("DOCTYPE", pi->s, 7)) {
+                pi->s += 7;
+                read_doctype(pi);
+            } else {
+                set_error(err, "invalid format, DOCTYPE or comment expected", pi->str, pi->s);
+                return Qnil;
+            }
+            break;
+        case '\0': set_error(err, "invalid format, document not terminated", pi->str, pi->s); return Qnil;
+        default:
+            read_element(pi, 0);
+            body_read = 1;
+            break;
+        }
+        if (err_has(&pi->err)) {
+            *err = pi->err;
+            return Qnil;
+        }
+        if (block_given && Qnil != pi->obj && Qundef != pi->obj) {
+            if (NULL != pi->pcb->finish) {
+                pi->pcb->finish(pi);
+            }
+            rb_yield(pi->obj);
+        }
+    }
+    if (NULL != pi->pcb->finish) {
+        pi->pcb->finish(pi);
+    }
+    return pi->obj;
+}
+
+static VALUE ox_parse_ensure(VALUE ctxv) {
+    ParseCtx ctx = (ParseCtx)ctxv;
+
+    // pi is a stack value wrapped for GC marking. Detach the wrapper before
+    // this frame is gone so a later conservative GC can not mark a dead helper
+    // stack, and free the helper stack whether the parse returned normally or a
+    // callback raised out of it.
+    if (Qnil != ctx->wrap) {
+        DATA_PTR(ctx->wrap) = NULL;
+    }
+    helper_stack_cleanup(&ctx->pi->helpers);
+    return Qnil;
+}
+
 VALUE
 ox_parse(char *xml, size_t len, ParseCallbacks pcb, char **endp, Options options, Err err) {
-    struct _pInfo  pi;
-    int            body_read   = 0;
-    int            block_given = rb_block_given_p();
-    volatile VALUE wrap;
+    struct _pInfo    pi;
+    struct _parseCtx ctx;
 
     if (0 == xml) {
         set_error(err, "Invalid arg, xml string can not be null", xml, 0);
@@ -153,9 +248,6 @@ ox_parse(char *xml, size_t len, ParseCallbacks pcb, char **endp, Options options
     }
     // initialize parse info
     helper_stack_init(&pi.helpers);
-    // Protect against GC
-    wrap = TypedData_Wrap_Struct(rb_cObject, &ox_wrap_type, &pi);
-
     err_init(&pi.err);
     pi.str        = xml;
     pi.end        = pi.str + len;
@@ -167,79 +259,16 @@ ox_parse(char *xml, size_t len, ParseCallbacks pcb, char **endp, Options options
     pi.marked     = NULL;
     pi.mark_size  = 0;
     pi.mark_cnt   = 0;
-    while (1) {
-        next_non_white(&pi);  // skip white space
-        if ('\0' == *pi.s) {
-            break;
-        }
-        if (body_read && 0 != endp) {
-            *endp = pi.s;
-            break;
-        }
-        if ('<' != *pi.s) {  // all top level entities start with <
-            set_error(err, "invalid format, expected <", pi.str, pi.s);
-            helper_stack_cleanup(&pi.helpers);
-            return Qnil;
-        }
-        pi.s++;  // past <
-        switch (*pi.s) {
-        case '?':  // processing instruction
-            pi.s++;
-            read_instruction(&pi);
-            break;
-        case '!':  // comment or doctype
-            pi.s++;
-            if ('\0' == *pi.s) {
-                set_error(err, "invalid format, DOCTYPE or comment not terminated", pi.str, pi.s);
-                helper_stack_cleanup(&pi.helpers);
-                return Qnil;
-            } else if ('-' == *pi.s) {
-                pi.s++;  // skip -
-                if ('-' != *pi.s) {
-                    set_error(err, "invalid format, bad comment format", pi.str, pi.s);
-                    helper_stack_cleanup(&pi.helpers);
-                    return Qnil;
-                } else {
-                    pi.s++;  // skip second -
-                    read_comment(&pi);
-                }
-            } else if ((TolerantEffort == options->effort) ? 0 == strncasecmp("DOCTYPE", pi.s, 7)
-                                                           : 0 == strncmp("DOCTYPE", pi.s, 7)) {
-                pi.s += 7;
-                read_doctype(&pi);
-            } else {
-                set_error(err, "invalid format, DOCTYPE or comment expected", pi.str, pi.s);
-                helper_stack_cleanup(&pi.helpers);
-                return Qnil;
-            }
-            break;
-        case '\0':
-            set_error(err, "invalid format, document not terminated", pi.str, pi.s);
-            helper_stack_cleanup(&pi.helpers);
-            return Qnil;
-        default:
-            read_element(&pi, 0);
-            body_read = 1;
-            break;
-        }
-        if (err_has(&pi.err)) {
-            *err = pi.err;
-            helper_stack_cleanup(&pi.helpers);
-            return Qnil;
-        }
-        if (block_given && Qnil != pi.obj && Qundef != pi.obj) {
-            if (NULL != pcb->finish) {
-                pcb->finish(&pi);
-            }
-            rb_yield(pi.obj);
-        }
-    }
-    DATA_PTR(wrap) = NULL;
-    helper_stack_cleanup(&pi.helpers);
-    if (NULL != pcb->finish) {
-        pcb->finish(&pi);
-    }
-    return pi.obj;
+
+    ctx.pi          = &pi;
+    ctx.endp        = endp;
+    ctx.err         = err;
+    ctx.block_given = rb_block_given_p();
+    // Protect against GC. The wrapper marks the helper stack while parsing;
+    // ox_parse_ensure detaches it on every exit, including a callback raise.
+    ctx.wrap = TypedData_Wrap_Struct(rb_cObject, &ox_wrap_type, &pi);
+
+    return rb_ensure(ox_parse_body, (VALUE)&ctx, ox_parse_ensure, (VALUE)&ctx);
 }
 
 // Entered after the "<?" sequence. Ready to read the rest.

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -617,6 +617,44 @@ class Func < Test::Unit::TestCase
     end
   end
 
+  # An object-mode parse disables GC while it runs. When a callback raised
+  # (here a <t> Time element whose text is not a time) the matching
+  # rb_gc_enable was skipped, leaving GC disabled for the rest of the process.
+  def test_object_mode_error_reenables_gc
+    GC.enable  # start from a known enabled state
+    begin
+      Ox.load('<t>not a time</t>', mode: :object)
+    rescue StandardError
+      # expected: ArgumentError from Time.parse
+    end
+    # GC.enable returns true only if GC was still disabled. After the fix the
+    # parse re-enabled it, so this returns false.
+    assert_equal(false, GC.enable, 'object-mode error left GC disabled')
+  ensure
+    GC.enable
+  end
+
+  # ox_parse wraps a stack PInfo for GC marking and used to clear that wrapper
+  # only on the normal return. When a callback raised, the wrapper was left
+  # pointing at the dead stack frame and a later GC could walk a freed helper
+  # stack and crash in mark_pi_cb. Drive the raise-then-mark path hard; a
+  # regression segfaults the process.
+  def test_object_mode_error_wrapper_not_marked_after_raise
+    sink = []
+    200.times do |i|
+      begin
+        Ox.load("<top><a><b>#{'x' * (i % 20)}</b></a></top>", mode: :object)
+      rescue StandardError
+      end
+      GC.enable
+      GC.start(full_mark: true, immediate_sweep: true)
+      sink << Ox.load("<top><a><b>#{'y' * (i % 25)}</b></a></top>", mode: :hash)
+    end
+    assert_equal(200, sink.size)
+  ensure
+    GC.enable
+  end
+
   def test_escape_truncated
     Ox.default_options = $ox_object_options
     xml = %{<top>&</top>}


### PR DESCRIPTION
## Problem

`ox_parse()` wraps its stack-allocated `_pInfo` in a Ruby object so the helper stack is marked while parsing, and it clears that wrapper (`DATA_PTR(wrap) = NULL`) only on the normal return path. When a callback raises — most easily an object-mode `<t>` Time element whose text is not a time — the exception `longjmp`s straight out of `ox_parse` and skips the clear. The wrapper is now unowned but still points at the dead stack frame, and a later conservative GC can find its stale `VALUE` on the machine stack, mark it, and walk a helper stack whose `head`/`tail` are now garbage:

```
[BUG] Segmentation fault
    mark_pi_cb ext/ox/parse.c
    gc_mark_children / gc_marks_rest / heap_prepare
    load ext/ox/ox.c
```

It is timing dependent — it needs a later parse to reach a similar stack depth and trigger a mark before the stale slot is overwritten — but it is reachable from plain Ruby with only a `mode: :object` load of an invalid document.

A second, related issue: an object-mode parse runs with GC disabled, and a raised parse skipped the matching `rb_gc_enable`, leaving GC disabled for the rest of the process.

## Fix

- Run the parse body under `rb_ensure` (`ox_parse_body` / `ox_parse_ensure`) so the wrapper is detached and the helper stack freed on **every** exit, including a callback raise. `mark_pi_cb` already guards against a `NULL` data pointer, so a resurrected wrapper now marks nothing.
- Pair `rb_gc_disable` with `rb_gc_enable` on the object-mode paths in `load()` and `to_obj()` via `rb_ensure`, and only re-enable when this call is the one that disabled it.

Parsing output is unchanged.

## Testing

- `test_object_mode_error_reenables_gc` — deterministic; fails on `develop`, passes with the fix.
- `test_object_mode_error_wrapper_not_marked_after_raise` — drives the raise-then-mark path; a regression segfaults the process.
- Full `test/tests.rb` and `test/sax/sax_test.rb` pass, and are clean under `OX_ASAN=1`.
- The crash was reproduced at roughly 1 in 10 runs of a raise-then-mark stress; with this fix it did not recur over 34 runs.

---

Note: this is the first of two related changes. A separate `read_text` speedup PR will follow; because that change shifts GC timing it makes this latent crash more likely to surface, so it is worth landing this fix first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)