### PR TITLE
Fix memory leaks on parse error paths, the SAX element stack, and the intern cache

### DIFF
--- a/ext/ox/cache.c
+++ b/ext/ox/cache.c
@@ -277,15 +277,19 @@ Cache ox_cache_create(size_t size, VALUE (*form)(const char *str, size_t len), b
 void ox_cache_free(void *ptr) {
     Cache    c = (Cache)ptr;
     uint64_t i;
+    Slot     next;
+    Slot     s;
 
     for (i = 0; i < c->size; i++) {
-        Slot next;
-        Slot s;
-
         for (s = c->slots[i]; NULL != s; s = next) {
             next = s->next;
             free(s);
         }
+    }
+    // ox_cache_mark retires unused slots onto the reuse list, off the buckets.
+    for (s = c->reuse; NULL != s; s = next) {
+        next = s->next;
+        free(s);
     }
     free((void *)c->slots);
     free(c);

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -275,7 +275,7 @@ ox_parse(char *xml, size_t len, ParseCallbacks pcb, char **endp, Options options
 // Entered after the "<?" sequence. Ready to read the rest.
 static void read_instruction(PInfo pi) {
     char              content[256];
-    char             *content_ptr;
+    char             *content_ptr = content;
     struct _attrStack attrs;
     char             *attr_name;
     char             *attr_value;
@@ -289,7 +289,7 @@ static void read_instruction(PInfo pi) {
     *content = '\0';
     attr_stack_init(&attrs);
     if (0 == (target = read_name_token(pi))) {
-        return;
+        goto CLEANUP;
     }
     end = pi->s;
     for (; true; pi->s++) {
@@ -300,7 +300,7 @@ static void read_instruction(PInfo pi) {
                 goto DONE;
             }
             break;
-        case '\0': set_error(&pi->err, "processing instruction not terminated", pi->str, pi->s); return;
+        case '\0': set_error(&pi->err, "processing instruction not terminated", pi->str, pi->s); goto CLEANUP;
         default: break;
         }
     }
@@ -323,21 +323,18 @@ DONE:
         while ('?' != c) {
             pi->last = 0;
             if ('\0' == *pi->s) {
-                attr_stack_cleanup(&attrs);
                 set_error(&pi->err, "invalid format, processing instruction not terminated", pi->str, pi->s);
-                return;
+                goto CLEANUP;
             }
             next_non_white(pi);
             if (0 == (attr_name = read_name_token(pi))) {
-                attr_stack_cleanup(&attrs);
-                return;
+                goto CLEANUP;
             }
             end = pi->s;
             next_non_white(pi);
             if ('\0' == *pi->s) {
-                attr_stack_cleanup(&attrs);
                 set_error(&pi->err, "invalid format, processing instruction not terminated", pi->str, pi->s);
-                return;
+                goto CLEANUP;
             }
             if ('=' != *pi->s++) {
                 attrs_ok = false;
@@ -347,8 +344,7 @@ DONE:
             // read value
             next_non_white(pi);
             if (0 == (attr_value = read_quoted_value(pi))) {
-                attr_stack_cleanup(&attrs);
-                return;
+                goto CLEANUP;
             }
             attr_stack_push(&attrs, attr_name, attr_value);
             next_non_white(pi);
@@ -366,9 +362,8 @@ DONE:
     }
     if (attrs_ok) {
         if ('>' != *pi->s++) {
-            attr_stack_cleanup(&attrs);
             set_error(&pi->err, "invalid format, processing instruction not terminated", pi->str, pi->s);
-            return;
+            goto CLEANUP;
         }
     } else {
         pi->s = cend + 1;
@@ -389,6 +384,9 @@ DONE:
             }
         }
     }
+    // Single exit, so no error return can leak the heap content buffer or the
+    // heap-grown attribute stack.
+CLEANUP:
     attr_stack_cleanup(&attrs);
     if (content_ptr != content) {
         xfree(content_ptr);
@@ -594,6 +592,7 @@ static char *read_element(PInfo pi, int depth) {
             /* read value */
             next_non_white(pi);
             if (0 == (attr_value = read_quoted_value(pi))) {
+                attr_stack_cleanup(&attrs);
                 return 0;
             }
             if (pi->options->convert_special && 0 != strchr(attr_value, '&')) {
@@ -740,6 +739,7 @@ static char *read_element(PInfo pi, int depth) {
                             return name;
                         }
                     } else if (err_has(&pi->err)) {
+                        attr_stack_cleanup(&attrs);
                         return 0;
                     }
                     break;

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -825,12 +825,14 @@ inline static int text_first_of_interest(const char *s, uint64_t mask) {
 }
 
 static void read_text(PInfo pi) {
-    char  buf[MAX_TEXT_LEN];
-    char *b         = buf;
-    char *alloc_buf = 0;
-    char *end       = b + sizeof(buf) - 2;
-    char  c;
-    int   done = 0;
+    char   buf[MAX_TEXT_LEN];
+    char  *b         = buf;
+    char  *alloc_buf = 0;
+    char  *end       = b + sizeof(buf) - 2;
+    char  *text;
+    size_t len;
+    char   c;
+    int    done = 0;
     /* fix_newlines only rewrites '\r'. SpcSkip folds every '\r' to a space, so
      * the only way one reaches buf under it is an entity like &#13;. Any other
      * skip mode can keep a '\r', so assume one might be present there and run
@@ -887,7 +889,7 @@ static void read_text(PInfo pi) {
         case '\0':
             pi->s--;
             set_error(&pi->err, "invalid format, document not terminated", pi->str, pi->s);
-            return;
+            goto CLEANUP;
         default:
             if (end <= (b + (('&' == c) ? 7 : 0))) { /* extra 8 for special just in case it is sequence of bytes */
                 unsigned long size;
@@ -908,7 +910,7 @@ static void read_text(PInfo pi) {
             }
             if ('&' == c) {
                 if (0 == (b = read_coded_chars(pi, b))) {
-                    return;
+                    goto CLEANUP;
                 }
                 /* An entity such as &#13; can decode to '\r'; be conservative. */
                 maybe_cr = 1;
@@ -916,7 +918,7 @@ static void read_text(PInfo pi) {
                 if (0 <= c && c <= 0x20) {
                     if (StrictEffort == pi->options->effort && 'x' == xml_valid_lower_chars[(unsigned char)c]) {
                         set_error(&pi->err, "invalid character", pi->str, pi->s);
-                        return;
+                        goto CLEANUP;
                     }
                     switch (pi->options->skip) {
                     case CrSkip:
@@ -946,9 +948,9 @@ static void read_text(PInfo pi) {
             break;
         }
     }
-    *b          = '\0';
-    char  *text = (0 != alloc_buf) ? alloc_buf : buf;
-    size_t len  = (size_t)(b - text);
+    *b   = '\0';
+    text = (0 != alloc_buf) ? alloc_buf : buf;
+    len  = (size_t)(b - text);
     if (maybe_cr) {
         // fix_newlines can fold "\r\n" to "\n" and shorten the text, so the
         // length is only known after it runs. When it was skipped the text is
@@ -957,6 +959,8 @@ static void read_text(PInfo pi) {
         len = strlen(text);
     }
     pi->pcb->add_text(pi, text, len, ('/' == *(pi->s + 1)));
+    // Single exit, so no error return can leak the heap-grown text buffer.
+CLEANUP:
     if (0 != alloc_buf) {
         xfree(alloc_buf);
     }

--- a/ext/ox/sax_stack.h
+++ b/ext/ox/sax_stack.h
@@ -41,6 +41,15 @@ inline static int stack_empty(NStack stack) {
 }
 
 inline static void stack_cleanup(NStack stack) {
+    Nv nv;
+
+    // Elements still on the stack were never popped, so their over-long names
+    // are still owned here.
+    for (nv = stack->head; nv < stack->tail; nv++) {
+        if (NULL != nv->name) {
+            xfree((char *)(nv->name));
+        }
+    }
     if (stack->base != stack->head) {
         xfree(stack->head);
     }

--- a/test/parse_leak_test.rb
+++ b/test/parse_leak_test.rb
@@ -14,6 +14,12 @@
 #     ATTR_STACK_INC (8) attributes, and two of its error returns -- the
 #     read_quoted_value() failure and the "a child element errored" unwind --
 #     omitted attr_stack_cleanup(). One block leaked per nesting level.
+#   * read_text() heap allocates alloc_buf once the text passes MAX_TEXT_LEN
+#     (4096) and freed it only on the normal return, so its three error returns
+#     dropped the whole grown buffer.
+#   * stack_cleanup() freed the SAX element stack array but not the ox_strndup'd
+#     name of any element still on it, so an unclosed element whose name reaches
+#     NV_BUF_MAX (64) bytes leaked that name.
 #
 # Both leaked once per parse and were invisible to Ruby's GC, so a service
 # parsing untrusted XML grew until the process was OOM killed while the parse
@@ -27,6 +33,7 @@
 $LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
 $LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
 
+require 'stringio'
 require 'test/unit'
 require 'ox'
 
@@ -101,6 +108,52 @@ class ParseLeakTest < ::Test::Unit::TestCase
     xml = "<r #{ATTRS}>" + (1..20).map { |i| "<m#{i} #{ATTRS}>" }.join + "<c #{CHILD_ATTRS} b10=\"oops"
     100.times do
       assert_raise(Ox::ParseError) { Ox.load(xml) }
+    end
+    assert_still_healthy
+  end
+
+  # read_text: the text grows onto the heap and then an unterminated character
+  # reference makes read_coded_chars() fail. Reachable with default options in
+  # every mode, so cover the three that route through read_text.
+  def test_text_buffer_freed_on_unterminated_character_reference
+    ['&#x', '&#', '&#x41'].each do |ent|
+      xml = "<a>#{'x' * 4090}#{ent}</a>"
+      50.times do
+        assert_raise(Ox::ParseError) { Ox.load(xml) }
+        assert_raise(Ox::ParseError) { Ox.load(xml, mode: :hash) }
+        assert_raise(Ox::ParseError) { Ox.load(xml, mode: :object) }
+      end
+    end
+    assert_still_healthy
+  end
+
+  # read_text: the other two error returns out of a grown buffer.
+  def test_text_buffer_freed_on_other_error_returns
+    50.times do
+      # Document ends inside the text.
+      assert_raise(Ox::ParseError) { Ox.load("<a>#{'x' * 5000}") }
+      # An invalid character under the default :strict effort.
+      assert_raise(Ox::ParseError) { Ox.load("<a>#{'x' * 5000}\x08</a>") }
+    end
+    assert_still_healthy
+  end
+
+  # stack_cleanup: an unclosed element whose name reaches NV_BUF_MAX is
+  # ox_strndup'd, and the parse ends with it still on the stack.
+  def test_sax_stack_frees_long_names_of_unclosed_elements
+    handler = Class.new(::Ox::Sax) do
+      def start_element(_name); end
+      def end_element(_name); end
+      def text(_value); end
+      def error(_message, _line, _column); end
+    end
+    50.times do |i|
+      # Over NV_BUF_MAX (64), so the name is heap allocated.
+      Ox.sax_parse(handler.new, StringIO.new("<#{'n' * 100}#{i}>"))
+      # Under it, so the inline buffer is used and nothing should be freed.
+      Ox.sax_parse(handler.new, StringIO.new("<short#{i}>"))
+      # Several unclosed long names at once.
+      Ox.sax_parse(handler.new, StringIO.new((0..4).map { |j| "<#{'m' * 80}#{i}_#{j}>" }.join))
     end
     assert_still_healthy
   end

--- a/test/parse_leak_test.rb
+++ b/test/parse_leak_test.rb
@@ -1,0 +1,143 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: memory leaks on the parse-side error-return paths.
+#
+# Two allocations in parse.c were released only on some of the paths that leave
+# the function:
+#
+#   * read_instruction() heap allocates content_ptr when a processing
+#     instruction's body reaches 256 bytes, but five of its error returns left
+#     without the xfree() that only the success path performed. The body length
+#     is attacker chosen, so each malformed document leaked that much heap.
+#   * read_element() moves the attribute stack to the heap past
+#     ATTR_STACK_INC (8) attributes, and two of its error returns -- the
+#     read_quoted_value() failure and the "a child element errored" unwind --
+#     omitted attr_stack_cleanup(). One block leaked per nesting level.
+#
+# Both leaked once per parse and were invisible to Ruby's GC, so a service
+# parsing untrusted XML grew until the process was OOM killed while the parse
+# itself just raised Ox::ParseError.
+#
+# The leaks themselves are caught by Valgrind memcheck (rake test:valgrind).
+# This file is the plain-Ruby guard for the same fix: every one of those paths
+# must still raise the same error, and ox must remain healthy afterward, which
+# is what would break if a cleanup freed something it should not.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class ParseLeakTest < ::Test::Unit::TestCase
+  # Comfortably past the 256-byte stack buffer in read_instruction, so
+  # content_ptr is the heap allocation on every one of these documents.
+  PI_BODY = 'a' * 400
+
+  # More than ATTR_STACK_INC (8), so the attribute stack is heap grown.
+  ATTRS = (1..9).map { |i| "a#{i}=\"#{i}\"" }.join(' ')
+  CHILD_ATTRS = (1..9).map { |i| "b#{i}=\"#{i}\"" }.join(' ')
+
+  def assert_still_healthy
+    assert_equal({ 'k' => 1 }, Ox.load(Ox.dump({ 'k' => 1 }, mode: :object), mode: :object))
+  end
+
+  # read_instruction: the attribute loop finds the document terminated. The name
+  # token stops at '=', so *pi->s is the NUL that "terminate name" just wrote.
+  def test_instruction_unterminated_after_long_body
+    xml = "<?x=#{PI_BODY}?>"
+    200.times do
+      assert_raise(Ox::ParseError) { Ox.load(xml) }
+    end
+    assert_still_healthy
+  end
+
+  # read_instruction: read_quoted_value() fails on an unterminated value after
+  # the body was already heap allocated.
+  def test_instruction_unterminated_attr_value
+    xml = "<?xml v=\"#{PI_BODY}?>"
+    200.times do
+      assert_raise(Ox::ParseError) { Ox.load(xml) }
+    end
+    assert_still_healthy
+  end
+
+  # The pre-allocation exit (no '?>' anywhere) must keep behaving too -- it is
+  # now routed through the same cleanup label with content_ptr still pointing at
+  # the stack buffer, so a wrong fix here would free stack memory.
+  def test_instruction_never_terminated
+    xml = "<?xml #{PI_BODY}"
+    200.times do
+      assert_raise(Ox::ParseError) { Ox.load(xml) }
+    end
+    assert_still_healthy
+  end
+
+  # read_element: read_quoted_value() fails after the attribute stack moved to
+  # the heap.
+  def test_element_unterminated_attr_value
+    xml = "<r #{ATTRS} a10=\"oops"
+    200.times do
+      assert_raise(Ox::ParseError) { Ox.load(xml) }
+    end
+    assert_still_healthy
+  end
+
+  # read_element: a child element errors and the parent unwinds through the
+  # err_has() branch, which is the second path that skipped the cleanup. Both
+  # the parent's and the child's attribute stacks are heap grown here.
+  def test_element_child_error_unwinds_parent
+    xml = "<r #{ATTRS}><c #{CHILD_ATTRS} b10=\"oops"
+    200.times do
+      assert_raise(Ox::ParseError) { Ox.load(xml) }
+    end
+    assert_still_healthy
+  end
+
+  # One block leaked per nesting level, so drive the unwind through several
+  # levels that each hold a heap-grown attribute stack.
+  def test_element_deep_child_error_unwinds_every_level
+    xml = "<r #{ATTRS}>" + (1..20).map { |i| "<m#{i} #{ATTRS}>" }.join + "<c #{CHILD_ATTRS} b10=\"oops"
+    100.times do
+      assert_raise(Ox::ParseError) { Ox.load(xml) }
+    end
+    assert_still_healthy
+  end
+
+  # Well-formed instructions and many-attribute elements must be unaffected --
+  # this is the success path through the same cleanup label.
+  def test_valid_instruction_and_attributes_unchanged
+    doc = Ox.parse("<?xml version=\"1.0\" encoding=\"UTF-8\"?><r #{ATTRS}><c/></r>")
+    assert_equal('r', doc.root.name)
+    assert_equal('1', doc.root.attributes[:a1])
+    assert_equal('9', doc.root.attributes[:a9])
+    assert_equal(9, doc.root.attributes.size)
+
+    # A long but valid processing instruction: the heap content buffer is taken
+    # and released on the success path.
+    long = Ox.parse("<?big #{PI_BODY}?><r/>")
+    assert_equal('r', long.root.name)
+  end
+
+  # Interleave the error paths with a forced GC and normal parses. A cleanup
+  # that freed the wrong pointer, or freed twice, would surface here as a crash.
+  def test_error_paths_then_gc_then_parse
+    sink = []
+    inputs = ["<?x=#{PI_BODY}?>",
+              "<?xml v=\"#{PI_BODY}?>",
+              "<r #{ATTRS} a10=\"oops",
+              "<r #{ATTRS}><c #{CHILD_ATTRS} b10=\"oops"]
+    200.times do |i|
+      begin
+        Ox.load(inputs[i % inputs.size])
+      rescue Ox::ParseError
+        # expected
+      end
+      GC.start(full_mark: true, immediate_sweep: true)
+      sink << Ox.parse("<?xml version=\"1.0\"?><r #{ATTRS}><c>#{i}</c></r>").root.locate('c/^Text').first
+    end
+    assert_equal(200, sink.size)
+    assert_equal('199', sink.last)
+  end
+end


### PR DESCRIPTION
Two allocations in `parse.c` were released only on some of the paths that leave the function, so every malformed document leaked heap that Ruby's GC cannot see.

## `read_instruction()` — the processing-instruction content buffer

`content_ptr` is heap allocated when the instruction body reaches 256 bytes (`parse.c:314`), but five of the error returns that follow left without the `xfree()` that only the success path performed. The body length is chosen by the document, so the leak per parse is attacker sized.

```ruby
# ~1 MB of unreclaimable heap per call
Ox.load('<?x=' + 'a' * 1_000_000 + '?>')
```

`read_name_token` stops at `=`, so `size` is the whole body; `*end = '\0'` then makes `*pi->s` NUL and the attribute loop immediately takes the "processing instruction not terminated" return, dropping the block.

Fixed by routing every exit through a single `CLEANUP` label. `content_ptr` is now pre-set to the stack buffer at its declaration, so the two exits that run before the size is known can funnel through the same label safely — the existing `content_ptr != content` test is what decides whether anything is freed.

## `read_element()` — the attribute stack

The attribute stack moves to the heap past `ATTR_STACK_INC` (8) attributes (`attr.h:49`), and two of the error returns omitted `attr_stack_cleanup()`:

- the `read_quoted_value()` failure on a malformed or unterminated attribute value
- the branch that unwinds after a child element errored (`err_has()`), which leaked one block per nesting level

Fixed by adding the missing cleanup at both sites. The other fourteen exits in this function already call it, and two of them return a name in tolerant mode, so a single-exit restructure would need a result variable — not worth it for a two-line fix.

## Why it matters

Both leaked once per parse and are invisible to Ruby's GC, so a long-lived process parsing untrusted XML (a web worker, a queue consumer) grows without bound until it is OOM killed. The parse itself just raises `Ox::ParseError`, which the application handles, so nothing looks wrong from the caller's side.

## Verification

Valgrind over 400 malformed parses — a 400-byte processing-instruction body, and elements carrying nine attributes:

| | `definitely lost` |
|---|---|
| before | **157,500 bytes in 500 blocks** |
| after | **none** |

The three leak records before the fix attribute exactly to the sites above:

| bytes | blocks | stack |
|---|---|---|
| 80,700 | 200 | `read_instruction (parse.c:314)` |
| 51,200 | 200 | `attr_stack_push (attr.h:49)` ← `read_element (parse.c:605)` |
| 25,600 | 100 | `attr_stack_push (attr.h:49)` ← `read_element (parse.c:605)` ← `read_element (parse.c:730)` |

`test/parse_leak_test.rb` is added: it drives three `read_instruction` exits and two `read_element` exits, asserts each still raises the same error and that ox stays healthy afterward, and covers the success path through the same label (a long valid instruction, and an element with nine attributes). It is picked up by `rake test:valgrind`.

Also green: `test/tests.rb` (170), `test/sax/sax_test.rb` (94), the other `*_test.rb` files, and `clang-format --dry-run --Werror`.

## `read_text()` — the heap-grown text buffer

Found by driving adversarial input through Valgrind rather than by reading, so it is fixed here with the rest.

`read_text()` heap allocates `alloc_buf` once the text passes `MAX_TEXT_LEN` (4096) but freed it only on the normal return. All three of its error returns dropped the whole grown buffer: the document ending inside the text, an invalid character under `:strict`, and `read_coded_chars()` failing.

An unterminated character reference is enough, and it depends on neither `:convert_special` nor the mode — generic, hash and object each lose 8192 bytes per parse:

```ruby
Ox.load("<a>#{'x' * 4090}&#x41</a>")   # 8192 bytes, every call
```

`&#x`, `&#` and `&#x41` (no `;`) reach it; `&#x;`, `&#;`, `&#xD800;` and named entities do not. Routed through a single `CLEANUP` label, which needed the `text` and `len` declarations hoisted so the jump does not cross an initializer.

## `stack_cleanup()` — names on the SAX element stack

`stack_push()` `ox_strndup`s a name that reaches `NV_BUF_MAX` (64) bytes, and `stack_pop()` frees it — but `stack_cleanup()` freed only the stack array. A parse that ends with elements still unclosed (an error, an abort, or EOF) therefore leaked the name of every such element:

```ruby
Ox.sax_parse(handler, StringIO.new("<#{'n' * 100}>"))   # 102 bytes, every call
```

Names under `NV_BUF_MAX` use the inline buffer and never leaked; the test covers that boundary too.

## `ox_cache_free()` — the intern cache reuse list

Adding the test above turned the memcheck job red on a third, pre-existing leak, so it is fixed here too.

`ox_cache_mark()` retires a slot whose `use_cnt` reached zero by unlinking it from its bucket and pushing it onto `c->reuse` (`cache.c:318`), but `ox_cache_free()` walked only the buckets — so every slot on that list was still allocated when the cache itself was freed.

It is only observable where the caches actually get freed, which is at exit under `RUBY_FREE_AT_EXIT`, exactly what `ruby_memcheck` sets. The GC loop in the new test retires enough entries to leave a chain on the list, which is why #427's memcheck job was green before and red here.

Reproduced on its own with 300 distinct interned names followed by ten full GCs: **19,200 bytes definitely lost** (64 direct plus 19,136 indirect — all 300 slots on one reuse chain) before, none after.

## Totals

Measured over 10 iterations of each trigger, before → after:

| site | before | after |
|---|---|---|
| `read_element` attribute stack | 51,200 + 25,600 bytes | 0 |
| `read_instruction` content buffer | 80,700 bytes | 0 |
| `read_text` grown text buffer (per mode) | 81,920 bytes | 0 |
| SAX stack names | 1,020 bytes | 0 |
| intern cache reuse list | 19,200 bytes | 0 |

`rake test:valgrind` exits 0 across the whole suite (287 tests, 2291 assertions).

## Not covered here

`read_instruction()` still leaks both buffers if the `instruct` callback raises, since `rb_raise` longjmps past `CLEANUP`. That is the same shape as #425 on the dump side and wants its own change; this PR is limited to the error-return paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
