### PR TITLE
Fix out-of-bounds heap write and read in the circular reference table

### DIFF
--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -32,7 +32,6 @@ static VALUE         get_class_from_attrs(Attr a, PInfo pi, VALUE base_class);
 static VALUE         classname2class(const char *name, PInfo pi, VALUE base_class);
 static unsigned long get_id_from_attrs(PInfo pi, Attr a);
 static CircArray     circ_array_new(void);
-static void          circ_array_free(CircArray ca);
 static void          circ_array_set(CircArray ca, VALUE obj, unsigned long id);
 static VALUE         circ_array_get(CircArray ca, unsigned long id);
 
@@ -253,7 +252,8 @@ static CircArray circ_array_new(void) {
     return ca;
 }
 
-static void circ_array_free(CircArray ca) {
+// Also called from ox_parse_ensure() when a parse ends before end_element().
+void ox_circ_array_free(CircArray ca) {
     if (ca->objs != ca->obj_array) {
         xfree(ca->objs);
     }
@@ -681,7 +681,7 @@ static void end_element(PInfo pi, const char *ename) {
         }
     }
     if (0 != pi->circ_array && helper_stack_empty(&pi->helpers)) {
-        circ_array_free(pi->circ_array);
+        ox_circ_array_free(pi->circ_array);
         pi->circ_array = 0;
     }
     if (DEBUG <= pi->options->trace) {

--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -219,16 +219,25 @@ static VALUE get_class_from_attrs(Attr a, PInfo pi, VALUE base_class) {
     return Qundef;
 }
 
+// The id indexes the circular reference table, which is grown to fit it, so an
+// unbounded id is an unbounded heap write. Cap it at the document length: every
+// referenced object needs at least one element, so no valid id can exceed it.
 static unsigned long get_id_from_attrs(PInfo pi, Attr a) {
     for (; 0 != a->name; a++) {
         if ('i' == *a->name && '\0' == *(a->name + 1)) {
-            unsigned long id   = 0;
-            const char   *text = a->value;
-            char          c;
+            unsigned long       id    = 0;
+            const unsigned long limit = (unsigned long)(pi->end - pi->str);
+            const char         *text  = a->value;
+            char                c;
 
             for (; '\0' != *text; text++) {
                 c = *text;
                 if ('0' <= c && c <= '9') {
+                    // Checked before the multiply so id can not overflow.
+                    if (limit / 10 < id || limit < id * 10 + (unsigned long)(c - '0')) {
+                        set_error(&pi->err, "circular reference id out of range", pi->str, pi->s);
+                        return 0;
+                    }
                     id = id * 10 + (c - '0');
                 } else {
                     set_error(&pi->err, "bad number format", pi->str, pi->s);
@@ -289,7 +298,9 @@ static void circ_array_set(CircArray ca, VALUE obj, unsigned long id) {
 static VALUE circ_array_get(CircArray ca, unsigned long id) {
     VALUE obj = Qundef;
 
-    if (id <= ca->cnt) {
+    // id is 0 when the `i` attribute is missing or invalid. Without the lower
+    // bound that reads objs[-1] and hands the word to Ruby as an object.
+    if (0 < id && id <= ca->cnt) {
         obj = ca->objs[id - 1];
     }
     return obj;
@@ -398,7 +409,8 @@ static void add_text(PInfo pi, char *text, size_t len, int closed) {
             rb_enc_associate(v, pi->options->rb_enc);
         }
         if (0 != pi->circ_array) {
-            circ_array_set(pi->circ_array, v, (unsigned long)h->obj);
+            // h->obj is still Qundef; add_element() parked the id in pi->id.
+            circ_array_set(pi->circ_array, v, pi->id);
         }
         h->obj = v;
         break;

--- a/ext/ox/ox.h
+++ b/ext/ox/ox.h
@@ -159,6 +159,7 @@ struct _pInfo {
 
 extern VALUE ox_parse(char *xml, size_t len, ParseCallbacks pcb, char **endp, Options options, Err err);
 extern void  _ox_raise_error(const char *msg, const char *xml, const char *current, const char *file, int line);
+extern void  ox_circ_array_free(CircArray ca);
 
 extern void ox_sax_define(void);
 

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -232,6 +232,12 @@ static VALUE ox_parse_ensure(VALUE ctxv) {
         DATA_PTR(ctx->wrap) = NULL;
     }
     helper_stack_cleanup(&ctx->pi->helpers);
+    // end_element() only frees the circular reference table on a complete
+    // parse, so release it here for an error or a callback raising out.
+    if (0 != ctx->pi->circ_array) {
+        ox_circ_array_free(ctx->pi->circ_array);
+        ctx->pi->circ_array = 0;
+    }
     return Qnil;
 }
 

--- a/test/objload_circular_test.rb
+++ b/test/objload_circular_test.rb
@@ -1,0 +1,127 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: object-mode circular reference table indexing.
+#
+# In mode: :object the `i` attribute is the index into the circular reference
+# table and is fully attacker controlled. get_id_from_attrs() accumulated it
+# into an unsigned long without any bound, so:
+#
+#   * circ_array_set() computed `id + 512` as the new table size, which wraps
+#     for ids near ULONG_MAX. The table was then grown far too small and the
+#     fill loop wrote past the end of it.
+#   * circ_array_get() accepted id 0 (an element with no `i` attribute, or an
+#     invalid one) and read objs[-1], outside the allocation, handing the word
+#     back to Ruby as an object reference.
+#
+# Both must raise instead. The valid cases below guard against over tightening
+# the new bound.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class ObjLoadCircularTest < ::Test::Unit::TestCase
+  class Bag
+    attr_accessor :a, :b
+
+    def initialize(a, b)
+      @a = a
+      @b = b
+    end
+  end
+
+  # id + 512 wraps, so the table is allocated with 411 slots and the fill loop
+  # then writes Qundef from index 1 upwards with no end.
+  def test_id_that_overflows_the_table_size_raises
+    xml = %(<a i="1"><s i="#{2**64 - 101}">x</s></a>)
+    assert_raise(Ox::ParseError) { Ox.parse_obj(xml) }
+  end
+
+  def test_id_at_the_very_top_of_the_range_raises
+    [2**64 - 1, 2**64 - 512, 2**64 - 513, 2**63].each do |id|
+      xml = %(<a i="1"><s i="#{id}">x</s></a>)
+      assert_raise(Ox::ParseError, "id #{id} must be rejected") { Ox.parse_obj(xml) }
+    end
+  end
+
+  # An id far larger than the document could ever have objects for is rejected
+  # rather than allocating id + 512 slots for it.
+  def test_id_beyond_the_document_length_raises
+    xml = %(<a i="1"><s i="100000">x</s></a>)
+    assert_raise(Ox::ParseError) { Ox.parse_obj(xml) }
+  end
+
+  def test_ref_without_an_id_attribute_raises
+    assert_raise(Ox::ParseError) { Ox.parse_obj(%(<a i="1"><p/></a>)) }
+  end
+
+  def test_ref_with_a_zero_id_raises
+    assert_raise(Ox::ParseError) { Ox.parse_obj(%(<a i="1"><p i="0"/></a>)) }
+  end
+
+  def test_ref_with_an_empty_or_non_numeric_id_raises
+    ['', 'x', '-1', '1.5'].each do |id|
+      assert_raise(Ox::ParseError, "id #{id.inspect} must be rejected") do
+        Ox.parse_obj(%(<a i="1"><s i="2">x</s><p i="#{id}"/></a>))
+      end
+    end
+  end
+
+  def test_ref_past_the_end_of_the_table_raises
+    assert_raise(Ox::ParseError) { Ox.parse_obj(%(<a i="1"><s i="2">x</s><p i="3"/></a>)) }
+  end
+
+  # Everything below must keep working.
+
+  def test_valid_circular_reference_resolves
+    a = Ox.parse_obj(%(<a i="1"><s i="2">x</s><p i="2"/></a>))
+    assert_equal(%w[x x], a)
+    assert_same(a[0], a[1])
+  end
+
+  def test_self_reference_resolves
+    a = Ox.parse_obj(%(<a i="1"><p i="1"/></a>))
+    assert_same(a, a[0])
+  end
+
+  def test_id_with_leading_zeros_resolves
+    a = Ox.parse_obj(%(<a i="1"><s i="0000000000000000002">x</s><p i="00002"/></a>))
+    assert_same(a[0], a[1])
+  end
+
+  # A base64 String element parks its id in pi->id for the following add_text,
+  # which used to pass h->obj (still Qundef at that point) to circ_array_set
+  # instead. The string was registered under the numeric value of Qundef, so no
+  # reference to it could ever resolve.
+  def test_base64_string_can_be_referenced
+    a = Ox.parse_obj(%(<a i="1"><b i="2">aGVsbG8=</b><p i="2"/></a>))
+    assert_equal(%w[hello hello], a)
+    assert_same(a[0], a[1])
+  end
+
+  def test_dump_load_round_trip_preserves_sharing
+    str = 'shared'
+    bag = Bag.new(1, 2)
+    obj = { 'one' => [str, str], 'two' => [bag, bag, str] }
+
+    back = Ox.parse_obj(Ox.dump(obj, circular: true, indent: 2))
+    assert_same(back['one'][0], back['one'][1])
+    assert_same(back['one'][0], back['two'][2])
+    assert_same(back['two'][0], back['two'][1])
+    assert_equal('shared', back['one'][0])
+  end
+
+  # More objects than the table's initial 1024 slots, so the grow path runs.
+  def test_round_trip_grows_the_table
+    strs = Array.new(1500) { |i| "s#{i}" }
+    obj  = strs + strs
+
+    back = Ox.parse_obj(Ox.dump(obj, circular: true, indent: 2))
+    assert_equal(3000, back.size)
+    assert_same(back[0], back[1500])
+    assert_same(back[1499], back[2999])
+  end
+end

--- a/test/parse_leak_test.rb
+++ b/test/parse_leak_test.rb
@@ -20,6 +20,11 @@
 #   * stack_cleanup() freed the SAX element stack array but not the ox_strndup'd
 #     name of any element still on it, so an unclosed element whose name reaches
 #     NV_BUF_MAX (64) bytes leaked that name.
+#   * obj_load.c allocates the circular reference table when the top level
+#     element of an object mode document carries an `i` attribute, and freed it
+#     only in end_element(), when that element closes. Every parse error and
+#     every callback raise therefore dropped the table -- 8 KB, plus the grown
+#     objs array once the document has more than 1024 referenced objects.
 #
 # Both leaked once per parse and were invisible to Ruby's GC, so a service
 # parsing untrusted XML grew until the process was OOM killed while the parse
@@ -155,6 +160,61 @@ class ParseLeakTest < ::Test::Unit::TestCase
       # Several unclosed long names at once.
       Ox.sax_parse(handler.new, StringIO.new((0..4).map { |j| "<#{'m' * 80}#{i}_#{j}>" }.join))
     end
+    assert_still_healthy
+  end
+
+  # obj_load: the top level `i` attribute allocates the circular reference
+  # table, then a bad reference ends the parse before end_element() can free it.
+  def test_circ_array_freed_on_invalid_circular_reference
+    200.times do
+      assert_raise(Ox::ParseError) { Ox.parse_obj('<a i="1"><s i="2">x</s><p i="3"/></a>') }
+    end
+    assert_still_healthy
+  end
+
+  # obj_load: the document is unterminated, so the parse ends with the table
+  # still held and the helper stack not empty.
+  def test_circ_array_freed_on_unterminated_document
+    200.times do
+      assert_raise(Ox::ParseError) { Ox.parse_obj('<a i="1"><s i="2">x</s>') }
+    end
+    assert_still_healthy
+  end
+
+  # obj_load: past the table's 1024 inline slots, so objs is a second heap
+  # allocation that leaked with it. The document is deliberately long enough
+  # that its ids stay well inside the valid range.
+  def test_circ_array_freed_after_the_table_grows
+    body = (2..1100).map { |i| %(<s i="#{i}">x</s>) }.join
+    20.times do
+      assert_raise(Ox::ParseError) { Ox.parse_obj(%(<a i="1">#{body}<p i="99999"/></a>)) }
+      assert_raise(Ox::ParseError) { Ox.parse_obj(%(<a i="1">#{body})) }
+    end
+    assert_still_healthy
+  end
+
+  # obj_load: a callback raising out of the parse (rb_const_get on an undefined
+  # class under the default :strict effort) unwinds past end_element entirely.
+  def test_circ_array_freed_when_a_callback_raises
+    200.times do
+      assert_raise(NameError) do
+        Ox.parse_obj('<a i="1"><s i="2">x</s><o c="NoSuchClassXYZ"/></a>')
+      end
+    end
+    assert_still_healthy
+  end
+
+  # The success path still frees the table exactly once. A double free would
+  # surface here rather than as a leak.
+  def test_valid_circular_documents_unchanged
+    200.times do
+      a = Ox.parse_obj('<a i="1"><s i="2">x</s><p i="2"/></a>')
+      assert_same(a[0], a[1])
+    end
+    obj = { 'one' => %w[shared shared] }
+    obj['two'] = obj['one']
+    back = Ox.parse_obj(Ox.dump(obj, circular: true, indent: 2))
+    assert_same(back['one'], back['two'])
     assert_still_healthy
   end
 


### PR DESCRIPTION
Depends on #433 — it is the parent commit here, so that one should go first. This branch's tests exercise the same error paths and would otherwise turn the Valgrind lane red.

In `mode: :object` the `i` attribute is the index into the circular reference table and is fully attacker controlled. `get_id_from_attrs()` accumulated it into an `unsigned long` with no bound at all, and two callers then used the result as an array index.

## 1. Out-of-bounds heap write

`circ_array_set()` grows the table with `unsigned long cnt = id + 512`, which wraps for an id near `ULONG_MAX`:

```ruby
Ox.parse_obj('<a i="1"><s i="18446744073709551515">x</s></a>')
```

`2**64 - 101 + 512` wraps to 411, so `ALLOC_N(VALUE, 411)` takes 3288 bytes and the fill loop then writes `Qundef` from index 1 upwards with no end. Under ASAN:

```
==94486==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7dba2280f358
WRITE of size 8 at 0x7dba2280f358 thread T0
    #0 circ_array_set /home/watson/prj/ox/ext/ox/obj_load.c:280
    #1 add_element /home/watson/prj/ox/ext/ox/obj_load.c:475
    #2 read_element /home/watson/prj/ox/ext/ox/parse.c:564

0x7dba2280f358 is located 0 bytes after 3288-byte region [0x7dba2280e680,0x7dba2280f358)
```

Without ASAN the same document is a SIGSEGV (`ruby` exits 139).

## 2. Out-of-bounds heap read

`circ_array_get()` guarded only the upper bound, `id <= ca->cnt`, and `get_id_from_attrs()` returns 0 both for an element with no `i` attribute and for a malformed one. So:

```ruby
Ox.parse_obj('<a i="1"><p/></a>')
```

reads `objs[-1]` and returns that word to Ruby as an object reference. ASAN puts it 8 bytes before the 8216-byte allocation.

A correction to what this actually leaks: on glibc the word is the malloc chunk header, whose `PREV_INUSE` bit is set, so it decodes as a Fixnum. Over 200 runs it returned an `Integer` every time — the allocation size, 4112 for the inline table and 10056 once the table has grown. So in practice this is an allocator metadata disclosure, not the type confusion it would be where the word happens to be even. The out-of-bounds read itself is undefined behavior and both ASAN and Valgrind flag it.

## The fix

Bound the id in `get_id_from_attrs()`, the single place a document supplied id enters the parser, checking before the multiply so the accumulator itself cannot overflow. The bound is the document length, `pi->end - pi->str`: every referenced object needs at least one element in the document, so no id Ox itself produces can exceed it, and rejecting above it also keeps the memory the parser will allocate proportional to its input rather than to a 20-character attribute value.

Then add the missing lower bound to `circ_array_get()`, which routes an id of 0 into the "Invalid circular reference" error the caller already has.

## 3. The one caller that bypassed the bound

That leaves a single `circ_array_set()` call whose id never went through `get_id_from_attrs()`. A base64 String element parks its id in `pi->id` for the following `add_text()`, which then passed `h->obj` — still `Qundef` at that point — instead:

```c
case String64Code:
    h->obj = Qundef;
    if (0 != pi->circ_array) {
        pi->id = get_id_from_attrs(pi, attrs);   // add_element parks it here
    }
    break;
```
```c
case String64Code: {
    ...
    if (0 != pi->circ_array) {
        circ_array_set(pi->circ_array, v, (unsigned long)h->obj);   // ... and this ignores it
    }
```

The string was registered under the numeric value of `Qundef`, so no reference to it could ever resolve. `'<a i="1"><b i="2">aGVsbG8=</b><p i="2"/></a>'` raised `Invalid element for object mode` and now returns `["hello", "hello"]` with both entries the same object. The `StringCode` case two branches up already does this correctly with `pi->id`.

Ox itself has not emitted base64 strings since `USE_B64` was set to 0 in `dump.c`, but the loader still accepts them from a document, which is why this is reachable at all.

## Verification

- **Output identity.** 114 dump/parse round trips — 19 object graphs (shared strings, arrays, hashes, symbols, objects, structs, ranges, times, exceptions, bignums, regexps, a self reference, a 20-deep ring, 300-wide sharing) × 6 option sets — comparing the SHA-256 of the dump and the loaded result. Identical before and after, modulo object addresses.
- **Sweep.** 718 hand-written documents: every element code that registers a circular id (`s b a h o u e x`) × 23 id values from 0 to `ULONG_MAX` × 4 reference targets, plus the malformed reference forms. No ASAN report in any of the 832 cases.
- `rake` is green (48 tests, 2774 assertions), `rake test:valgrind` is clean (312 tests), and `clang-format --dry-run --Werror ext/ox/*.c ext/ox/*.h` passes.

ASAN build used: `ruby extconf.rb --with-cflags="-g -O0 -fsanitize=address -fno-omit-frame-pointer -fPIC" --with-ldflags="-fsanitize=address -shared"`, with gcc's libasan preloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
