### PR TITLE
Speed up Ox.load text parsing with a SWAR fast path

### DIFF
--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -700,7 +700,7 @@ static VALUE obj_parse_reenable(VALUE was_disabled) {
 }
 
 static VALUE to_obj(VALUE self, VALUE ruby_xml) {
-    char            *xml, *x;
+    char            *xml, *x, *str;
     size_t           len;
     VALUE            obj;
     VALUE            was_disabled;
@@ -711,8 +711,12 @@ static VALUE to_obj(VALUE self, VALUE ruby_xml) {
     err_init(&err);
     Check_Type(ruby_xml, T_STRING);
     /* the xml string gets modified so make a copy of it */
+    str = StringValuePtr(ruby_xml);
     len = RSTRING_LEN(ruby_xml) + 1;
-    x   = defuse_bom(StringValuePtr(ruby_xml), &options);
+    x   = defuse_bom(str, &options);
+    // Drop the BOM from len as well, otherwise the copy below reads past the
+    // end of the Ruby string and xml is left without a terminating '\0'.
+    len -= (size_t)(x - str);
     if (SMALL_XML < len) {
         xml = ALLOC_N(char, len);
     } else {
@@ -744,7 +748,7 @@ static VALUE to_obj(VALUE self, VALUE ruby_xml) {
  * _raise_ [Exception] if the XML is malformed.
  */
 static VALUE to_gen(VALUE self, VALUE ruby_xml) {
-    char           *xml, *x;
+    char           *xml, *x, *str;
     size_t          len;
     VALUE           obj;
     struct _options options = ox_default_options;
@@ -753,8 +757,12 @@ static VALUE to_gen(VALUE self, VALUE ruby_xml) {
     err_init(&err);
     Check_Type(ruby_xml, T_STRING);
     /* the xml string gets modified so make a copy of it */
+    str = StringValuePtr(ruby_xml);
     len = RSTRING_LEN(ruby_xml) + 1;
-    x   = defuse_bom(StringValuePtr(ruby_xml), &options);
+    x   = defuse_bom(str, &options);
+    // Drop the BOM from len as well, otherwise the copy below reads past the
+    // end of the Ruby string and xml is left without a terminating '\0'.
+    len -= (size_t)(x - str);
     if (SMALL_XML < len) {
         xml = ALLOC_N(char, len);
     } else {
@@ -884,6 +892,7 @@ static int load_options_cb(VALUE k, VALUE v, VALUE opts) {
 
 static VALUE load(char *xml, size_t len, int argc, VALUE *argv, VALUE self, VALUE encoding, Err err) {
     VALUE           obj;
+    char           *body;
     struct _options options = ox_default_options;
 
     if (1 == argc && rb_cHash == rb_obj_class(*argv)) {
@@ -898,7 +907,11 @@ static VALUE load(char *xml, size_t len, int argc, VALUE *argv, VALUE self, VALU
     } else if (0 == options.rb_enc) {
         options.rb_enc = rb_enc_find(options.encoding);
     }
-    xml = defuse_bom(xml, &options);
+    // Shorten len by the size of the BOM so that xml + len stays the address
+    // of the terminating '\0' rather than running past the end of the buffer.
+    body = defuse_bom(xml, &options);
+    len -= (size_t)(body - xml);
+    xml = body;
     switch (options.mode) {
     case ObjMode: {
         struct _objParse args = {xml, len, &options, err};

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -5,6 +5,7 @@
 
 #include <errno.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -774,6 +775,53 @@ static char *read_element(PInfo pi, int depth) {
     return 0;
 }
 
+#define TEXT_ONES 0x0101010101010101ULL
+#define TEXT_HIGH 0x8080808080808080ULL
+
+/* Sets the high bit of every byte of a word that read_text can not copy
+ * through as is, that is a byte less than or equal to 0x20, a '&', or a '<'.
+ * Bytes with the high bit set are never flagged because ~v clears them, which
+ * matches the byte loop where a signed char with the high bit set is negative
+ * and so falls to the plain copy.
+ *
+ * A borrow out of one byte can also flag the byte above it, but a borrow is
+ * only produced by a byte that matched, so the lowest flagged byte is always a
+ * real match and there are never false negatives.
+ */
+inline static uint64_t text_bytes_of_interest(uint64_t v) {
+    uint64_t a = v ^ (TEXT_ONES * (uint64_t)'&');
+    uint64_t l = v ^ (TEXT_ONES * (uint64_t)'<');
+
+    return (((v - TEXT_ONES * 0x21) & ~v) | ((a - TEXT_ONES) & ~a) | ((l - TEXT_ONES) & ~l)) & TEXT_HIGH;
+}
+
+/* Offset of the lowest flagged byte, which is the first byte of the word that
+ * has to go through the switch below. Only ever called with a non-zero mask.
+ */
+inline static int text_first_of_interest(const char *s, uint64_t mask) {
+#if defined(__GNUC__) || defined(__clang__)
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+    (void)s;
+    return (int)(__builtin_clzll(mask) >> 3);
+#else
+    (void)s;
+    return (int)(__builtin_ctzll(mask) >> 3);
+#endif
+#else
+    int i;
+
+    (void)mask;
+    for (i = 0; i < 8; i++) {
+        unsigned char u = (unsigned char)s[i];
+
+        if (u <= 0x20 || '&' == u || '<' == u) {
+            break;
+        }
+    }
+    return i;
+#endif
+}
+
 static void read_text(PInfo pi) {
     char  buf[MAX_TEXT_LEN];
     char *b         = buf;
@@ -783,6 +831,44 @@ static void read_text(PInfo pi) {
     int   done = 0;
 
     while (!done) {
+        /* A byte above 0x20 that is neither '&' nor '<' is copied through
+         * unchanged for every skip mode and every effort, so runs of them can
+         * be moved a word at a time instead of one switch dispatch per byte.
+         * pi->end addresses the terminating '\0' so the loads never leave the
+         * document, which keeps the loop clean under ASan.
+         */
+        while (pi->s + 8 <= pi->end && b + 8 <= end) {
+            uint64_t v;
+            uint64_t mask;
+
+            memcpy(&v, pi->s, 8);
+            mask = text_bytes_of_interest(v);
+            /* b + 8 <= end so the whole word can be stored even when only part
+             * of it is kept. The bytes past the kept prefix are overwritten by
+             * the next copy or cut off by the terminating '\0'.
+             */
+            memcpy(b, pi->s, 8);
+            if (0 != mask) {
+                int n = text_first_of_interest(pi->s, mask);
+
+                b += n;
+                pi->s += n;
+                break;
+            }
+            b += 8;
+            pi->s += 8;
+        }
+        /* Only reached when a bound stopped the word loop, or for the byte the
+         * word loop stopped on.
+         */
+        while (pi->s < pi->end && b < end) {
+            unsigned char u = (unsigned char)*pi->s;
+
+            if (u <= 0x20 || '&' == u || '<' == u) {
+                break;
+            }
+            *b++ = *pi->s++;
+        }
         c = *pi->s++;
         switch (c) {
         case '<':

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -655,6 +655,32 @@ class Func < Test::Unit::TestCase
     GC.enable
   end
 
+  # The document is larger than SMALL_XML so that the copy the parser works on
+  # is heap allocated. Before the BOM length fix the copy read past the end of
+  # the Ruby string, which OX_ASAN=1 reports as a heap-buffer-overflow.
+  def test_bom_large_document
+    Ox.default_options = $ox_object_options
+    text = 'x' * 6000
+    xml = %{\xEF\xBB\xBF<?xml?>\n<top name="bom">#{text}</top>\n}
+
+    doc = Ox.parse(xml).root
+    assert_equal('bom', doc.attributes[:name])
+    assert_equal(text, doc.nodes[0])
+
+    doc = Ox.load(xml, mode: :generic).root
+    assert_equal('bom', doc.attributes[:name])
+    assert_equal(text, doc.nodes[0])
+
+    assert_equal({ top: [{ name: 'bom' }, text] }, Ox.load(xml, mode: :hash))
+  end
+
+  def test_bom_parse_obj_large_document
+    Ox.default_options = $ox_object_options
+    str = 'y' * 6000
+    xml = "\xEF\xBB\xBF#{Ox.dump(str, mode: :object)}"
+    assert_equal(str, Ox.parse_obj(xml))
+  end
+
   def test_escape_truncated
     Ox.default_options = $ox_object_options
     xml = %{<top>&</top>}


### PR DESCRIPTION
## Summary

`read_text()` in `ext/ox/parse.c` consumes element text one byte at a time through a `switch`. A callgrind profile of `Ox.load` attributes about a third of the parse to this one function, at roughly 9 instructions for every byte that is copied straight through and about 29 for every byte of whitespace. Most element text is neither, so most of that work is dispatch.

A byte above `0x20` that is neither `&` nor `<` is copied through unchanged for all four skip modes and both efforts:

- the strict-effort invalid character check only runs inside the `0 <= c && c <= 0x20` branch, so bytes with the high bit set, negative as a `signed char`, are never examined;
- `CrSkip` and `SpcSkip` only fold whitespace and control characters;
- UTF-8 lead and continuation bytes are copied as is.

A whole word of such bytes can therefore be moved with no dispatch at all. `read_text()` now loads eight bytes and flags the ones that still need the `switch` with

```c
(((v - ones * 0x21) & ~v) | ((a - ones) & ~a) | ((l - ones) & ~l)) & high
```

where `a` and `l` are `v` xored with `'&'` and `'<'` broadcast to every byte, `ones` is `0x0101010101010101` and `high` is `0x8080808080808080`. A zero result means the word is plain text and is copied whole.

On a hit the *lowest* flagged byte is always a real match: within each term a borrow can only flag the byte above one that already matched, so there are no false negatives and no false positive below a real one. Counting trailing zeros and dividing by eight therefore gives the first byte that has to go through the `switch`.

The word is stored *before* the mask is tested rather than after, which is what makes short runs pay. Storing conditionally and letting the byte loop re-copy the prefix costs more than the word test saves once specials are closer together than eight bytes apart; an earlier version that did so gained 8% on prose and *lost* 2% on entity-dense text. Storing unconditionally is safe because the loop only runs while `b + 8 <= end`, so the whole word always fits, and the bytes past the kept prefix are either overwritten by the next copy or cut off by the terminating `'\0'`.

The word loop is bounded by `pi->end`, which addresses the terminating `'\0'`, so it never reads past the document. That keeps it clean under AddressSanitizer rather than relying on aligned loads never crossing a page, which sanitizers report even though it cannot fault.

Only `read_text()` is touched. `read_cdata()`, `read_comment()` and the SAX parser are unchanged.

### The BOM fix this depends on

Using `pi->end` as a load bound requires `pi->end` to be correct, and it is not. `defuse_bom()` advances the xml pointer past a UTF-8 BOM but leaves the byte count unchanged, so all three entry points that call it are off by the size of the BOM. The first commit fixes that; it is a real bug independent of the speedup.

`Ox.parse` (`to_gen`) and `Ox.parse_obj` (`to_obj`) copy `RSTRING_LEN + 1` bytes starting at the *post-BOM* pointer. That reads three bytes past the end of the Ruby string and leaves the copy without a terminating `'\0'`. With a document large enough for the copy to be heap allocated it is visible today on `develop` under `OX_ASAN=1`:

```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 4104 thread T0
    #0 in memcpy
    #1 in to_gen ext/ox/ox.c:763
... is located 0 bytes after 4104-byte region
```

`Ox.load` and `Ox.load_file` (`load`) hand the unadjusted length to `ox_parse()`, so `pi->end`, documented as the end of the original string, addresses three bytes past the buffer. Nothing dereferences `pi->end` on `develop`, so that one is latent, but it makes the field useless as a bound. Subtracting the BOM from `len` in all three restores `xml + len` as the address of the terminating `'\0'`.

## Benchmark

- CPU: Intel Core Ultra 9 275HX
- OS: Linux 7.1.3 (x86_64)
- Compiler: gcc 16.1.1
- Ruby: 4.0.5, `-O3`

The document is ~185 KB: 200 elements holding a ~900 byte text node each. `prose` is whitespace-dense English with some `\r\n` and tabs, `dense` is whitespace-free base64 alphabet, `entity` is whitespace-free with an `&amp;` every ten bytes.

```ruby
require 'benchmark/ips'
require 'ox'

srand(4242)
WORDS = %w[the quick brown fox jumps over lazy dog lorem ipsum dolor sit amet
           consectetur adipiscing elit sed do eiusmod tempor incididunt ut
           labore et dolore magna aliqua].freeze
B64 = [*'A'..'Z', *'a'..'z', *'0'..'9', '+', '/'].freeze

def prose_text
  s = +''
  s << WORDS.sample << ' ' while s.bytesize < 860
  s << "\r\n" << WORDS.sample << "\t" << WORDS.sample
end

def dense_text = Array.new(900) { B64.sample }.join

def doc(kind)
  body = (1..200).map { |i| "  <item id=\"#{i}\">#{send(kind)}</item>\n" }.join
  "<?xml version=\"1.0\"?>\n<root>\n#{body}</root>\n"
end

PROSE = doc(:prose_text)
DENSE = doc(:dense_text)
ENT = "<?xml version=\"1.0\"?>\n<root>\n" +
      (1..200).map { |i| "  <item id=\"#{i}\">#{Array.new(150) { B64.sample * 5 + '&amp;' }.join}</item>\n" }.join +
      "</root>\n"

Benchmark.ips do |x|
  x.config(warmup: 2, time: 4)
  x.report('generic/prose')  { Ox.load(PROSE, mode: :generic) }
  x.report('generic/dense')  { Ox.load(DENSE, mode: :generic) }
  x.report('hash/prose')     { Ox.load(PROSE, mode: :hash) }
  x.report('hash/dense')     { Ox.load(DENSE, mode: :hash) }
  x.report('generic/entity') { Ox.load(ENT, mode: :generic) }
  x.report('generic/prose/skip_white')  { Ox.load(PROSE, mode: :generic, skip: :skip_white) }
  x.report('generic/prose/skip_return') { Ox.load(PROSE, mode: :generic, skip: :skip_return) }
  x.compare!
end
```

Medians of five runs alternating between the two builds:

| case                      | before (i/s) | after (i/s) | speedup |
|---------------------------|-------------:|------------:|:-------:|
| generic/prose             |        2656  |      4974   | 1.87x   |
| generic/dense             |        7710  |     12776   | 1.66x   |
| hash/prose                |        2574  |      4668   | 1.81x   |
| hash/dense                |        7059  |     10981   | 1.56x   |
| generic/entity            |        2384  |      2618   | 1.10x   |
| generic/prose/skip_white  |        2660  |      4971   | 1.87x   |
| generic/prose/skip_return |        2576  |      5157   | 2.00x   |

The per-run distributions are disjoint for every case, so the ordering is not noise; `generic/prose` for instance ranges 2640-2696 before and 4894-4989 after.

`generic/entity` is the adversarial case: with a special byte every ten bytes there is at most one full word to skip between them, and it still gains 10% because the word that triggered the mask is already stored by the time the trailing-zero count picks the byte to resume at.

Whitespace-dense text gains more than whitespace-free text even though it has fewer bytes on the fast path, because the bytes it avoids are the expensive ones: a space cost about 29 instructions in the old `switch` against 9 for a pass-through byte.

## Notes

**Parse output is unchanged.** A corpus of 151160 rows, every combination of mode (generic, object, hash, hash_no_attrs, limited), effort (strict, tolerant), skip (`skip_none`, `skip_return`, `skip_white`, `skip_off`) and input, covering entities, whitespace runs, multibyte UTF-8, control characters, truncated documents, BOM and non-BOM documents, mixed content, every text length from 1 to 9 and around the 4093-4097 and 8200 byte buffer boundaries, `&` and `<` at each of the eight word offsets, empty and whitespace-only text, and 3500 seeded fuzz cases, is byte-for-byte identical to `develop`, down to the line and column of every one of the 80248 `ParseError`s. The same corpus also comes out identical when the `__builtin_ctzll` path is compiled out in favour of the portable byte-scan fallback.

**The word test was checked directly.** The mask and the trailing-zero count were cross-checked against a naive byte scan over 40032768 words, random and boundary-structured, with no mismatch.

**AddressSanitizer is clean, and the check has positive controls.** `OX_ASAN=1` over 46166 loads of the corpus reports nothing, plus a 224-process sweep that runs exactly one parse per process across the buffer boundaries with and without a BOM. Because a clean sanitizer run only means something if the sanitizer can see the bound, both bounds were deliberately broken and both fire: relaxing the load bound to `pi->s < pi->end` gives `READ of size 8` in `read_text`, and relaxing the store bound to `b < end` gives `stack-buffer-overflow WRITE of size 1` in `read_text`.

Two caveats for anyone re-running this. Valgrind is blind to it: documents at or below `SMALL_XML` are `alloca`'d, and memcheck failed to report even a deliberately injected heap over-read that ASan caught. And `OX_ASAN=1 rake` reports spurious stack overflows on `develop` as well as here — `rb_raise` longjmps out of an instrumented frame, and since Ruby itself is not built with ASan `__asan_handle_no_return` never runs, so the escaped frame's shadow stays poisoned and the next call to reuse that stack region is blamed. ASan gives it away by printing "Memory access at offset 128 is **inside** this variable". The drivers above avoid raising for that reason.

**Compiles clean.** No new warnings. On compilers without `__builtin_ctzll`/`__builtin_clzll` the byte-scan fallback is used, and the big-endian branch is selected from `__BYTE_ORDER__`.
