### PR TITLE
Fix rake test_all silently skipping most of the test suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,23 @@ Rake::ExtensionTask.new('ox') do |ext|
   ext.lib_dir = 'lib/ox'
 end
 
+# test_all invokes this. Without it Rake::Task['test'] silently resolved to a
+# synthesized file task for the test/ directory, so everything below never ran.
+#
+# tests.rb and sax/sax_test.rb are excluded because test_all runs them
+# separately through run(), which adds the ASAN preload when OX_ASAN is set.
+# cache_test.rb / cache8_test.rb call Ox.cache_test / Ox.cache8_test, C
+# self-tests only compiled into a debug build, and smart_test.rb runs
+# opts.parse(ARGV) at load and exits on the test runner's -v flag.
+Rake::TestTask.new(:test) do |t|
+  t.test_files = FileList['test/**/*_test.rb']
+                 .exclude('test/cache_test.rb',
+                          'test/cache8_test.rb',
+                          'test/sax/smart_test.rb',
+                          'test/sax/sax_test.rb')
+  t.verbose = true
+end
+
 if RUBY_PLATFORM.include?('linux')
   begin
     require 'ruby_memcheck'


### PR DESCRIPTION
`test_all` does `Rake::Task['test'].invoke` (Rakefile:78), but no task named `test` is ever defined — only the `test:` namespace, and only on Linux. Rake therefore synthesized a **file task for the existing `test/` directory**, which has no actions, so the invoke was a no-op that neither ran anything nor complained:

```ruby
Rake::Task.task_defined?("test")  # => false
Rake::Task["test"].class          # => Rake::FileTask
Rake::Task["test"].actions.size   # => 0
```

## Consequence

`bundle exec rake` — the default task, and what every job on the CI matrix runs — executed only `test/tests.rb` and `test/sax/sax_test.rb`.

These never ran anywhere except the `memcheck` job, which has its own explicit file list and covers one platform and one Ruby:

- `test/dump_indent_test.rb`
- `test/dump_raise_test.rb`
- `test/objload_classname_test.rb`
- `test/sax_io_overflow_test.rb`

So the regression tests added with the fixes in #421, #425 and friends were not actually guarding those fixes on 20 of the 21 matrix cells.

## Fix

Define the task with `Rake::TestTask`, which the `require 'rake/testtask'` at the top of the file already anticipated.

`tests.rb` and `sax/sax_test.rb` stay out of the list because `test_all` runs them separately through `run()`, which adds the ASAN preload when `OX_ASAN` is set. The other three exclusions and their reasoning are copied from the memcheck list: `cache_test.rb` and `cache8_test.rb` call `Ox.cache_test` / `Ox.cache8_test`, C self-tests only compiled into a debug build, and `sax/smart_test.rb` runs `opts.parse(ARGV)` at load and exits on the test runner's `-v` flag.

## Verification

`bundle exec rake` now reports **12 more tests and 225 more assertions**, with all four previously-invisible suites named in the output, and exits 0.

The gate actually gates now: temporarily adding a failing test to a file covered by the new task produced

```
13 tests, 226 assertions, 1 failures, ...
rake aborted!
```

and a **non-zero exit**, where before the same failure would have gone completely unnoticed. (The temporary test was removed; it is not part of this change.)

`rake test:valgrind` is untouched — it keeps its own file list — and still exits 0 over 276 tests. `rake -T` shows `test` alongside `test:check_valgrind` and `test:valgrind`; a top-level task and a namespace of the same name coexist without conflict.

## On collecting several files into one process

`Rake::TestTask` loads every matching file into a single process, so it is worth saying why that is safe here.

`Ox.default_options` is process-global, but this repo's tests set it at the **top of each test method** (`Ox.default_options = $ox_object_options` and friends appear about 250 times in `tests.rb` and `sax/sax_test.rb`) rather than setting it once and relying on cleanup. Each test therefore establishes its own baseline and does not depend on what ran before it. The four files this task newly collects do not touch `Ox.default_options` at all.

Verified rather than assumed — test-unit defaults to `alphabetic` order, so repeated runs alone prove nothing:

| `TESTOPTS` | result |
|---|---|
| `--order=alphabetic` | 12 tests, 225 assertions, 0 failures |
| `--order=defined` | 12 tests, 225 assertions, 0 failures |
| `--order=random` | 12 tests, 225 assertions, 0 failures |

Worth knowing for future tests: a test that sets `Ox.default_options` and leaves it set would make the suite order-dependent, because nothing resets it between files. The existing set-at-entry convention is what keeps that from happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
