### PR TITLE
Fix hash flooding by seeding the name cache hash per process

### DIFF
--- a/ext/ox/cache.c
+++ b/ext/ox/cache.c
@@ -27,6 +27,23 @@
 // almost the Murmur hash algorithm
 #define M 0x5bd1e995
 
+// Mixed into the initial state of hash_calc(). Element and attribute names come
+// straight from the document, so without a per process seed the bucket every
+// name lands in can be precomputed offline. Written once by ox_hash_seed_init()
+// during Init_ox and only read afterwards, so the caches stay Ractor safe.
+static uint64_t hash_seed = 0;
+
+void ox_hash_seed_init(void) {
+#ifdef HAVE_RB_HASH_START
+    // Folds in the random seed Ruby uses to defend Hash against the same attack.
+    hash_seed = (uint64_t)rb_hash_start(0);
+#else
+    // String#hash is per process randomized too. It can be negative, so take it
+    // as signed and reinterpret rather than letting NUM2ULL reject it.
+    hash_seed = (uint64_t)(int64_t)NUM2LL(rb_funcall(rb_str_new_literal("ox"), rb_intern("hash"), 0));
+#endif
+}
+
 typedef struct _slot {
     struct _slot     *next;
     VALUE             val;
@@ -68,7 +85,7 @@ const rb_data_type_t ox_cache_type = {
 static uint64_t hash_calc(const uint8_t *key, size_t len) {
     const uint8_t *end     = key + len;
     const uint8_t *endless = key + (len & 0xFFFFFFFC);
-    uint64_t       h       = (uint64_t)len;
+    uint64_t       h       = (uint64_t)len ^ hash_seed;
     uint64_t       k;
 
     while (key < endless) {

--- a/ext/ox/cache.h
+++ b/ext/ox/cache.h
@@ -13,6 +13,8 @@ struct _cache;
 
 extern const rb_data_type_t ox_cache_type;
 
+extern void ox_hash_seed_init(void);
+
 extern struct _cache *ox_cache_create(size_t size, VALUE (*form)(const char *str, size_t len), bool mark, bool locking);
 extern void           ox_cache_free(void *ptr);
 extern void           ox_cache_mark(void *ptr);

--- a/ext/ox/extconf.rb
+++ b/ext/ox/extconf.rb
@@ -46,6 +46,9 @@ have_func('rb_ext_ractor_safe', 'ruby.h')
 have_func('pthread_mutex_init')
 have_func('rb_enc_interned_str')
 have_func('index')
+# Seeds the name cache hash. Not on every implementation, so cache.c falls back
+# to String#hash, which is per process randomized everywhere it matters.
+have_func('rb_hash_start', 'ruby.h')
 
 have_header('ruby/st.h')
 have_header('sys/uio.h')

--- a/ext/ox/intern.c
+++ b/ext/ox/intern.c
@@ -68,7 +68,12 @@ static VALUE form_id(const char *str, size_t len) {
 }
 
 void ox_hash_init(void) {
-    VALUE cache_class = rb_define_class_under(Ox, "Cache", rb_cObject);
+    VALUE cache_class;
+
+    // Before the first cache exists, so no name is ever hashed unseeded.
+    ox_hash_seed_init();
+
+    cache_class = rb_define_class_under(Ox, "Cache", rb_cObject);
 #if RUBY_API_VERSION_CODE >= 30200
     rb_undef_alloc_func(cache_class);
 #endif


### PR DESCRIPTION
Related to https://github.com/ohler55/oj/pull/1053 — the same defect and the same fix in oj's copy of `cache.c`.

## Problem

Every XML element and attribute name shorter than `CACHE_MAX_KEY` (35) is interned through `ox_cache_intern()`, and the bucket it lands in is decided by `hash_calc()` in `ext/ox/cache.c`. That function is an almost-Murmur hash whose only input is the key bytes and its length, with a compile time constant `M = 0x5bd1e995` and no per process seed:

```c
uint64_t h = (uint64_t)len;
```

Because the hash is fully determined at compile time, a caller can precompute names that all land in the same bucket. `cache.c` resolves collisions with an unbounded singly linked list that is walked on every insert and every lookup (`ext/ox/cache.c:198-207`), so a document made of such names turns interning into a chain walk per name. The entries live in a process wide cache that survives many GC cycles, so later unrelated parses stay slow too.

This affects the ordinary entry points with default options: `Ox.load` in `:generic` mode and `Ox.sax_parse` both intern attribute names through `ox_sym_intern` (`ext/ox/gen_load.c:266`, `ext/ox/sax.c:87`).

## Fix

Mix a per process random value into the initial state of `hash_calc()`, which is the standard Murmur seeding position:

```c
uint64_t h = (uint64_t)len ^ hash_seed;
```

`hash_seed` is set once by `ox_hash_seed_init()`, called at the top of `ox_hash_init()` so that it is in place before the first cache exists. The seed comes from `rb_hash_start(0)`, which folds in the random seed Ruby itself uses to defend against the same attack on `Hash`. `rb_hash_start` is behind a `have_func` check with a `String#hash` fallback for implementations that lack it.

One difference from the oj change: oj had to seed two copies of `hash_calc()` because its `intern.c` carried its own. ox has only one — `intern.c` shares the one in `cache.c` — so there is no second site.

The seed is written once during `Init_ox` and only read afterwards, so this does not change the Ractor safety of the caches.

I did not add the second half that a chain length cap would provide. Once the hash is seeded an attacker cannot construct a colliding set offline, and with a uniform hash at the cache's load factor of 4 the expected longest chain is small, so the cap would add a cache-bypass path for a case that no longer occurs.

## Measurements

Ruby 4.0.6, x86_64-linux. The script at the end reproduces these. It reimplements the pre-patch `hash_calc()` in Ruby, brute forces N distinct 16 byte attribute names that share the low 10 bits of the hash, and writes that document plus a control document of the same size, name count and name length with sequential names. Each is parsed with `Ox.load` in a process of its own, since the intern cache is process wide, and the iteration count is chosen from a calibration parse so both documents get the same wall clock budget.

| N colliding names | document | before: colliding vs control | ratio | after: colliding vs control | ratio |
| --- | --- | --- | --- | --- | --- |
| 1500 | 30 KB | 3.593 vs 0.127 ms | 28.4x | 0.129 vs 0.127 ms | 1.02x |
| 3000 | 60 KB | 10.569 vs 0.275 ms | 38.5x | 0.288 vs 0.272 ms | 1.06x |
| 4000 | 80 KB | 16.924 vs 0.380 ms | 44.5x | 0.400 vs 0.377 ms | 1.06x |

The colliding document costs 28x to 45x the control document before the change and is indistinguishable from it after. Throughput on ordinary documents is unchanged.

The excess over the control grows super-linearly with the number of colliding names: 2.0x the names costs 3.0x (1500 to 3000), close to the quadratic chain walk, though it flattens by 4000 where cache eviction starts to break up the chain. A larger precomputed set scales the gap further.

To take the before column, stash the patch and rebuild:

```
git stash push -- ext/ox/cache.c ext/ox/cache.h ext/ox/intern.c ext/ox/extconf.rb
rake compile && ruby bench_hash_flooding.rb
git stash pop && rake compile
```

`rake` is green (336 tests) and `rake test:valgrind` is clean (294 tests, exit 0).

`bench_hash_flooding.rb`, save at the root of an ox checkout:

```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true

# Reproduces the hash flooding measurement for the name intern cache.
#
#   rake compile
#   ruby bench_hash_flooding.rb
#
# It reimplements the pre-patch hash_calc() from ext/ox/cache.c in Ruby, brute
# forces KEYS distinct 16 byte attribute names that share the low bits of the
# hash, and writes two documents of the same size, attribute count and name
# length: one made of those colliding names, one of sequential names. Each is
# then parsed ITER times with Ox.load, each document in a process of its own
# since the intern cache is process wide.
#
# KEYS overrides the default key count and BUDGET the seconds spent per
# document. The precomputed documents are cached in the temp directory so later
# runs start measuring immediately.

require 'benchmark'
require 'digest'
require 'tmpdir'

KEYS   = Integer(ENV.fetch('KEYS', 3000))
BUDGET = Float(ENV.fetch('BUDGET', 2.0))

M    = 0x5bd1e995
U64  = 0xFFFF_FFFF_FFFF_FFFF

# ext/ox/cache.c hash_calc(), before the per process seed. The bucket is
# h & c->mask, and the cache settles at 1024 slots for this key count, so
# sharing the low 10 bits of h puts every key in one bucket.
def hash_calc(key)
  b       = key.bytes
  len     = b.size
  endless = len & 0xFFFF_FFFC
  h       = len
  i       = 0

  while i < endless
    k = b[i] | (b[i + 1] << 8) | (b[i + 2] << 16) | (b[i + 3] << 24)
    i += 4
    k = (k * M) & U64
    k ^= k >> 24
    h = (h * M) & U64
    h ^= (k * M) & U64
  end
  if 1 < len - i
    k16 = b[i] | (b[i + 1] << 8)
    i += 2
    h ^= k16 << 8
  end
  h ^= b[i] if i < len
  h = (h * M) & U64
  h ^= h >> 13
  h = (h * M) & U64
  h ^= h >> 15
  h
end

# The cache starts at 256 slots and quadruples when cnt/size passes 4, so
# 1024 < KEYS <= 4096 settles at 1024 slots.
SIZE = begin
  size = 256
  size *= 4 while 4 < KEYS / size
  size
end
MASK = SIZE - 1
BITS = MASK.bit_length

def name_for(prefix, i)
  "#{prefix}#{i.to_s(36).rjust(15, '0')}"
end

def colliding_names(count)
  buckets = Hash.new { |h, k| h[k] = [] }
  i       = 0
  loop do
    n = name_for('a', i)
    b = buckets[hash_calc(n) & MASK]
    b << n
    return b if b.size == count

    i += 1
    raise "no #{count} way collision found" if 40 * count * SIZE < i
  end
end

def doc_for(names)
  "<r #{names.map { |n| "#{n}=\"\"" }.join(' ')}/>"
end

cache_dir = File.join(Dir.tmpdir, "ox-hash-flooding-#{KEYS}")
Dir.mkdir(cache_dir) unless Dir.exist?(cache_dir)
collide_path = File.join(cache_dir, 'collide.xml')
control_path = File.join(cache_dir, 'control.xml')

unless File.exist?(collide_path) && File.exist?(control_path)
  warn "precomputing #{KEYS} names that collide in the low #{BITS} bits (#{SIZE} slots)..."
  t = Time.now
  File.write(collide_path, doc_for(colliding_names(KEYS)))
  File.write(control_path, doc_for((0...KEYS).map { |i| name_for('b', i) }))
  warn format('  %.1fs', Time.now - t)
end

# One process per document: the intern cache lives for the life of the process,
# so a shared one would let the first document pay for the second. Iterations
# are chosen from a calibration parse so both documents get the same wall clock
# budget -- at a few tenths of a millisecond per parse a fixed count is all
# noise.
def measure(path, budget)
  script = <<~RUBY
    require 'ox'
    require 'benchmark'
    doc = File.read(#{path.inspect})
    Ox.load(doc)                                    # warm up the parser itself
    one  = Benchmark.realtime { Ox.load(doc) }
    iter = [(#{budget} / [one, 1e-6].max).to_i, 5].max
    t    = Benchmark.realtime { iter.times { Ox.load(doc) } }
    puts [t / iter * 1000, iter].join(' ')
  RUBY
  out = IO.popen([RbConfig.ruby, '-Ilib', '-e', script], &:read)
  ms, iter = out.split
  [Float(ms), Integer(iter)]
end

collide, citer = measure(collide_path, BUDGET)
control, niter = measure(control_path, BUDGET)

puts format('document size:   %d bytes, %d attribute names of 16 bytes', File.size(collide_path), KEYS)
puts format('cache:           %d slots, low %d bits shared by every colliding name', SIZE, BITS)
puts
puts format('colliding names: %8.3f ms/parse  (%d parses)', collide, citer)
puts format('control names:   %8.3f ms/parse  (%d parses)', control, niter)
puts format('ratio:           %8.2fx', collide / control)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
