### PR TITLE
Drop a redundant strlen and newline scan from text node parsing

### DIFF
--- a/ext/ox/gen_load.c
+++ b/ext/ox/gen_load.c
@@ -21,7 +21,7 @@ static void nomode_instruct(PInfo pi, const char *target, Attr attrs, const char
 static void add_doctype(PInfo pi, const char *docType);
 static void add_comment(PInfo pi, const char *comment);
 static void add_cdata(PInfo pi, const char *cdata, size_t len);
-static void add_text(PInfo pi, char *text, int closed);
+static void add_text(PInfo pi, char *text, size_t len, int closed);
 static void add_element(PInfo pi, const char *ename, Attr attrs, int hasChildren);
 static void end_element(PInfo pi, const char *ename);
 static void add_instruct(PInfo pi, const char *name, Attr attrs, const char *content);
@@ -230,8 +230,8 @@ static void add_cdata(PInfo pi, const char *cdata, size_t len) {
     rb_ary_push(helper_stack_peek(&pi->helpers)->obj, n);
 }
 
-static void add_text(PInfo pi, char *text, int closed) {
-    VALUE s = rb_str_new2(text);
+static void add_text(PInfo pi, char *text, size_t len, int closed) {
+    VALUE s = rb_str_new(text, len);
 
     if (0 != pi->options->rb_enc) {
         rb_enc_associate(s, pi->options->rb_enc);

--- a/ext/ox/hash_load.c
+++ b/ext/ox/hash_load.c
@@ -92,8 +92,8 @@ static void add_str(PInfo pi, VALUE s) {
     }
 }
 
-static void add_text(PInfo pi, char *text, int closed) {
-    VALUE s = rb_str_new2(text);
+static void add_text(PInfo pi, char *text, size_t len, int closed) {
+    VALUE s = rb_str_new(text, len);
     if (0 != pi->options->rb_enc) {
         rb_enc_associate(s, pi->options->rb_enc);
     }

--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -17,7 +17,7 @@
 #include "ruby/encoding.h"
 
 static void instruct(PInfo pi, const char *target, Attr attrs, const char *content);
-static void add_text(PInfo pi, char *text, int closed);
+static void add_text(PInfo pi, char *text, size_t len, int closed);
 static void add_element(PInfo pi, const char *ename, Attr attrs, int hasChildren);
 static void end_element(PInfo pi, const char *ename);
 
@@ -323,7 +323,7 @@ static void instruct(PInfo pi, const char *target, Attr attrs, const char *conte
     }
 }
 
-static void add_text(PInfo pi, char *text, int closed) {
+static void add_text(PInfo pi, char *text, size_t len, int closed) {
     Helper h = helper_stack_peek(&pi->helpers);
 
     if (!closed) {
@@ -343,7 +343,7 @@ static void add_text(PInfo pi, char *text, int closed) {
     switch (h->type) {
     case NoCode:
     case StringCode:
-        h->obj = rb_str_new2(text);
+        h->obj = rb_str_new(text, len);
         if (0 != pi->options->rb_enc) {
             rb_enc_associate(h->obj, pi->options->rb_enc);
         }

--- a/ext/ox/ox.h
+++ b/ext/ox/ox.h
@@ -98,7 +98,7 @@ typedef struct _parseCallbacks {
     void (*add_doctype)(PInfo pi, const char *docType);
     void (*add_comment)(PInfo pi, const char *comment);
     void (*add_cdata)(PInfo pi, const char *cdata, size_t len);
-    void (*add_text)(PInfo pi, char *text, int closed);
+    void (*add_text)(PInfo pi, char *text, size_t len, int closed);
     void (*add_element)(PInfo pi, const char *ename, Attr attrs, int hasChildren);
     void (*end_element)(PInfo pi, const char *ename);
     void (*finish)(PInfo pi);

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -624,7 +624,7 @@ static char *read_element(PInfo pi, int depth) {
             if (OffSkip == pi->options->skip && start < pi->s && '<' == *pi->s) {
                 c      = *pi->s;
                 *pi->s = '\0';
-                pi->pcb->add_text(pi, start, 1);
+                pi->pcb->add_text(pi, start, (size_t)(pi->s - start), 1);
                 *pi->s = c;
             }
             c = *pi->s++;
@@ -706,7 +706,9 @@ static char *read_element(PInfo pi, int depth) {
                         default: break;
                         }
                         if ('\0' != *start) {
-                            pi->pcb->add_text(pi, start, 1);
+                            // The skip handling above moves the terminator, so
+                            // the length is whatever survived it.
+                            pi->pcb->add_text(pi, start, strlen(start), 1);
                         }
                     }
                     pi->s++;
@@ -944,12 +946,17 @@ static void read_text(PInfo pi) {
             break;
         }
     }
-    *b         = '\0';
-    char *text = (0 != alloc_buf) ? alloc_buf : buf;
+    *b          = '\0';
+    char  *text = (0 != alloc_buf) ? alloc_buf : buf;
+    size_t len  = (size_t)(b - text);
     if (maybe_cr) {
+        // fix_newlines can fold "\r\n" to "\n" and shorten the text, so the
+        // length is only known after it runs. When it was skipped the text is
+        // exactly b - text, so add_text avoids a strlen on the common path.
         fix_newlines(text);
+        len = strlen(text);
     }
-    pi->pcb->add_text(pi, text, ('/' == *(pi->s + 1)));
+    pi->pcb->add_text(pi, text, len, ('/' == *(pi->s + 1)));
     if (0 != alloc_buf) {
         xfree(alloc_buf);
     }

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -829,6 +829,13 @@ static void read_text(PInfo pi) {
     char *end       = b + sizeof(buf) - 2;
     char  c;
     int   done = 0;
+    /* fix_newlines only rewrites '\r'. SpcSkip folds every '\r' to a space, so
+     * the only way one reaches buf under it is an entity like &#13;. Any other
+     * skip mode can keep a '\r', so assume one might be present there and run
+     * fix_newlines as before. SpcSkip text with no such entity, the common
+     * case, then skips the fix_newlines scan and second pass entirely.
+     */
+    int maybe_cr = (SpcSkip != pi->options->skip);
 
     while (!done) {
         /* A byte above 0x20 that is neither '&' nor '<' is copied through
@@ -901,6 +908,8 @@ static void read_text(PInfo pi) {
                 if (0 == (b = read_coded_chars(pi, b))) {
                     return;
                 }
+                /* An entity such as &#13; can decode to '\r'; be conservative. */
+                maybe_cr = 1;
             } else {
                 if (0 <= c && c <= 0x20) {
                     if (StrictEffort == pi->options->effort && 'x' == xml_valid_lower_chars[(unsigned char)c]) {
@@ -935,14 +944,14 @@ static void read_text(PInfo pi) {
             break;
         }
     }
-    *b = '\0';
+    *b         = '\0';
+    char *text = (0 != alloc_buf) ? alloc_buf : buf;
+    if (maybe_cr) {
+        fix_newlines(text);
+    }
+    pi->pcb->add_text(pi, text, ('/' == *(pi->s + 1)));
     if (0 != alloc_buf) {
-        fix_newlines(alloc_buf);
-        pi->pcb->add_text(pi, alloc_buf, ('/' == *(pi->s + 1)));
         xfree(alloc_buf);
-    } else {
-        fix_newlines(buf);
-        pi->pcb->add_text(pi, buf, ('/' == *(pi->s + 1)));
     }
 }
 


### PR DESCRIPTION
## Summary

`read_text()` runs two whole-buffer scans on every text node that are redundant on the common path: `fix_newlines()` scans for a `'\r'` that, under the default skip mode, cannot be there, and each mode's `add_text` callback re-derives the text length with `strlen()` even though `read_text()` already knows it. This removes both. It is a small cleanup rather than an optimization push — the measurable effect is a couple of percent on whitespace-free text nodes and nothing on prose — but it also brings `add_text` in line with the `add_cdata` callback, which already takes a length. Only text nodes are touched, and parse output is unchanged.

### Skip the newline fixup scan when the text has no carriage return

`read_text()` calls `fix_newlines()` on every text node. `fix_newlines()` folds `"\r\n"` to `"\n"` and a lone `"\r"` to `"\n"`, and it guards the rewrite with an `index(buf, '\r')` scan. Under the default `SpcSkip` that scan never finds anything: a `'\r'` is whitespace, so it is folded to a space while the text is read and never reaches the buffer. The only way one arrives under `SpcSkip` is an entity such as `&#13;`.

`read_text()` now tracks whether a `'\r'` might be in the buffer and calls `fix_newlines()` only when it can be. The flag is seeded once from the skip mode — `SpcSkip` starts it clear, every other mode starts it set because they can keep a raw `'\r'` — and the only other place it is set is the entity branch. No per-byte work is added to any mode, and every mode that could already contain a `'\r'` runs `fix_newlines()` exactly as before.

### Hand `add_text` the text length instead of a NUL-terminated string

`read_text()` knows how many bytes it wrote, but the `add_text` callback in each mode took only a pointer and rebuilt the length with `rb_str_new2()` (`rb_str_new_cstr`), walking the whole text node a second time before allocating the Ruby string.

`add_text` now takes a `size_t len`, matching the existing `add_cdata` signature, and builds the string with `rb_str_new(text, len)`. The `add_text` implementations are `static` in each mode's source file and nothing outside the extension constructs a `ParseCallbacks`, so this is an internal change with no public API impact. The length is free on the common path: when the newline fixup above is skipped the text is exactly `b - text`. When `fix_newlines()` does run it can shorten the text, so the length is taken after it, which is the same `strlen()` that `rb_str_new2()` used to do, hoisted out of the callback. The two `OffSkip` call sites in `read_element()` pass their length the same way. In object mode only the string case uses the length; the number, time and base64 cases still walk the NUL-terminated text.

## What was considered and left alone

A callgrind profile after #421 attributes the remaining `read_text()` cost mostly to the per-special-byte switch and the Ruby string allocation in the callbacks. Reducing the switch dispatch was prototyped two ways and dropped: hoisting the `effort`/`skip` option loads into locals cut instructions but not time (the loads are L1-resident and hidden by out-of-order execution), and folding the `SpcSkip` whitespace handling into the fast path gained ~4% there while costing 1–2% in the other skip modes, which is not a trade worth the code duplication it needs to avoid. This PR keeps only the two changes that have no downside in any mode.

## Effect

The document is ~185 KB: 200 elements each holding a ~900 byte text node, built two ways, whitespace-free (base64 alphabet) and whitespace-dense (prose with some `\r\n` and tabs).

```ruby
require 'benchmark/ips'
require 'ox'

srand(4242)
WORDS = %w[the quick brown fox jumps over lazy dog lorem ipsum dolor sit amet
           consectetur adipiscing elit sed do eiusmod tempor incididunt ut
           labore et dolore magna aliqua].freeze
B64 = [*'A'..'Z', *'a'..'z', *'0'..'9', '+', '/'].freeze

# ~900 bytes of whitespace-free data (base64 alphabet)
def whitespace_free_text = Array.new(900) { B64.sample }.join

# ~900 bytes of whitespace-dense prose with some \r\n and tabs
def whitespace_dense_text
  s = +''
  s << WORDS.sample << ' ' while s.bytesize < 860
  s << "\r\n" << WORDS.sample << "\t" << WORDS.sample
end

def doc(kind)
  body = (1..200).map { |i| "  <item id=\"#{i}\">#{send(kind)}</item>\n" }.join
  "<?xml version=\"1.0\"?>\n<root>\n#{body}</root>\n"
end

FREE  = doc(:whitespace_free_text)
DENSE = doc(:whitespace_dense_text)

Benchmark.ips do |x|
  x.config(warmup: 2, time: 4)
  x.report('generic, whitespace-free')  { Ox.load(FREE,  mode: :generic) }
  x.report('hash,    whitespace-free')  { Ox.load(FREE,  mode: :hash) }
  x.report('generic, whitespace-dense') { Ox.load(DENSE, mode: :generic) }
  x.report('hash,    whitespace-dense') { Ox.load(DENSE, mode: :hash) }
  x.compare!
end
```

Deterministic instruction counts from callgrind on that document with GC disabled, which do not depend on timing:

| case                  | before (Ir) | after (Ir) | delta   |
|-----------------------|------------:|-----------:|:-------:|
| whitespace-free text  |  39,517,076 | 38,129,365 | -3.51%  |
| whitespace-dense text |  85,244,704 | 83,891,091 | -1.59%  |

The whitespace-free drop is the skipped `strlen()`; the whitespace-dense drop is mostly the skipped `index()` scan.

In wall-clock terms (benchmark-ips, medians of eight runs alternating build order between rounds), whitespace-free text — the base64/identifier/numeric data payload case, where the skipped `strlen()` is the whole node — comes out 2.5–3.4% faster with non-overlapping per-run ranges; prose and entity-dense text sit inside the run-to-run noise, with no case regressing. That is the expected shape: on prose the two skipped scans are short, predictable, and a small fraction of the parse.

## Notes

Parse output is unchanged. A corpus of 151160 rows, every combination of mode (generic, object, hash, hash_no_attrs, limited), effort (strict, tolerant), skip (`skip_none`, `skip_return`, `skip_white`, `skip_off`) and input, covering entities, whitespace runs, multibyte UTF-8, control characters, truncated documents, BOM and non-BOM documents, mixed content, and the 4093-4097 and 8200 byte buffer boundaries, is byte-for-byte identical to `develop`, down to the line and column of every `ParseError`.

The carriage-return handling was checked separately, because the corpus above has raw `"\r\n"` and lone `"\r"` but no entity-encoded carriage return, which is exactly the case the skip flag has to be conservative about. A second corpus of `&#13;`, `&#13;&#10;`, `&#xd;&#xa;`, raw `"\r\n"`, lone `"\r"`, and a `"\r\n"` straddling the buffer growth boundary, across the same modes, efforts and skips, is byte-for-byte identical as well.

`test/tests.rb` and `test/sax/sax_test.rb` pass. `OX_ASAN=1` over 46166 exception-free loads of the corpus reports nothing; the length handed to `rb_str_new()` never exceeds what was written. One caveat for anyone re-running with ASan: an object-mode `<t>` whose text is not a time raises out of an instrumented frame, and because Ruby itself is not built with ASan the escaped frame's stack shadow stays poisoned and the next `pm_eval_make_iseq` is blamed for a spurious stack overflow. That report reproduces identically on unmodified `develop` and is unrelated to this change, which is why the ASan driver stays exception-free.

Compiles with no new warnings.
