### PR TITLE
Free the Ox.dump output buffer when a dump raises

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -1222,22 +1222,13 @@ dump_gen_val_node(VALUE obj, int depth, const char *pre, size_t plen, const char
     *out->cur = '\0';
 }
 
-static void dump_obj_to_xml(VALUE obj, Options copts, Out out) {
+// The dump traversal, run under rb_protect so the output buffer is freed even
+// when it raises (invalid character, oversized indent, deep-recursion circular
+// reference, ...). out->obj and out->opts carry everything it needs.
+static VALUE dump_obj_to_xml_body(VALUE outv) {
+    Out   out  = (Out)outv;
+    VALUE obj  = out->obj;
     VALUE clas = rb_obj_class(obj);
-
-    out->w_time     = (Yes == copts->xsd_date) ? dump_time_xsd : dump_time_thin;
-    out->buf        = ALLOC_N(char, 65336);
-    out->end        = out->buf + 65325; /* 10 less than end plus extra for possible errors */
-    out->cur        = out->buf;
-    out->circ_cache = 0;
-    out->circ_cnt   = 0;
-    out->opts       = copts;
-    out->obj        = obj;
-    *out->cur       = '\0';
-    if (Yes == copts->circular) {
-        ox_cache8_new(&out->circ_cache);
-    }
-    out->indent = copts->indent;
 
     if (ox_document_clas == clas) {
         dump_gen_doc(obj, -1, out);
@@ -1259,8 +1250,38 @@ static void dump_obj_to_xml(VALUE obj, Options copts, Out out) {
     if (0 <= out->indent) {
         dump_value(out, "\n", 1);
     }
+    return Qnil;
+}
+
+static void dump_obj_to_xml(VALUE obj, Options copts, Out out) {
+    int state = 0;
+
+    out->w_time     = (Yes == copts->xsd_date) ? dump_time_xsd : dump_time_thin;
+    out->buf        = ALLOC_N(char, 65336);
+    out->end        = out->buf + 65325; /* 10 less than end plus extra for possible errors */
+    out->cur        = out->buf;
+    out->circ_cache = 0;
+    out->circ_cnt   = 0;
+    out->opts       = copts;
+    out->obj        = obj;
+    *out->cur       = '\0';
+    if (Yes == copts->circular) {
+        ox_cache8_new(&out->circ_cache);
+    }
+    out->indent = copts->indent;
+
+    // Run the traversal under rb_protect. On the normal path out->buf is handed
+    // back to the caller; on a raise the longjmp would otherwise skip the free,
+    // so release the buffer (and the circular cache) here before re-raising.
+    rb_protect(dump_obj_to_xml_body, (VALUE)out, &state);
+
     if (Yes == copts->circular) {
         ox_cache8_delete(out->circ_cache);
+    }
+    if (0 != state) {
+        xfree(out->buf);
+        out->buf = NULL;
+        rb_jump_tag(state);
     }
 }
 
@@ -1279,10 +1300,14 @@ void ox_write_obj_to_file(VALUE obj, const char *path, Options copts) {
     dump_obj_to_xml(obj, copts, &out);
     size = out.cur - out.buf;
     if (0 == (f = fopen(path, "w"))) {
+        xfree(out.buf);
         rb_raise(rb_eIOError, "%s\n", strerror(errno));
     }
     if (size != fwrite(out.buf, 1, size, f)) {
         int err = ferror(f);
+
+        fclose(f);
+        xfree(out.buf);
         rb_raise(rb_eIOError, "Write failed. [%d:%s]\n", err, strerror(err));
     }
     xfree(out.buf);

--- a/test/dump_raise_test.rb
+++ b/test/dump_raise_test.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: Ox.dump output buffer leak on the dump-side raise paths.
+#
+# dump_obj_to_xml() allocates out->buf with ALLOC_N and the caller frees it only
+# on the normal return. Before the fix, any rb_raise during the traversal (an
+# invalid character, an oversized :indent, or the deep-recursion SystemStackError
+# from a circular reference) longjmped past that free and leaked the whole buffer
+# (plus any grow() reallocations).
+#
+# The leak itself is caught by Valgrind memcheck (rake test:valgrind). This file
+# is the plain-Ruby guard for the same fix: every dump-side raise must still raise
+# the right error, and -- the part that would break if the cleanup were wrong --
+# ox must remain in a healthy state afterward, so a normal dump right after a
+# raise still produces correct output.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class DumpRaiseTest < ::Test::Unit::TestCase
+  def test_invalid_character_still_raises_and_recovers
+    100.times do
+      assert_raise(Ox::SyntaxError) { Ox.dump("bad\x19char") }
+    end
+    # The buffer cleanup must leave ox able to dump normally afterward.
+    assert_equal('ok', Ox.load(Ox.dump('ok', mode: :object), mode: :object))
+  end
+
+  def test_oversized_indent_still_raises_and_recovers
+    100.times do
+      assert_raise(Ox::ParseError) { Ox.dump([1], indent: 10_000_000) }
+    end
+    assert_equal([1, 2], Ox.load(Ox.dump([1, 2], mode: :object, indent: 2), mode: :object))
+  end
+
+  def test_circular_reference_still_raises_and_recovers
+    10.times do
+      a = []
+      a << a
+      assert_raise(SystemStackError) { Ox.dump(a, mode: :object) }
+    end
+    # circular: true is the supported path and must still succeed.
+    a = []
+    a << a
+    assert_nothing_raised { Ox.dump(a, mode: :object, circular: true) }
+  end
+
+  # Interleave dump-side raises with a forced GC and normal dumps. A buffer that
+  # was freed twice, or left dangling, would surface here as a crash.
+  def test_raise_then_gc_then_dump
+    sink = []
+    200.times do |i|
+      begin
+        Ox.dump("x\x19#{i}")
+      rescue Ox::SyntaxError
+        # expected
+      end
+      GC.start(full_mark: true, immediate_sweep: true)
+      sink << Ox.load(Ox.dump({ 'i' => i }, mode: :object), mode: :object)
+    end
+    assert_equal(200, sink.size)
+    assert_equal({ 'i' => 199 }, sink.last)
+  end
+end


### PR DESCRIPTION
# Free the Ox.dump output buffer when a dump raises

## Summary

`Ox.dump` leaks its entire output buffer whenever the dump raises. `dump_obj_to_xml` (`ext/ox/dump.c`) allocates the buffer with `out->buf = ALLOC_N(char, 65336)` (plus any `grow()` reallocations as the output grows), and the caller `dump()` (`ext/ox/ox.c`) frees it with `xfree()` **only on the normal return**. Any `rb_raise` during the traversal `longjmp`s past that free, leaking the buffer on every raised dump.

Triggering inputs, all reachable from a plain `Ox.dump` call:

- an invalid control character in a string → `Ox::SyntaxError`
- an oversized `:indent` → `Ox::ParseError`
- a circular reference without `circular: true` → `SystemStackError` (deep recursion; the leaked block includes the `grow()` reallocations)

## Reproduction

Every trigger is a plain `Ox.dump` call that raises; the raise `longjmp`s past the `xfree`, so the 65,336-byte buffer (plus any `grow()` reallocations) is leaked once per call. The script below hammers each trigger and prints the process RSS before/after — no Valgrind required.

```ruby
require 'ox'

def rss_kb
  File.read("/proc/#{Process.pid}/status")[/VmRSS:\s+(\d+)/, 1].to_i
end

N = 2000
circ = []
circ << circ

triggers = {
  'invalid char (Ox::SyntaxError)'    => -> { Ox.dump("bad\x19char") },
  'oversized indent (Ox::ParseError)' => -> { Ox.dump([1], indent: 10_000_000) },
  'circular ref (SystemStackError)'   => -> { Ox.dump(circ, mode: :object) },
}

triggers.each do |label, blk|
  GC.start
  before = rss_kb
  N.times { begin; blk.call; rescue Exception; end }
  GC.start
  after = rss_kb
  printf("%-34s N=%d  RSS %d -> %d KB  (+%d KB)\n", label, N, before, after, after - before)
end
```

Output on `develop` (leaking) — RSS grows unbounded, and the circular case nearly exhausts memory because `grow()` keeps reallocating the leaked buffer as the recursion deepens:

```
invalid char (Ox::SyntaxError)     N=2000  RSS 18248 -> 26372 KB     (+8124 KB)
oversized indent (Ox::ParseError)  N=2000  RSS 26372 -> 26940 KB     (+568 KB)
circular ref (SystemStackError)    N=2000  RSS 26940 -> 1995324 KB   (+1968384 KB)   # ~1.9 GB
```

(RSS under-counts the string/indent cases because only the first few pages of each 65,336-byte buffer are touched before the raise; Valgrind, which counts the whole allocation, reports one 65,336-byte *definitely lost* block per call regardless.)

Confirming with Valgrind memcheck via [`ruby_memcheck`](https://github.com/Shopify/ruby_memcheck):

```
$ ruby_memcheck -Ilib -Iext repro.rb
...
32,668,000 bytes in 500 blocks are definitely lost in loss record 157 of 157
   *dump_obj_to_xml (dump.c:1229)
   *ox_write_obj_to_str (dump.c:1270)
   *dump (ox.c:1357)
```

The same leak is reachable via `Ox.to_file` on the two `rb_raise(rb_eIOError, ...)` paths in `ox_write_obj_to_file` (`fopen`/`fwrite` failure), which also leak the already-built buffer — and the `fwrite` path leaks the open `FILE *` as well.

## Notes

- This is a focused memory fix; it does not touch the parse/load/SAX/Builder paths, which were checked under the same memcheck net and reported no leaks.
