### PR TITLE
Fix heap out-of-bounds read and write after the Ox::Builder depth raise

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -306,7 +306,7 @@ static void builder_free(void *ptr) {
     }
     b = (Builder)ptr;
     buf_cleanup(&b->buf);
-    for (e = b->stack, d = b->depth; 0 < d; d--, e++) {
+    for (e = b->stack, d = b->depth; 0 <= d; d--, e++) {
         if (e->name != e->buf) {
             free(e->name);
         }
@@ -623,10 +623,10 @@ static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
     }
     i_am_a_child(b, false);
     append_indent(b);
-    b->depth++;
-    if (MAX_DEPTH <= b->depth) {
+    if (MAX_DEPTH <= b->depth + 1) {
         rb_raise(ox_arg_error_class, "XML too deeply nested");
     }
+    b->depth++;
     switch (rb_type(*argv)) {
     case T_STRING:
         name = StringValuePtr(*argv);

--- a/test/builder_depth_test.rb
+++ b/test/builder_depth_test.rb
@@ -1,0 +1,118 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: Ox::Builder left an out-of-range depth after the
+# "XML too deeply nested" raise.
+#
+# builder_element() incremented b->depth before validating it and did not roll
+# the increment back when it raised, so the Builder survived with
+# b->depth == MAX_DEPTH while struct _builder only has stack[MAX_DEPTH]. Every
+# later call reached i_am_a_child() or pop(), which index &b->stack[b->depth]
+# behind only a "0 <= b->depth" guard. Each further rescued element() call
+# pushed the index another element past the end, so the writes marched
+# arbitrarily far out of the allocation and pop()/builder_free() eventually read
+# a name pointer out of adjacent memory and free()d it.
+#
+# Reusing such a builder segfaulted; under Valgrind it showed as an invalid
+# 1-byte read and two invalid 1-byte writes in i_am_a_child().
+#
+# builder_free() also stopped one element short of the deepest one, leaking the
+# strdup'd name of any element whose name did not fit the 64-byte inline buffer.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class BuilderDepthTest < ::Test::Unit::TestCase
+  MAX_DEPTH = 128
+
+  # Nesting right up to the limit must still work, so the fix cannot have moved
+  # the threshold.
+  def test_nesting_to_the_limit_is_allowed
+    b = Ox::Builder.new
+    assert_nothing_raised do
+      MAX_DEPTH.times { |i| b.element("e#{i}") }
+    end
+    xml = b.to_s
+    assert_equal(MAX_DEPTH, xml.scan(/<e\d+/).size)
+  end
+
+  def test_one_past_the_limit_raises
+    b = Ox::Builder.new
+    MAX_DEPTH.times { |i| b.element("e#{i}") }
+    assert_raise(Ox::ArgError) { b.element('too_deep') }
+  end
+
+  # The crash: rescue the raise, then keep using the same builder.
+  def test_builder_is_usable_after_a_rescued_depth_raise
+    b = Ox::Builder.new
+    (MAX_DEPTH + 1).times do |i|
+      begin
+        b.element("e#{i}")
+      rescue Ox::ArgError
+        # expected once the limit is reached
+      end
+    end
+    # Before the fix these walked past the end of the element stack.
+    assert_nothing_raised { b.text('text') }
+    assert_nothing_raised { b.close }
+  end
+
+  # Repeated rescued calls used to push the index further out on every one.
+  def test_many_rescued_depth_raises_then_reuse
+    b = Ox::Builder.new
+    300.times do |i|
+      begin
+        b.element("e#{i}")
+      rescue Ox::ArgError
+        # expected past the limit
+      end
+    end
+    assert_nothing_raised { b.text('text') }
+    assert_nothing_raised { b.close }
+    assert_operator(b.to_s.length, :>, 0)
+  end
+
+  # The same shape, but the builder is dropped and collected rather than closed,
+  # so builder_free() walks the stack instead of pop().
+  def test_gc_after_rescued_depth_raises
+    200.times do |i|
+      b = Ox::Builder.new
+      (MAX_DEPTH + 5).times do |j|
+        begin
+          b.element("e#{i}_#{j}")
+        rescue Ox::ArgError
+          # expected past the limit
+        end
+      end
+      b = nil
+    end
+    assert_nothing_raised { GC.start(full_mark: true, immediate_sweep: true) }
+  end
+
+  # builder_free()'s loop bound: names over the 64-byte inline buffer are
+  # strdup'd, and the deepest element's copy was never freed. The leak itself is
+  # caught by rake test:valgrind; this keeps the path exercised.
+  def test_dropped_builder_with_long_element_names
+    200.times do |i|
+      b = Ox::Builder.new
+      3.times { |j| b.element("#{'n' * 100}#{i}_#{j}") }
+      b = nil
+    end
+    assert_nothing_raised { GC.start(full_mark: true, immediate_sweep: true) }
+  end
+
+  # Normal use must be unchanged.
+  def test_normal_nesting_output_unchanged
+    xml = Ox::Builder.new(indent: 2) do |b|
+      b.element('top') do
+        b.element('mid', 'a' => '1') do
+          b.text('hello')
+        end
+      end
+    end
+    assert_equal(%(<top>\n  <mid a="1">hello</mid>\n</top>\n), xml)
+  end
+end


### PR DESCRIPTION
Reusing an `Ox::Builder` after a rescued "XML too deeply nested" raise segfaults.

```ruby
b = Ox::Builder.new
129.times { begin; b.element('x'); rescue Ox::ArgError; end }
b.text('after')   # [BUG] Segmentation fault
```

## Cause

`builder_element()` incremented `b->depth` *before* validating it, and did not roll the increment back when it raised:

```c
b->depth++;
if (MAX_DEPTH <= b->depth) {
    rb_raise(ox_arg_error_class, "XML too deeply nested");
}
```

So the Builder survives with `b->depth == MAX_DEPTH` while `struct _builder` only has `stack[MAX_DEPTH]`. Every later call reaches `i_am_a_child()` or `pop()`, which index `&b->stack[b->depth]` behind only a `0 <= b->depth` guard — and because each further rescued `element()` call increments again, the index marches one more element past the end every time. `pop()` and `builder_free()` then read a `name` pointer out of adjacent memory and `free()` it.

## Fix

Validate before mutating:

```c
if (MAX_DEPTH <= b->depth + 1) {
    rb_raise(ox_arg_error_class, "XML too deeply nested");
}
b->depth++;
```

The threshold is unchanged — 128 elements are still accepted and the 129th still raises `Ox::ArgError` — but `b->depth` can no longer leave the stack, which makes the existing `0 <= b->depth` guards sufficient again.

`builder_free()` had a related off-by-one: it walked the stack with `0 < d`, stopping one short of the deepest element, so the `strdup`'d name of any element whose name did not fit the 64-byte inline `buf` was never freed when a builder was collected without being closed. Changed to `0 <= d`.

## Verification

`test/builder_depth_test.rb` is added and **exits 139 (SIGSEGV) on the old code**, at the `b.text()` that follows the rescue. Under Valgrind the same input reports, all in `i_am_a_child()`:

| | location | what |
|---|---|---|
| invalid read, 1 byte | `builder.c:258` | `e->has_child` |
| invalid write, 1 byte | `builder.c:259` | `e->has_child = true` |
| invalid write, 1 byte | `builder.c:265` | `e->non_text_child = true` |

2185 Valgrind errors before the fix against 2 after (the two remaining are `set address range perms` warnings, not errors in ox).

The test covers nesting exactly to the limit, the 129th element raising, reuse after one rescued raise, 300 rescued raises followed by reuse, GC of a builder abandoned past the limit, GC of builders holding long `strdup`'d names, and that ordinary nested output is byte-for-byte unchanged.

Green on 4.0.6: `rake test:valgrind` (283 tests, exit 0), `test/tests.rb` (170), `test/sax/sax_test.rb` (94), `test/dump_raise_test.rb`, `test/dump_indent_test.rb`. `clang-format --dry-run --Werror` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
