### PR TITLE
Fix memory leak of the object-mode circular reference table

### DIFF
--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -32,7 +32,6 @@ static VALUE         get_class_from_attrs(Attr a, PInfo pi, VALUE base_class);
 static VALUE         classname2class(const char *name, PInfo pi, VALUE base_class);
 static unsigned long get_id_from_attrs(PInfo pi, Attr a);
 static CircArray     circ_array_new(void);
-static void          circ_array_free(CircArray ca);
 static void          circ_array_set(CircArray ca, VALUE obj, unsigned long id);
 static VALUE         circ_array_get(CircArray ca, unsigned long id);
 
@@ -253,7 +252,8 @@ static CircArray circ_array_new(void) {
     return ca;
 }
 
-static void circ_array_free(CircArray ca) {
+// Also called from ox_parse_ensure() when a parse ends before end_element().
+void ox_circ_array_free(CircArray ca) {
     if (ca->objs != ca->obj_array) {
         xfree(ca->objs);
     }
@@ -681,7 +681,7 @@ static void end_element(PInfo pi, const char *ename) {
         }
     }
     if (0 != pi->circ_array && helper_stack_empty(&pi->helpers)) {
-        circ_array_free(pi->circ_array);
+        ox_circ_array_free(pi->circ_array);
         pi->circ_array = 0;
     }
     if (DEBUG <= pi->options->trace) {

--- a/ext/ox/ox.h
+++ b/ext/ox/ox.h
@@ -159,6 +159,7 @@ struct _pInfo {
 
 extern VALUE ox_parse(char *xml, size_t len, ParseCallbacks pcb, char **endp, Options options, Err err);
 extern void  _ox_raise_error(const char *msg, const char *xml, const char *current, const char *file, int line);
+extern void  ox_circ_array_free(CircArray ca);
 
 extern void ox_sax_define(void);
 

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -232,6 +232,12 @@ static VALUE ox_parse_ensure(VALUE ctxv) {
         DATA_PTR(ctx->wrap) = NULL;
     }
     helper_stack_cleanup(&ctx->pi->helpers);
+    // end_element() only frees the circular reference table on a complete
+    // parse, so release it here for an error or a callback raising out.
+    if (0 != ctx->pi->circ_array) {
+        ox_circ_array_free(ctx->pi->circ_array);
+        ctx->pi->circ_array = 0;
+    }
     return Qnil;
 }
 

--- a/test/parse_leak_test.rb
+++ b/test/parse_leak_test.rb
@@ -20,6 +20,11 @@
 #   * stack_cleanup() freed the SAX element stack array but not the ox_strndup'd
 #     name of any element still on it, so an unclosed element whose name reaches
 #     NV_BUF_MAX (64) bytes leaked that name.
+#   * obj_load.c allocates the circular reference table when the top level
+#     element of an object mode document carries an `i` attribute, and freed it
+#     only in end_element(), when that element closes. Every parse error and
+#     every callback raise therefore dropped the table -- 8 KB, plus the grown
+#     objs array once the document has more than 1024 referenced objects.
 #
 # Both leaked once per parse and were invisible to Ruby's GC, so a service
 # parsing untrusted XML grew until the process was OOM killed while the parse
@@ -155,6 +160,61 @@ class ParseLeakTest < ::Test::Unit::TestCase
       # Several unclosed long names at once.
       Ox.sax_parse(handler.new, StringIO.new((0..4).map { |j| "<#{'m' * 80}#{i}_#{j}>" }.join))
     end
+    assert_still_healthy
+  end
+
+  # obj_load: the top level `i` attribute allocates the circular reference
+  # table, then a bad reference ends the parse before end_element() can free it.
+  def test_circ_array_freed_on_invalid_circular_reference
+    200.times do
+      assert_raise(Ox::ParseError) { Ox.parse_obj('<a i="1"><s i="2">x</s><p i="3"/></a>') }
+    end
+    assert_still_healthy
+  end
+
+  # obj_load: the document is unterminated, so the parse ends with the table
+  # still held and the helper stack not empty.
+  def test_circ_array_freed_on_unterminated_document
+    200.times do
+      assert_raise(Ox::ParseError) { Ox.parse_obj('<a i="1"><s i="2">x</s>') }
+    end
+    assert_still_healthy
+  end
+
+  # obj_load: past the table's 1024 inline slots, so objs is a second heap
+  # allocation that leaked with it. The document is deliberately long enough
+  # that its ids stay well inside the valid range.
+  def test_circ_array_freed_after_the_table_grows
+    body = (2..1100).map { |i| %(<s i="#{i}">x</s>) }.join
+    20.times do
+      assert_raise(Ox::ParseError) { Ox.parse_obj(%(<a i="1">#{body}<p i="99999"/></a>)) }
+      assert_raise(Ox::ParseError) { Ox.parse_obj(%(<a i="1">#{body})) }
+    end
+    assert_still_healthy
+  end
+
+  # obj_load: a callback raising out of the parse (rb_const_get on an undefined
+  # class under the default :strict effort) unwinds past end_element entirely.
+  def test_circ_array_freed_when_a_callback_raises
+    200.times do
+      assert_raise(NameError) do
+        Ox.parse_obj('<a i="1"><s i="2">x</s><o c="NoSuchClassXYZ"/></a>')
+      end
+    end
+    assert_still_healthy
+  end
+
+  # The success path still frees the table exactly once. A double free would
+  # surface here rather than as a leak.
+  def test_valid_circular_documents_unchanged
+    200.times do
+      a = Ox.parse_obj('<a i="1"><s i="2">x</s><p i="2"/></a>')
+      assert_same(a[0], a[1])
+    end
+    obj = { 'one' => %w[shared shared] }
+    obj['two'] = obj['one']
+    back = Ox.parse_obj(Ox.dump(obj, circular: true, indent: 2))
+    assert_same(back['one'], back['two'])
     assert_still_healthy
   end
 


### PR DESCRIPTION
`obj_load.c` allocates a `CircArray` when the top level element of an object mode document carries an `i` attribute, and frees it in `end_element()`:

```c
if (0 != pi->circ_array && helper_stack_empty(&pi->helpers)) {
    circ_array_free(pi->circ_array);
    pi->circ_array = 0;
}
```

`helper_stack_empty()` is only true once that top level element closes, so this runs on a complete parse and nowhere else. Every other exit from `ox_parse()` dropped the table: a parse error, and a callback raising out of the parse.

## Impact

The table is 8216 bytes on its own, and once a document references more than 1024 objects `circ_array_set()` moves `objs` to a second heap allocation that leaked with it. Neither is visible to Ruby's GC, so a service calling `Ox.parse_obj` or `Ox.load(mode: :object)` on untrusted XML grows by at least 8 KB per malformed document while the parse itself just raises `Ox::ParseError`.

Every one of these leaks, on the current `develop`:

```ruby
Ox.parse_obj('<a i="1"><s i="2">x</s><p i="3"/></a>')   # invalid circular reference
Ox.parse_obj('<a i="1"><s i="2">x</s>')                 # document not terminated
Ox.parse_obj('<a i="1"><s i="2">x</s><o c="NoSuchClass"/></a>')  # NameError from the callback
```

## The fix

Free the table in `ox_parse_ensure()`, which `rb_ensure()` runs on every exit from `ox_parse()`. This is the same shape as the helper stack cleanup already there.

`end_element()` still frees on the success path and clears `pi->circ_array`, so the ensure is a no-op there and nothing is freed twice. `circ_array_free()` becomes `ox_circ_array_free()` so `parse.c` can call it.

## Measurements

Measured with `rake test:valgrind` on Ruby 4.0.6, Valgrind 3.25.1.

With the five new tests in `test/parse_leak_test.rb` and the current `obj_load.c`, Valgrind reports four loss records, all in `circ_array_new()`:

| bytes | blocks |
| --- | --- |
| 20,512 (8,216 direct, 12,296 indirect) | 1 |
| 24,648 | 3 |
| 799,968 (320,424 direct, 479,544 indirect) | 39 |
| 4,904,952 | 597 |
| **5,750,080 total** | **640** |

With the fix the whole memcheck lane is clean: 299 tests, 3148 assertions, exit 0.

The new tests cover the invalid-reference error, the unterminated document, a grown table (more than the 1024 inline slots, so the second allocation is in play), and a callback raising out through `rb_ensure`. `test_valid_circular_documents_unchanged` covers the success path so a double free would show up as a crash rather than as silence.

`rake` is green, and `clang-format --dry-run --Werror ext/ox/*.c ext/ox/*.h` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
