### PR TITLE
Limit the CI workflows to a read-only token and stop persisting it

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   Build:
     strategy:
@@ -32,6 +35,8 @@ jobs:
     name: Ruby ${{ matrix.ruby }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -14,6 +14,9 @@ on:
       - "**/*.c"
       - "**/*.h"
 
+permissions:
+  contents: read
+
 jobs:
   formatting-check:
     name: Formatting Check
@@ -22,6 +25,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Run clang-format style check
       uses: jidicula/clang-format-action@v4.18.0

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -22,6 +22,8 @@ jobs:
           - '4.0'
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install Valgrind
         run: |
           sudo apt-get update


### PR DESCRIPTION
Two pieces of defense in depth for the three workflows. Neither is a fix for a reachable hole — see "Exploitability" below.

## 1. Declare `permissions:`

`permissions:` was declared only in `valgrind.yml`, so `CI.yml` and `clang-format.yml` ran with whatever the repository default grants, which is read-write unless the org has changed it.

None of the three needs more than read: they check out, install Ruby, and run either the test suite or clang-format. Nothing writes back to the repository, creates a release, or comments on a PR. So declare `contents: read` at the workflow level in the two that lack it, matching what `valgrind.yml` already does.

## 2. Stop persisting the token in the workspace

`actions/checkout` defaults `persist-credentials` to true, which leaves the token in `.git/config` for every later step to read. Nothing in these workflows pushes, and `Gemfile` has no git sources, so nothing needs those credentials to survive the checkout step. Set `persist-credentials: false` in all three.

## Exploitability

Low, and I would rather say so than oversell it. Every trigger here is `pull_request`, not `pull_request_target`, so GitHub already issues a read-only `GITHUB_TOKEN` for fork PRs and passes no secrets. A write token is only present on push and same-repository PRs, which come from someone who already has write access. The value of this change is that it stops depending on the trigger type staying that way, and on the repository default staying narrow.

## Compatibility

`contents: read` and `persist-credentials: false` are both compatible with `bundler-cache: true` — `valgrind.yml` has been running with `contents: read` and that cache since #427, and the bundler cache does not use the git credentials left by checkout.

## Not included

Two related items I did not act on unilaterally, because both want your call rather than a patch:

- **Pinning actions to commit SHAs.** `actions/checkout@v7`, `ruby/setup-ruby@v1` and `jidicula/clang-format-action@v4.18.0` are all mutable tags. Pinning removes the "the tag moved under us" risk but adds a standing update chore, which is a maintenance preference, not a security bug. Happy to send it if you want it.
- **`xml/wr.xml` contains what look like real credentials.** The string `zigeyi22` appears as a root password and an iLO management password in 20+ places, next to `10.251.x.x` internal addresses and plausible hostnames. It is sample data from around 2012 and no test reads the file, so it is almost certainly long dead — but since it is committed to a public repository, it seemed worth asking whether it ever was live rather than quietly rewriting the fixture. Tell me which you prefer and I will send that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
