### PR TITLE
Speed up Ox.dump / Ox::Builder string escaping with a SWAR fast path

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -14,6 +14,7 @@
 #include "ruby.h"
 #include "ruby/encoding.h"
 #include "ruby/version.h"
+#include "xml_str.h"
 
 #define MAX_DEPTH 128
 
@@ -92,16 +93,6 @@ static const char xml_element_chars[257] = "\
 11111111111111111111111111111111\
 11111111111111111111111111111111";
 
-inline static size_t xml_str_len(const unsigned char *str, size_t len, const char *table) {
-    size_t size = 0;
-    size_t i    = len;
-
-    for (; 0 < i; str++, i--) {
-        size += table[*str];
-    }
-    return size - len * (size_t)'0';
-}
-
 static void append_indent(Builder b) {
     if (0 >= b->indent) {
         return;
@@ -136,45 +127,102 @@ static void append_string(Builder b, const char *str, size_t size, const char *t
         }
         b->pos += size;
     } else {
-        char   buf[256];
-        char  *end = buf + sizeof(buf) - 1;
-        char  *bp  = buf;
-        size_t i   = size;
-        int    fcnt;
+        char        buf[256];
+        char       *bp   = buf;
+        char       *bend = buf + sizeof(buf) - 1;
+        const char *send = str + size;
 
-        for (; '\0' != *str && 0 < i; i--, str++) {
-            if ('1' == (fcnt = table[(unsigned char)*str])) {
-                if (end <= bp) {
+        while (str < send && '\0' != *str) {
+            /* Copy runs of pass-through bytes a word at a time into the staging
+             * buffer. A clean word has no byte below 0x20, so it can hold no
+             * newline and no '\0': col and pos advance by the whole word and the
+             * line is unchanged. On a hit the store is kept up to the first
+             * flagged byte and the rest is redone by the loops below.
+             */
+            while (str + 8 <= send) {
+                uint64_t v;
+                uint64_t mask;
+
+                memcpy(&v, str, 8);
+                mask = xml_bytes_of_interest(v);
+                if (bend < bp + 8) {
                     buf_append_string(&b->buf, buf, bp - buf);
                     bp = buf;
                 }
-                if ('\n' == *str) {
-                    b->line++;
-                    b->col = 1;
-                } else {
-                    b->col++;
-                }
-                b->pos++;
-                *bp++ = *str;
-            } else {
-                b->pos += fcnt - '0';
-                b->col += fcnt - '0';
-                if (buf < bp) {
-                    buf_append_string(&b->buf, buf, bp - buf);
-                    bp = buf;
-                }
-                switch (*str) {
-                case '"': buf_append_string(&b->buf, "&quot;", 6); break;
-                case '&': buf_append_string(&b->buf, "&amp;", 5); break;
-                case '\'': buf_append_string(&b->buf, "&apos;", 6); break;
-                case '<': buf_append_string(&b->buf, "&lt;", 4); break;
-                case '>': buf_append_string(&b->buf, "&gt;", 4); break;
-                default:
-                    // Must be one of the invalid characters.
-                    if (!strip_invalid_chars) {
-                        rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *str);
-                    }
+                memcpy(bp, str, 8);
+                if (0 != mask) {
+                    int n = xml_first_of_interest((const unsigned char *)str, mask);
+
+                    bp += n;
+                    str += n;
+                    b->col += n;
+                    b->pos += n;
                     break;
+                }
+                bp += 8;
+                str += 8;
+                b->col += 8;
+                b->pos += 8;
+            }
+            /* Pass-through bytes the word loop left: the tail shorter than a
+             * word. These are all >= 0x20 and not escape characters, so no
+             * newline check is needed.
+             */
+            while (str < send && '\0' != *str) {
+                unsigned char c = (unsigned char)*str;
+
+                if (c < 0x20 || '"' == c || '\'' == c || '&' == c || '<' == c || '>' == c) {
+                    break;
+                }
+                if (bend <= bp) {
+                    buf_append_string(&b->buf, buf, bp - buf);
+                    bp = buf;
+                }
+                *bp++ = *str++;
+                b->col++;
+                b->pos++;
+            }
+            /* One byte the predicate flagged: an escape, an invalid character,
+             * or a byte the table keeps unchanged ('"' and '\'' in the element
+             * table, and 0x09/0x0a/0x0d in every table).
+             */
+            if (str < send && '\0' != *str) {
+                int fcnt = table[(unsigned char)*str];
+
+                if ('1' == fcnt) {
+                    if (bend <= bp) {
+                        buf_append_string(&b->buf, buf, bp - buf);
+                        bp = buf;
+                    }
+                    if ('\n' == *str) {
+                        b->line++;
+                        b->col = 1;
+                    } else {
+                        b->col++;
+                    }
+                    b->pos++;
+                    *bp++ = *str++;
+                } else {
+                    b->pos += fcnt - '0';
+                    b->col += fcnt - '0';
+                    if (buf < bp) {
+                        buf_append_string(&b->buf, buf, bp - buf);
+                        bp = buf;
+                    }
+                    switch (*str) {
+                    case '"': buf_append_string(&b->buf, "&quot;", 6); break;
+                    case '&': buf_append_string(&b->buf, "&amp;", 5); break;
+                    case '\'': buf_append_string(&b->buf, "&apos;", 6); break;
+                    case '<': buf_append_string(&b->buf, "&lt;", 4); break;
+                    case '>': buf_append_string(&b->buf, "&gt;", 4); break;
+                    default:
+                        // Must be one of the invalid characters.
+                        if (!strip_invalid_chars) {
+                            rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *str);
+                        }
+                        break;
+                    }
+                    str++;
                 }
             }
         }

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -13,6 +13,7 @@
 #include "base64.h"
 #include "cache8.h"
 #include "ox.h"
+#include "xml_str.h"
 
 #define USE_B64 0
 #define MAX_DEPTH 1000
@@ -114,16 +115,6 @@ inline static int is_xml_friendly(const uchar *str, int len, const char *table) 
         }
     }
     return 1;
-}
-
-inline static size_t xml_str_len(const uchar *str, size_t len, const char *table) {
-    size_t size = 0;
-    size_t i    = len;
-
-    for (; 0 < i; str++, i--) {
-        size += table[*str];
-    }
-    return size - len * (size_t)'0';
 }
 
 inline static void dump_hex(uchar c, Out out) {
@@ -374,36 +365,78 @@ inline static void dump_str_value(Out out, const char *value, size_t size, const
         *out->cur = '\0';
         return;
     }
-    for (; 0 < size; size--, value++) {
-        if ('1' == table[(uchar)*value]) {
-            *out->cur++ = *value;
-        } else {
-            switch (*value) {
-            case '"': APPEND_CHARS(out->cur, "&quot;", 6); break;
-            case '&': APPEND_CHARS(out->cur, "&amp;", 5); break;
-            case '\'': APPEND_CHARS(out->cur, "&apos;", 6); break;
-            case '<': APPEND_CHARS(out->cur, "&lt;", 4); break;
-            case '>': APPEND_CHARS(out->cur, "&gt;", 4); break;
-            default:
-                // Must be one of the invalid characters.
-                if (StrictEffort == out->opts->effort) {
-                    rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *value);
-                }
-                if (Yes == out->opts->allow_invalid) {
-                    *out->cur++ = '&';
-                    *out->cur++ = '#';
-                    *out->cur++ = 'x';
-                    *out->cur++ = '0';
-                    *out->cur++ = '0';
-                    dump_hex(*value, out);
-                    *out->cur++ = ';';
-                } else if ('\0' != *out->opts->inv_repl) {
-                    // If the empty string then ignore. The first character of
-                    // the replacement is the length.
-                    memcpy(out->cur, out->opts->inv_repl + 1, (size_t)*out->opts->inv_repl);
-                    out->cur += *out->opts->inv_repl;
-                }
+    const char *end = value + size;
+
+    while (value < end) {
+        /* Copy runs of pass-through bytes a word at a time. A word with no byte
+         * of interest is stored whole; on a hit the store is kept up to the
+         * first flagged byte and the rest is redone by the loops below. xsize
+         * was reserved for the whole escaped result so out->cur stays inside the
+         * buffer, and out->cur + 8 <= out->end keeps the wide store in bounds on
+         * its own.
+         */
+        while (value + 8 <= end && out->cur + 8 <= out->end) {
+            uint64_t v;
+            uint64_t mask;
+
+            memcpy(&v, value, 8);
+            mask = xml_bytes_of_interest(v);
+            memcpy(out->cur, value, 8);
+            if (0 != mask) {
+                int n = xml_first_of_interest((const unsigned char *)value, mask);
+
+                value += n;
+                out->cur += n;
                 break;
+            }
+            value += 8;
+            out->cur += 8;
+        }
+        /* Pass-through bytes the word loop could not take: the tail shorter than
+         * a word, and the '"' or '\'' the element table keeps that the predicate
+         * flags anyway.
+         */
+        while (value < end) {
+            uchar c = (uchar)*value;
+
+            if (c < 0x20 || '"' == c || '\'' == c || '&' == c || '<' == c || '>' == c) {
+                break;
+            }
+            *out->cur++ = *value++;
+        }
+        if (value < end) {
+            char c = *value++;
+
+            if ('1' == table[(uchar)c]) {
+                *out->cur++ = c;
+            } else {
+                switch (c) {
+                case '"': APPEND_CHARS(out->cur, "&quot;", 6); break;
+                case '&': APPEND_CHARS(out->cur, "&amp;", 5); break;
+                case '\'': APPEND_CHARS(out->cur, "&apos;", 6); break;
+                case '<': APPEND_CHARS(out->cur, "&lt;", 4); break;
+                case '>': APPEND_CHARS(out->cur, "&gt;", 4); break;
+                default:
+                    // Must be one of the invalid characters.
+                    if (StrictEffort == out->opts->effort) {
+                        rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", c);
+                    }
+                    if (Yes == out->opts->allow_invalid) {
+                        *out->cur++ = '&';
+                        *out->cur++ = '#';
+                        *out->cur++ = 'x';
+                        *out->cur++ = '0';
+                        *out->cur++ = '0';
+                        dump_hex(c, out);
+                        *out->cur++ = ';';
+                    } else if ('\0' != *out->opts->inv_repl) {
+                        // If the empty string then ignore. The first character of
+                        // the replacement is the length.
+                        memcpy(out->cur, out->opts->inv_repl + 1, (size_t)*out->opts->inv_repl);
+                        out->cur += *out->opts->inv_repl;
+                    }
+                    break;
+                }
             }
         }
     }

--- a/ext/ox/xml_str.h
+++ b/ext/ox/xml_str.h
@@ -1,0 +1,121 @@
+/* xml_str.h
+ * Copyright (c) 2011, Peter Ohler
+ * All rights reserved.
+ */
+
+#ifndef OX_XML_STR_H
+#define OX_XML_STR_H
+
+#include <stdint.h>
+#include <string.h>
+
+/* Shared helpers for the serializer escape path used by both dump.c and
+ * builder.c. The size scan and the escape loop both walk the source string a
+ * word at a time and only fall to a byte at a time when a word contains a byte
+ * that might need escaping.
+ *
+ * Each escape table maps a byte to the length of its serialized form held as an
+ * ASCII digit, '1' meaning the byte is copied through unchanged. The tables in
+ * use (xml_element_chars, xml_quote_chars / xml_attr_chars) escape only a
+ * subset of
+ *
+ *     a byte below 0x20, '"', '\'', '&', '<', '>'
+ *
+ * so a word none of whose bytes are in that set is entirely pass-through and
+ * every one of its bytes is '1' in every table. The predicate below is that
+ * union. It is deliberately a superset: '"' and '\'' are pass-through in
+ * xml_element_chars, and 0x09, 0x0a and 0x0d are pass-through in every table,
+ * but flagging them only sends those bytes to the byte loop, which copies them
+ * through unchanged, so the output is identical. It must never miss a byte a
+ * table would escape, which is why the whole escaped union is covered even
+ * though no current table escapes '\''.
+ */
+
+#define XSTR_ONES 0x0101010101010101ULL
+#define XSTR_HIGH 0x8080808080808080ULL
+
+/* Sets the high bit of every byte of a word that is not guaranteed to be
+ * pass-through, that is a byte below 0x20, or a '"', '\'', '&', '<' or '>'.
+ *
+ * The byte below 0x20 test is the classic (v - ones*0x20) & ~v hasless, and the
+ * five character tests are haszero on v xored with the character broadcast to
+ * every byte. Bytes with the high bit already set, the UTF-8 lead and
+ * continuation bytes, are cleared by the & ~... term and so are never flagged.
+ *
+ * A borrow out of one byte can also flag the byte above it, but a borrow is
+ * only produced by a byte that already matched, so the lowest flagged byte is
+ * always a real match and there are never false negatives. That is what lets a
+ * zero result mean the whole word is pass-through, and the count of trailing
+ * zeros point at the first byte that has to go through the table.
+ */
+inline static uint64_t xml_bytes_of_interest(uint64_t v) {
+    uint64_t q = v ^ (XSTR_ONES * (uint64_t)'"');
+    uint64_t s = v ^ (XSTR_ONES * (uint64_t)'\'');
+    uint64_t a = v ^ (XSTR_ONES * (uint64_t)'&');
+    uint64_t l = v ^ (XSTR_ONES * (uint64_t)'<');
+    uint64_t g = v ^ (XSTR_ONES * (uint64_t)'>');
+
+    return (((v - XSTR_ONES * 0x20) & ~v) | ((q - XSTR_ONES) & ~q) | ((s - XSTR_ONES) & ~s) | ((a - XSTR_ONES) & ~a) |
+            ((l - XSTR_ONES) & ~l) | ((g - XSTR_ONES) & ~g)) &
+           XSTR_HIGH;
+}
+
+/* Offset of the lowest flagged byte, which is the first byte of the word that
+ * has to go through the table. Only ever called with a non-zero mask.
+ */
+inline static int xml_first_of_interest(const unsigned char *s, uint64_t mask) {
+#if defined(__GNUC__) || defined(__clang__)
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+    (void)s;
+    return (int)(__builtin_clzll(mask) >> 3);
+#else
+    (void)s;
+    return (int)(__builtin_ctzll(mask) >> 3);
+#endif
+#else
+    int i;
+
+    (void)mask;
+    for (i = 0; i < 8; i++) {
+        unsigned char u = s[i];
+
+        if (u < 0x20 || '"' == u || '\'' == u || '&' == u || '<' == u || '>' == u) {
+            break;
+        }
+    }
+    return i;
+#endif
+}
+
+/* Length of str once serialized through table, the sum of the table entries
+ * less len * '0' so that a pass-through byte counts as one. A word none of
+ * whose bytes need escaping contributes 8 * '1' with no table lookup at all;
+ * only words with a byte of interest are summed one byte at a time. The word
+ * loop is bounded by str + len so it never reads past the string.
+ */
+inline static size_t xml_str_len(const unsigned char *str, size_t len, const char *table) {
+    const unsigned char *end  = str + len;
+    size_t               size = 0;
+
+    while (str + 8 <= end) {
+        uint64_t v;
+
+        memcpy(&v, str, 8);
+        if (0 == xml_bytes_of_interest(v)) {
+            size += 8 * (size_t)'1';
+        } else {
+            int i;
+
+            for (i = 0; i < 8; i++) {
+                size += table[str[i]];
+            }
+        }
+        str += 8;
+    }
+    for (; str < end; str++) {
+        size += table[*str];
+    }
+    return size - len * (size_t)'0';
+}
+
+#endif /* OX_XML_STR_H */


### PR DESCRIPTION
This does for the serializer what #421 did for the parser: it copies runs of pass-through bytes a word at a time instead of one table lookup per byte. It touches only `dump.c`, `builder.c` and a new shared header, so it does not overlap the parser work in #422.

## Why

`dump_str_value()` (and its `Ox::Builder` twin `append_string()`) serialize a string in two passes: `xml_str_len()` sums a per-byte table lookup to size the escaped result, then a second loop copies the string and expands the bytes that have to be escaped, unless the string is entirely pass-through and can be `memcpy`'d whole (the #419 fast path).

A callgrind profile of `Ox.dump` on a 180 KB document (real ruby, GC off, median of 40 iterations, the two hot functions forced `noinline` for clean attribution):

| workload | `xml_str_len` (pass 1) | escape loop (pass 2) |
|---|---|---|
| clean text | 77.9% | ~0% (memcpy path) |
| object strings | 75.6% | 0.5% |
| attribute values | 36.6% | 5.2% |
| escape / 15 bytes | 28.4% | 63.2% |

The size scan dominates every clean workload and the escape loop dominates escape-heavy text, and both walk the string one byte at a time even though whole runs need no escaping.

## How

Every table in use (`xml_element_chars`, `xml_quote_chars` / `xml_attr_chars`) leaves a byte unchanged unless it is below `0x20` or is one of `"` `'` `&` `<` `>`. A word none of whose bytes are in that set is entirely pass-through and each of its bytes is `'1'` in the table. `xml_bytes_of_interest()` flags such bytes:

```c
(((v - ones*0x20) & ~v) | (q-ones)&~q | (s-ones)&~s
                        | (a-ones)&~a | (l-ones)&~l | (g-ones)&~g) & high
```

The control test is the classic `hasless` and the five character tests are `haszero` on `v` xored with each character. A zero result means the whole word is pass-through: the size scan adds `8 * '1'` and the escape loop stores the word whole. On a hit the lowest flagged byte is always a real match — a borrow can only flag the byte *above* one that already matched — so `__builtin_ctzll >> 3` gives the first byte that has to go through the table and the pass-through prefix is kept.

The predicate is a deliberate **superset**: `"` and `'` are pass-through in `xml_element_chars` and `0x09`/`0x0a`/`0x0d` are pass-through everywhere, but flagging them only sends those bytes to the byte loop, which copies them through unchanged, so the output is identical. `'` is covered even though no current table escapes it, keeping the predicate safe for every table. In `builder.c` the same property makes the bookkeeping safe to batch: a clean word has no byte below `0x20`, so it holds no newline and no `'\0'`, and `col`/`pos` advance by the whole word with the line unchanged.

### Bounds

- The size scan word loop is bounded by `str + len`, so it never reads past the string.
- In `dump`'s escape loop the unconditional word store is guarded by `out->cur + 8 <= out->end`; `xsize` was already reserved for the whole escaped result, but the guard keeps the wide store in bounds on its own, and the bytes past the kept prefix are overwritten by the next copy or cut off by the `'\0'`.
- In `builder` the staging store is guarded by the buffer's existing slack.
- A byte-scan fallback and a big-endian `__builtin_clzll` path cover compilers without `__builtin_ctzll`.

The size scan and the predicate live in a new shared header, `ext/ox/xml_str.h`, so `dump.c` and `builder.c` share one copy of `xml_str_len()` rather than keeping the duplicate that #419 had to fix in two places.

## Benchmark

- CPU: Intel Core Ultra 9 275HX
- OS: Linux 7.1.3 (x86_64)
- Compiler: gcc 16.1.1
- Ruby: 4.0.5

```ruby
require 'ox'
require 'benchmark/ips'

CLEAN = ('The quick brown fox jumps over the lazy dog while carrying twelve jugs. ' * 13)[0, 900]

def esc(every)
  s = CLEAN.dup
  i = every
  while i < s.length
    s[i] = i.even? ? '&' : '<'
    i += every
  end
  s
end

def nl
  s = CLEAN.dup
  i = 40
  while i < s.length
    s[i] = "\n"
    i += 40
  end
  s
end

def gen_doc(text, n = 200)
  doc  = Ox::Document.new
  root = Ox::Element.new('root')
  n.times { root << text.dup }
  doc << root
  doc
end

def gen_attr(n = 200, attrs = 6)
  doc  = Ox::Document.new
  root = Ox::Element.new('root')
  val  = ('attribute-value-' * 3)[0, 40]
  n.times do
    e = Ox::Element.new('item')
    attrs.times { |j| e["a#{j}"] = val.dup }
    root << e
  end
  doc << root
  doc
end

def build_text(text, n = 200)
  Ox::Builder.new { |b| b.element('root') { n.times { b.text(text) } } }
end

def build_attr(n = 200, attrs = 6)
  val = ('attribute-value-' * 3)[0, 40]
  Ox::Builder.new do |b|
    b.element('root') do
      n.times { b.element('item', Hash[Array.new(attrs) { |j| ["a#{j}", val] }]) {} }
    end
  end
end

DUMP_CLEAN = gen_doc(CLEAN)
DUMP_E10   = gen_doc(esc(10))
DUMP_E25   = gen_doc(esc(25))
DUMP_E50   = gen_doc(esc(50))
DUMP_ATTR  = gen_attr
DUMP_OBJ   = Array.new(200) { CLEAN.dup }
DUMP_NL    = gen_doc(nl)
BTEXT_E25  = esc(25)

cases = {
  'dump/clean' => -> { Ox.dump(DUMP_CLEAN) },
  'dump/esc10' => -> { Ox.dump(DUMP_E10) },
  'dump/esc25' => -> { Ox.dump(DUMP_E25) },
  'dump/esc50' => -> { Ox.dump(DUMP_E50) },
  'dump/attr'  => -> { Ox.dump(DUMP_ATTR) },
  'dump/obj'   => -> { Ox.dump(DUMP_OBJ) },
  'dump/nl'    => -> { Ox.dump(DUMP_NL) },
  'bld/clean'  => -> { build_text(CLEAN) },
  'bld/esc25'  => -> { build_text(BTEXT_E25) },
  'bld/attr'   => -> { build_attr },
}

cases.each do |name, blk|
  rep = Benchmark.ips(quiet: true) do |x|
    x.config(warmup: 1, time: 2)
    x.report(name, &blk)
  end
  printf "%-11s %12.1f i/s\n", name, rep.entries.first.ips
end
```

**Ox.dump**

| case | workload | develop | branch | |
|---|---|---:|---:|---:|
| `dump/clean` | clean text | 21984 | 23610 | +7.4% |
| `dump/obj` | object mode strings | 21559 | 23325 | +8.2% |
| `dump/attr` | attribute values | 34791 | 40253 | +15.7% |
| `dump/esc50` | escape every 50 bytes | 6252 | 10848 | +73.5% |
| `dump/esc25` | escape every 25 bytes | 5038 | 9050 | +79.6% |
| `dump/esc10` | escape every 10 bytes | 5677 | 6381 | +12.4% |
| `dump/nl` | newline every 40 bytes | 22450 | 23543 | +4.9% |

**Ox::Builder**

| case | workload | develop | branch | |
|---|---|---:|---:|---:|
| `bld/clean` | clean text | 10875 | 11222 | +3.2% |
| `bld/esc25` | escape every 25 bytes | 2984 | 6455 | +116.3% |
| `bld/attr` | attribute values | 4774 | 4934 | +3.4% |

The escape wins grow with the length of the clean run between escapes. The newline-heavy case, where the predicate flags every `0x0a`, is the worst case for the conservative predicate and still gains from the size scan rather than regressing. The Builder clean and attribute cases move little because the Builder spends most of its time in per-call Ruby method and block dispatch, so the C-level escaping is a small fraction there.

## Verification

- **Output equivalence, byte-identical to develop.** 29073 `Ox.dump` cases and 3898 `Ox::Builder` cases (the latter also checked for identical `line` / `column` / `pos`), over both tables, every escape character at every offset in a word, control and invalid bytes under every `effort` and `invalid_replace`, tab/newline/CR, multibyte UTF-8, binary, lengths 0..17 and buffer-growth boundaries.
- **Predicate cross-check.** The word test and the trailing-zero count matched a naive byte scan over 120M random and structured words (gcc, clang, and the byte-scan fallback), and `xml_str_len` matched a naive sum over random buffers of every length 0..80.
- **AddressSanitizer.** Clean over 10485 dump/builder ops and a 3M-iteration exact-size-buffer harness, with read and write positive controls on the input bound, the dump output bound and the builder staging bound that all fault when the guard is loosened (Ruby itself is not ASan-built, so the harness uses instrumented buffers). Raising cases are kept out of the ASan driver to avoid the known stale-shadow artifact from `rb_raise` longjmping out of an instrumented frame.
- `test/tests.rb` and `test/sax/sax_test.rb` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
