### PR TITLE
Add ruby_memcheck (Valgrind memcheck) integration as rake test:valgrind

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ group :development do
   gem 'rake-compiler', '>= 1.2', '< 2.0'
   gem 'rubocop', '~> 1.47', require: false
   gem 'test-unit', '~> 3.0'
+  gem 'ruby_memcheck', '~> 3.0' if RUBY_PLATFORM.include?('linux') && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
 end

--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,49 @@ Rake::ExtensionTask.new('ox') do |ext|
   ext.lib_dir = 'lib/ox'
 end
 
+if RUBY_PLATFORM.include?('linux')
+  begin
+    require 'ruby_memcheck'
+
+    RubyMemcheck.config(
+      binary_name: 'ox',
+      # Valgrind and YJIT interfere with each other, adding noise and slowdown,
+      # so keep YJIT disabled while running under Valgrind.
+      ruby: "#{FileUtils::RUBY} --disable-yjit"
+    )
+
+    # Every *_test.rb in test/, plus tests.rb (which does not match that glob).
+    # Excluded: cache_test.rb / cache8_test.rb call Ox.cache_test / Ox.cache8_test,
+    # C self-tests only compiled into a debug build; smart_test.rb runs
+    # opts.parse(ARGV) at load and exits on the test runner's -v flag. The two
+    # fork-based tests in tests.rb are skipped under Valgrind via OX_SKIP_FORK_TESTS
+    # (a forked child stays under Valgrind and only adds noise).
+    memcheck_test_files =
+      FileList['test/**/*_test.rb']
+      .exclude('test/cache_test.rb', 'test/cache8_test.rb', 'test/sax/smart_test.rb') + ['test/tests.rb']
+
+    namespace :test do
+      desc 'Fail early with a clear message when Valgrind is not installed'
+      task :check_valgrind do
+        unless system('command -v valgrind > /dev/null 2>&1')
+          abort("\nValgrind is required for `rake test:valgrind` but was not found.\n" \
+                "Install it first (Linux only), e.g. `sudo apt-get install valgrind`.\n")
+        end
+        # Inherited by the Ruby child that Valgrind traces; see the note above.
+        ENV['OX_SKIP_FORK_TESTS'] = '1'
+      end
+
+      RubyMemcheck::TestTask.new(valgrind: [:check_valgrind, :compile]) do |t|
+        t.test_files = memcheck_test_files
+        t.verbose    = true
+      end
+    end
+  rescue LoadError
+    # ruby_memcheck is an optional, Linux-only development dependency. If it is
+    # not installed just skip defining the task instead of breaking the Rakefile.
+  end
+end
+
 def run(command)
   if ENV['OX_ASAN']
     @ld_preload ||= `gcc -print-file-name=libasan.so`.strip

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -1709,6 +1709,9 @@ comment -->
 
   def test_builder_io
     omit 'needs fork' unless Process.respond_to?(:fork)
+    # A forked child stays under Valgrind and only adds noise there; the
+    # ruby_memcheck task (rake test:valgrind) sets this to skip these two tests.
+    omit 'skipped under Valgrind' if ENV['OX_SKIP_FORK_TESTS']
 
     IO.pipe do |r, w|
       if fork
@@ -1787,6 +1790,9 @@ comment -->
 
   def test_builder_block_io
     omit 'needs fork' unless Process.respond_to?(:fork)
+    # A forked child stays under Valgrind and only adds noise there; the
+    # ruby_memcheck task (rake test:valgrind) sets this to skip these two tests.
+    omit 'skipped under Valgrind' if ENV['OX_SKIP_FORK_TESTS']
 
     IO.pipe do |r, w|
       if fork


### PR DESCRIPTION
## Summary

This wires up [Shopify's `ruby_memcheck`](https://github.com/Shopify/ruby_memcheck) so the C extension's test suite can be run under Valgrind's memcheck to catch memory leaks and errors. The integration mirrors the setup already used in the sister gem `oj` and follows the reference integration in [rmagick#1716](https://github.com/rmagick/rmagick/pull/1716): the same `rake test:valgrind` entry point, the same "fail early if Valgrind is missing" guard, and the same YJIT-disabled configuration.

`ruby_memcheck` exists because plain Valgrind is unusable on Ruby: the interpreter intentionally does not free everything at shutdown, so Valgrind reports thousands of false positives. `ruby_memcheck` runs Valgrind with `--xml`, then filters with heuristics so that only errors whose stack trace passes through the extension's own binary are reported. It is used in production by `nokogiri`, `liquid-c`, `re2`, `protobuf`, `grpc`, and others, and has a solid track record of finding real leaks (e.g. 5 in nokogiri, 8 in re2).

## What is included

- **`rake test:valgrind`** (Rakefile) — a `RubyMemcheck::TestTask` over the test suite, with a `test:check_valgrind` prerequisite that aborts with a clear message when Valgrind is not installed. Configured with `binary_name: 'ox'` and `--disable-yjit` (Valgrind and YJIT interfere).
- **`ruby_memcheck` dev dependency** (Gemfile) — Linux-only and guarded on `RUBY_PLATFORM`, because Valgrind is not usable in practice on macOS/Windows; the whole Rakefile block is likewise guarded and wrapped in `rescue LoadError`, so `bundle install` and the Rakefile keep working everywhere.

No C code is changed. A companion PR adds the CI workflow that runs this task.

### Which tests run under memcheck

The task runs `FileList['test/**/*_test.rb'] + ['test/tests.rb']` (the main suite `tests.rb` does not match the `*_test.rb` glob, so it is added explicitly), minus three files that cannot run in the shared, single-process, `-v` test loader:

- `test/cache_test.rb` / `test/cache8_test.rb` call `Ox.cache_test` / `Ox.cache8_test`, C self-tests only compiled into a debug build (they raise `NoMethodError` in a normal build).
- `test/sax/smart_test.rb` runs `opts.parse(ARGV)` at load time and exits on the test runner's `-v` flag.

`tests.rb` has two fork-based tests (`test_builder_io` / `test_builder_block_io`); a forked child stays under Valgrind and only adds noise and slowdown, so they are skipped there via `OX_SKIP_FORK_TESTS`, which `check_valgrind` exports and the two tests honor. Nothing changes for a normal `rake` run.

Running the whole suite (rather than a bespoke leak-test file) keeps coverage broad and self-maintaining: any new `*_test.rb` is picked up automatically. This matters for the raise paths in particular — a `longjmp` out of the extension is structurally prone to leaking, and ox has had real bugs there (#420 fixed a dangling stack `PInfo` GC wrapper and a skipped `rb_gc_enable` on the object-mode callback-raise path). memcheck reports even a single leaked block whose trace passes through the binary, so the existing raise-path tests (`tests.rb`, `dump_indent_test.rb`, `objload_classname_test.rb`, `sax_io_overflow_test.rb`, `dump_raise_test.rb`) are sufficient to exercise them — no amplification file is needed.

## Limitations of this tool (important)

This is a **complement to, not a replacement for, ASan-based harnesses**:

- **Zero reports ≠ zero problems.** By design, `ruby_memcheck` only surfaces errors whose stack trace passes through the extension binary, only *definite* leaks (not *possible* leaks), and nothing in `Init` or in memory that Ruby allocated. A clean run means "none of the covered paths leaked in a way the heuristics can attribute to ox," not "ox is leak-free." Coverage is bounded by the test suite.
- **memcheck is blind to overflows contained within a stack buffer.** The earlier H2-class finding (an object-mode class name overrunning a fixed `char[1024]` on the stack) is exactly the kind of bug memcheck does **not** catch — it detects heap errors and heap/leak issues, not writes that stay inside a stack frame. Stack-buffer overflows still need ASan / stack canaries.

## Notes

- No C code is changed in this PR.
- `Gemfile.lock` is git-ignored in this repo, so only the `Gemfile` dependency entry is committed.
