### PR TITLE
Add a 20 minute timeout to the CI and Valgrind jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ jobs:
           - windows
 
     runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 20
     continue-on-error: ${{ matrix.ruby == '3.0' || matrix.ruby == 'head'}}
     name: Ruby ${{ matrix.ruby }} (${{ matrix.os }})
     steps:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -14,6 +14,7 @@ jobs:
   valgrind:
     name: memcheck (ubuntu, ruby ${{ matrix.ruby }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

GitHub Actions defaults to a **six hour** job timeout. A test that hangs — most likely under Valgrind, where the suite runs far slower and a runaway loop is easy to miss — would sit there consuming runner time until someone cancelled it by hand.

## Change

One `timeout-minutes: 20` per job definition:

- `.github/workflows/CI.yml` — the `Build` job, which covers all 21 matrix combinations (7 Ruby × 3 OS)
- `.github/workflows/valgrind.yml` — the `valgrind` job

## Why 20 minutes

Measured against recent runs, so there is roughly a 7–10× margin before a legitimately slower suite would trip it:

| Job | Observed |
|---|---|
| Valgrind memcheck (ubuntu, Ruby 4.0) | ~2 min |
| CI, slowest cell (windows, Ruby 2.7) | ~3 min |
| CI, every other cell | under 1 min |

No step-level timeouts were added — the job-level limit is enough to bound the damage, and keeping it to a single knob per workflow avoids two numbers drifting apart as the suite grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)