### PR TITLE
Use rb_range_values() to dump a Range instead of struct slots for Ruby 4.1

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -825,18 +825,19 @@ static void dump_obj(ID aid, VALUE obj, int depth, Out out) {
         }
         clas = rb_obj_class(obj);
         if (rb_cRange == clas) {
-            VALUE beg  = RSTRUCT_GET(obj, 0);
-            VALUE end  = RSTRUCT_GET(obj, 1);
-            VALUE excl = RSTRUCT_GET(obj, 2);
-            int   d2   = depth + 1;
+            VALUE beg;
+            VALUE end;
+            int   excl;
+            int   d2 = depth + 1;
 
+            rb_range_values(obj, &beg, &end, &excl);
             e.type     = RangeCode;
             e.clas.len = 5;
             e.clas.str = "Range";
             out->w_start(out, &e);
             dump_obj(ox_beg_id, beg, d2, out);
             dump_obj(ox_end_id, end, d2, out);
-            dump_obj(ox_excl_id, excl, d2, out);
+            dump_obj(ox_excl_id, excl ? Qtrue : Qfalse, d2, out);
             out->w_end(out, &e);
         } else {
             char num_buf[16];


### PR DESCRIPTION
`Ox.dump` raises on every `Range` under current Ruby head:

```
IndexError: offset 2 too large for struct(size:2)
```

On `ruby 4.1.0dev (2026-07-30T08:50:16Z master c692cc8fba)` that is four errors in `test/tests.rb` — `test_range`, `test_array_multi`, `test_hash_multi` and `test_object_multi`. Ruby head was still green on develop as of #427 (2026-07-13), so this is a new upstream change rather than a regression in ox.

## Cause

`dump_obj()` read a `Range` out of its `T_STRUCT` slots directly:

```c
VALUE beg  = RSTRUCT_GET(obj, 0);
VALUE end  = RSTRUCT_GET(obj, 1);
VALUE excl = RSTRUCT_GET(obj, 2);
```

Ruby 4.1 reduced `Range` to two slots and keeps `exclude_end?` in the object flags, so the third access is now out of range. `Range` is still a `T_STRUCT`, so the `case T_STRUCT` dispatch and the `rb_cRange == clas` test are unaffected — only the slot count changed.

## Fix

Read the three values with `rb_range_values()`, which is the supported accessor and has been public since 1.9, so it needs no version guard:

```c
rb_range_values(obj, &beg, &end, &excl);
```

`excl` comes back as an `int`, so it is passed on as `Qtrue`/`Qfalse`.

## Verification

The dumped XML is unchanged. Checked byte-identical on 3.2.11, 3.4.9, 4.0.6 and 4.1.0dev for five shapes, each round-tripping back to an equal `Range`:

| range | XML |
|---|---|
| `0..3` | `<r><i a="@beg">0</i><i a="@end">3</i><n a="@excl"/></r>` |
| `0...3` | `<r><i a="@beg">0</i><i a="@end">3</i><y a="@excl"/></r>` |
| `'a'...'f'` | `<r><s a="@beg">a</s><s a="@end">f</s><y a="@excl"/></r>` |
| `nil..5` | `<r><z a="@beg"/><i a="@end">5</i><n a="@excl"/></r>` |
| `1..nil` | `<r><i a="@beg">1</i><z a="@end"/><n a="@excl"/></r>` |

`test/tests.rb` (170 tests) and `test/sax/sax_test.rb` (94 tests) are green on 3.2.11, 3.4.9, 4.0.6 and 4.1.0dev — on head the assertion count goes from 289 to 296, since the four errors were aborting `test_range` and friends partway through. `clang-format --dry-run --Werror` is clean.

No test is added: `test_range` is the test that was failing, so it already guards this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
