### PR TITLE
Port oj's fast_memcpy16 into the Ox.dump short-copy path

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -85,6 +85,16 @@ static const char hex_chars[17] = "0123456789abcdef";
         buffer += size;                   \
     }
 
+#ifdef HAVE_FAST_MEMCPY
+#define APPEND_CHARS_SMALL(buffer, chars, size) \
+    {                                           \
+        fast_memcpy16(buffer, chars, size);     \
+        buffer += size;                         \
+    }
+#else
+#define APPEND_CHARS_SMALL(buffer, chars, size) APPEND_CHARS(buffer, chars, size)
+#endif
+
 // Each table below maps a byte to the length of its escaped form, held as an ASCII digit so that
 // xml_str_len() can sum the entries directly. The : character is equivalent to 10, used for replacement
 // characters up to 10 characters long such as '&#x10FFFF;'.
@@ -171,28 +181,21 @@ inline static void fill_indent(Out out, int cnt) {
 }
 
 inline static void fill_value(Out out, const char *value, size_t len) {
-    if (6 < len) {
-        memcpy(out->cur, value, len);
-        out->cur += len;
+    if (16 < len) {
+        APPEND_CHARS(out->cur, value, len);
     } else {
-        for (; 0 < len; len--, value++) {
-            *out->cur++ = *value;
-        }
+        APPEND_CHARS_SMALL(out->cur, value, len);
     }
 }
 
 inline static void fill_attr(Out out, char name, const char *value, size_t len) {
     *out->cur++ = ' ';
     *out->cur++ = name;
-    *out->cur++ = '=';
-    *out->cur++ = '"';
-    if (6 < len) {
-        memcpy(out->cur, value, len);
-        out->cur += len;
+    APPEND_CHARS_SMALL(out->cur, "=\"", 2);
+    if (16 < len) {
+        APPEND_CHARS(out->cur, value, len);
     } else {
-        for (; 0 < len; len--, value++) {
-            *out->cur++ = *value;
-        }
+        APPEND_CHARS_SMALL(out->cur, value, len);
     }
     *out->cur++ = '"';
 }
@@ -312,9 +315,7 @@ static void dump_start(Out out, Element e) {
     }
     if (e->closed) {
         if (out->opts->no_empty) {
-            *out->cur++ = '>';
-            *out->cur++ = '<';
-            *out->cur++ = '/';
+            APPEND_CHARS_SMALL(out->cur, "></", 3);
             *out->cur++ = e->type;
         } else {
             *out->cur++ = '/';
@@ -331,8 +332,7 @@ static void dump_end(Out out, Element e) {
         grow(out, size);
     }
     fill_indent(out, e->indent);
-    *out->cur++ = '<';
-    *out->cur++ = '/';
+    APPEND_CHARS_SMALL(out->cur, "</", 2);
     *out->cur++ = e->type;
     *out->cur++ = '>';
     *out->cur   = '\0';
@@ -342,13 +342,10 @@ inline static void dump_value(Out out, const char *value, size_t size) {
     if (out->end - out->cur <= (long)size) {
         grow(out, size);
     }
-    if (6 < size) {
-        memcpy(out->cur, value, size);
-        out->cur += size;
+    if (16 < size) {
+        APPEND_CHARS(out->cur, value, size);
     } else {
-        for (; 0 < size; size--, value++) {
-            *out->cur++ = *value;
-        }
+        APPEND_CHARS_SMALL(out->cur, value, size);
     }
     *out->cur = '\0';
 }
@@ -360,8 +357,11 @@ inline static void dump_str_value(Out out, const char *value, size_t size, const
         grow(out, xsize);
     }
     if (xsize == size) {
-        memcpy(out->cur, value, size);
-        out->cur += size;
+        if (16 < size) {
+            APPEND_CHARS(out->cur, value, size);
+        } else {
+            APPEND_CHARS_SMALL(out->cur, value, size);
+        }
         *out->cur = '\0';
         return;
     }
@@ -411,22 +411,18 @@ inline static void dump_str_value(Out out, const char *value, size_t size, const
                 *out->cur++ = c;
             } else {
                 switch (c) {
-                case '"': APPEND_CHARS(out->cur, "&quot;", 6); break;
-                case '&': APPEND_CHARS(out->cur, "&amp;", 5); break;
-                case '\'': APPEND_CHARS(out->cur, "&apos;", 6); break;
-                case '<': APPEND_CHARS(out->cur, "&lt;", 4); break;
-                case '>': APPEND_CHARS(out->cur, "&gt;", 4); break;
+                case '"': APPEND_CHARS_SMALL(out->cur, "&quot;", 6); break;
+                case '&': APPEND_CHARS_SMALL(out->cur, "&amp;", 5); break;
+                case '\'': APPEND_CHARS_SMALL(out->cur, "&apos;", 6); break;
+                case '<': APPEND_CHARS_SMALL(out->cur, "&lt;", 4); break;
+                case '>': APPEND_CHARS_SMALL(out->cur, "&gt;", 4); break;
                 default:
                     // Must be one of the invalid characters.
                     if (StrictEffort == out->opts->effort) {
                         rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", c);
                     }
                     if (Yes == out->opts->allow_invalid) {
-                        *out->cur++ = '&';
-                        *out->cur++ = '#';
-                        *out->cur++ = 'x';
-                        *out->cur++ = '0';
-                        *out->cur++ = '0';
+                        APPEND_CHARS_SMALL(out->cur, "&#x00", 5);
                         dump_hex(c, out);
                         *out->cur++ = ';';
                     } else if ('\0' != *out->opts->inv_repl) {
@@ -464,8 +460,11 @@ inline static void dump_num(Out out, VALUE obj) {
     if (out->end - out->cur <= size) {
         grow(out, size);
     }
-    memcpy(out->cur, b, size);
-    out->cur += size;
+    if (16 < size) {
+        APPEND_CHARS(out->cur, b, size);
+    } else {
+        APPEND_CHARS_SMALL(out->cur, b, size);
+    }
     *out->cur = '\0';
 }
 
@@ -491,8 +490,11 @@ static void dump_time_thin(Out out, VALUE obj) {
     if (out->end - out->cur <= size) {
         grow(out, size);
     }
-    memcpy(out->cur, b, size);
-    out->cur += size;
+    if (16 < size) {
+        APPEND_CHARS(out->cur, b, size);
+    } else {
+        APPEND_CHARS_SMALL(out->cur, b, size);
+    }
 }
 
 static void dump_date(Out out, VALUE obj) {
@@ -511,8 +513,11 @@ static void dump_date(Out out, VALUE obj) {
     if (out->end - out->cur <= size) {
         grow(out, size);
     }
-    memcpy(out->cur, b, size);
-    out->cur += size;
+    if (16 < size) {
+        APPEND_CHARS(out->cur, b, size);
+    } else {
+        APPEND_CHARS_SMALL(out->cur, b, size);
+    }
 }
 
 static void dump_time_xsd(Out out, VALUE obj) {
@@ -1072,13 +1077,10 @@ static void dump_gen_element(VALUE obj, int depth, Out out) {
         if (do_indent) {
             fill_indent(out, indent);
         }
-        *out->cur++ = '<';
-        *out->cur++ = '/';
+        APPEND_CHARS_SMALL(out->cur, "</", 2);
         fill_value(out, name, nlen);
     } else if (out->opts->no_empty) {
-        *out->cur++ = '>';
-        *out->cur++ = '<';
-        *out->cur++ = '/';
+        APPEND_CHARS_SMALL(out->cur, "></", 3);
         fill_value(out, name, nlen);
     } else {
         *out->cur++ = '/';
@@ -1107,8 +1109,7 @@ static void dump_gen_instruct(VALUE obj, int depth, Out out) {
     if (out->end - out->cur <= (long)size) {
         grow(out, size);
     }
-    *out->cur++ = '<';
-    *out->cur++ = '?';
+    APPEND_CHARS_SMALL(out->cur, "<?", 2);
     fill_value(out, name, nlen);
     if (0 != content) {
         if (' ' != *content) {
@@ -1118,9 +1119,8 @@ static void dump_gen_instruct(VALUE obj, int depth, Out out) {
     } else if (Qnil != attrs) {
         rb_hash_foreach(attrs, dump_gen_attr, (VALUE)out);
     }
-    *out->cur++ = '?';
-    *out->cur++ = '>';
-    *out->cur   = '\0';
+    APPEND_CHARS_SMALL(out->cur, "?>", 2);
+    *out->cur = '\0';
 }
 
 static int dump_gen_nodes(VALUE obj, int depth, Out out) {
@@ -1184,8 +1184,7 @@ static int dump_gen_attr(VALUE key, VALUE value, VALUE ov) {
     }
     *out->cur++ = ' ';
     fill_value(out, ks, klen);
-    *out->cur++ = '=';
-    *out->cur++ = '"';
+    APPEND_CHARS_SMALL(out->cur, "=\"", 2);
     dump_str_value(out, StringValuePtr(value), RSTRING_LEN(value), xml_quote_chars);
     *out->cur++ = '"';
 

--- a/ext/ox/xml_str.h
+++ b/ext/ox/xml_str.h
@@ -9,6 +9,32 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin_memcpy)
+#define HAVE_FAST_MEMCPY 1
+
+inline static void fast_memcpy16(void *dest, const void *src, size_t n) {
+    char       *d = (char *)dest;
+    const char *s = (const char *)src;
+
+    if (n >= 8) {
+        __builtin_memcpy(d, s, 8);
+        __builtin_memcpy(d + n - 8, s + n - 8, 8);
+    } else if (n >= 4) {
+        __builtin_memcpy(d, s, 4);
+        __builtin_memcpy(d + n - 4, s + n - 4, 4);
+    } else if (n >= 2) {
+        __builtin_memcpy(d, s, 2);
+        __builtin_memcpy(d + n - 2, s + n - 2, 2);
+    } else if (n >= 1) {
+        *d = *s;
+    }
+}
+#endif
+
 /* Shared helpers for the serializer escape path used by both dump.c and
  * builder.c. The size scan and the escape loop both walk the source string a
  * word at a time and only fall to a byte at a time when a word contains a byte


### PR DESCRIPTION
# Port oj's fast_memcpy16 into the Ox.dump short-copy path

Ox and oj are maintained together, so this brings oj's short-copy idiom over to Ox's serializer to keep the two codebases aligned. It touches only `ext/ox/dump.c` and the shared `ext/ox/xml_str.h`. The goal is maintainability, not a speed-up.

## Why

oj copies short, length-bounded runs with `fast_memcpy16` (`ext/oj/simd.h`) through an `APPEND_CHARS_SMALL` macro (`ext/oj/dump.h`), while Ox's `dump.c` still writes the same short runs with a plain `memcpy` or a byte-at-a-time loop. That is a small but real divergence: the same "copy a short, known-length run into the output buffer" operation reads differently in the two gems, so a fix or review in one does not map cleanly onto the other. Porting the idiom removes that divergence.

`fast_memcpy16` also has a genuine reason to exist: a `memcpy(dst, src, n)` with a run-time `n` the compiler cannot bound stays a call into libc, and for the short `n` of an element name, an attribute value or a number string the call and size dispatch cost more than the copy. It collapses an `n <= 16` copy into a pair of overlapping fixed-width loads and stores (a few `mov` pairs and three branches, no call).

### Bounds

`fast_memcpy16` is correct only for `n <= 16`; a larger `n` silently drops the middle bytes because the `n >= 8` arm writes only the leading and trailing eight. Two things keep every call inside that bound:

- Constant-length runs (the tag and escape literals) are all `<= 16`, so they call `APPEND_CHARS_SMALL` directly.
- Run-time-length copies whose length can exceed 16 (`fill_value`, `fill_attr`, `dump_value`, `dump_str_value`'s clean path, and the number strings) keep an explicit `if (16 < len) APPEND_CHARS else APPEND_CHARS_SMALL` split.

`fast_memcpy16`'s read/write footprint is exactly `[ptr, ptr + n)`, the same as `memcpy`, so it needs no more destination headroom than the code already reserves via `grow`. The SWAR word loop's fixed 8-byte `memcpy` and the user-controlled margin `memcpy` are deliberately left as-is: the SWAR copies do not advance the cursor in step (the advance is conditional on the escape scan), and the margin length is unbounded.

## Performance

This is a maintainability change, so performance is only a sanity check. Output is byte-identical, and wall-clock is neutral within measurement noise on string dumps (a little faster on number-heavy dumps).

callgrind (Ruby 4.0.5, gcc, `-O3`, `Ox.dump` of an attribute-heavy document, 60 x 2000 elements) shows the short copies moving off libc:

| workload | total Ir | libc memcpy share |
|---|---|---|
| attribute-heavy dump | -2.7% | 3.9% -> 2.5% |
| text-heavy dump | +0.1% (flat) | unchanged |

Wall-clock (benchmark-ips, paired and interleaved, 95% CI) is a few percent faster on number-heavy object dumps and within noise on string dumps -- the short copies are only a few percent of dump time, so the wall-clock effect is at the noise floor:

| workload | branch vs base |
|---|---|
| number-heavy object dump | +4.2% [+2.7, +5.7] |
| attribute-heavy dump | within noise |
| text-heavy dump | within noise |

Reproducer -- run it on the base branch and on this branch and compare the i/s per case (pin a core, since the string-dump effect is at the noise floor):

```ruby
require 'ox'
require 'benchmark/ips'

NAMES = %w[row item node cell rec entry field elem]          # 3-5 B element names
ATTRS = %w[id ref key type name code kind slot]              # 2-4 B attribute names
VALS  = %w[ok true false 42 alpha beta gamma v1.2.3]         # 2-8 B short values
TEXT  = 'The quick brown fox jumps over the lazy dog. ' * 4  # > 16 B

def gen_struct(count, attrs)
  root = Ox::Element.new('root')
  count.times do |i|
    e = Ox::Element.new(NAMES[i % NAMES.size])
    attrs.times { |j| e[ATTRS[j % ATTRS.size]] = VALS[(i + j) % VALS.size] }
    e << VALS[i % VALS.size]
    root << e
  end
  Ox::Document.new << root
end

def gen_nums(count)
  Array.new(count) { |i| { 'id' => i, 'delta' => (i * 7) - 3, 'big' => i * 1_000_003 } }
end

def gen_text(count)
  root = Ox::Element.new('root')
  count.times { root << (Ox::Element.new('p') << TEXT.dup) }
  Ox::Document.new << root
end

# build each document once, then only time the dump
STRUCT5  = gen_struct(4000, 5)
STRUCT12 = gen_struct(4000, 12)
NUMS     = gen_nums(8000)
DTEXT    = gen_text(4000)

cases = {
  'dump/struct-5attr'  => -> { Ox.dump(STRUCT5, indent: 0) },
  'dump/struct-12attr' => -> { Ox.dump(STRUCT12, indent: 0) },
  'dump/nums-object'   => -> { Ox.dump(NUMS, mode: :object, indent: 0) },
  'dump/text'          => -> { Ox.dump(DTEXT, indent: 0) },
}

cases.each do |name, blk|
  rep = Benchmark.ips(quiet: true) { |x| x.config(warmup: 1, time: 2); x.report(name, &blk) }
  printf "%-20s %12.1f i/s\n", name, rep.entries.first.ips
end
```

## Verification

- **Byte-identical** output vs the base across every length 0..17 for element names, attribute names, attribute values and text, with and without escaping, over `Ox.dump` (generic + object), `Ox::Builder` and load round-trips; plus targeted checks of the `allow_invalid` / `&#x00` path, `no_empty` (`></`), instruct (`<?`/`?>`), object-mode closing tags, circular refs, and number / Date / Time serialization.
- **`fast_memcpy16` unit test**: every `n` in 0..16 x all src/dest alignment offsets vs a naive copy, plus a padded-buffer check that nothing outside `[d, d+n)` is written. Passes on gcc, clang, and `-fsanitize=address,undefined`.
- **Exact-size-buffer ASan harness** (`malloc`s dest/src to exactly `n` bytes so red-zones flank every copy): clean. A positive control that violates the `n <= 16` precondition trips ASan `heap-buffer-overflow` inside `fast_memcpy16`, confirming the guard is load-bearing.
- **valgrind memcheck** on the live extension across all workloads: zero invalid reads/writes, same signature as the base.
- `test/tests.rb` (170) and `test/sax/sax_test.rb` (94) pass; clang-format clean.

Credit: `fast_memcpy16` is ported from oj (`ext/oj/simd.h`) and `APPEND_CHARS_SMALL` from oj (`ext/oj/dump.h`), same author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
