### PR TITLE
Fix SEGV when dumping a Time localtime() can not represent

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -520,45 +520,94 @@ static void dump_date(Out out, VALUE obj) {
     }
 }
 
+// Splits seconds since the epoch into a UTC date and wall clock. Used when
+// localtime() can not represent the time, so no timezone rules are needed.
+static void utc_from_epoch(time_t sec, long long *yearp, int *monp, int *dayp, int *hourp, int *minp, int *secp) {
+    long long days = (long long)sec / 86400;
+    long long rem  = (long long)sec % 86400;
+    long long era, doe, yoe, doy, mp;
+
+    if (0 > rem) {
+        rem += 86400;
+        days--;
+    }
+    *hourp = (int)(rem / 3600);
+    *minp  = (int)(rem % 3600 / 60);
+    *secp  = (int)(rem % 60);
+
+    // Hinnant's civil_from_days. The era starts in March so the leap day is
+    // last in the year and needs no special case.
+    days += 719468;
+    era    = (0 <= days ? days : days - 146096) / 146097;
+    doe    = days - era * 146097;
+    yoe    = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    doy    = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    mp     = (5 * doy + 2) / 153;
+    *dayp  = (int)(doy - (153 * mp + 2) / 5 + 1);
+    *monp  = (int)(10 > mp ? mp + 3 : mp - 9);
+    *yearp = yoe + era * 400 + (2 >= *monp);
+}
+
 static void dump_time_xsd(Out out, VALUE obj) {
     struct tm      *tm;
-    struct timespec ts   = rb_time_timespec(obj);
-    time_t          sec  = ts.tv_sec;
-    long            nsec = ts.tv_nsec;
-    int             tzhour, tzmin;
+    struct timespec ts     = rb_time_timespec(obj);
+    time_t          sec    = ts.tv_sec;
+    long            nsec   = ts.tv_nsec;
+    int             tzhour = 0, tzmin = 0;
     char            tzsign = '+';
+    long long       year;
+    int             mon, day, hour, min, tsec;
+    char            buf[64];
+    int             cnt;
 
-    if (out->end - out->cur <= 33) {
-        grow(out, 33);
-    }
     /* 2010-07-09T10:47:45.895826+09:00 */
     tm = localtime(&sec);
-#if HAVE_ST_TM_GMTOFF
-    if (0 > tm->tm_gmtoff) {
-        tzsign = '-';
-        tzhour = (int)(tm->tm_gmtoff / -3600);
-        tzmin  = (int)(tm->tm_gmtoff / -60) - (tzhour * 60);
+    if (NULL == tm) {
+        // localtime() returns NULL for times it can not represent: the
+        // Microsoft CRT rejects everything before the epoch, and glibc rejects
+        // years too large for tm_year. Reading tm anyway is a NULL dereference,
+        // so fall back to UTC, which is the same instant either way.
+        utc_from_epoch(sec, &year, &mon, &day, &hour, &min, &tsec);
     } else {
-        tzhour = (int)(tm->tm_gmtoff / 3600);
-        tzmin  = (int)(tm->tm_gmtoff / 60) - (tzhour * 60);
-    }
-#else
-    tzhour = 0;
-    tzmin  = 0;
+        year = tm->tm_year + 1900;
+        mon  = tm->tm_mon + 1;
+        day  = tm->tm_mday;
+        hour = tm->tm_hour;
+        min  = tm->tm_min;
+        tsec = tm->tm_sec;
+#if HAVE_ST_TM_GMTOFF
+        if (0 > tm->tm_gmtoff) {
+            tzsign = '-';
+            tzhour = (int)(tm->tm_gmtoff / -3600);
+            tzmin  = (int)(tm->tm_gmtoff / -60) - (tzhour * 60);
+        } else {
+            tzhour = (int)(tm->tm_gmtoff / 3600);
+            tzmin  = (int)(tm->tm_gmtoff / 60) - (tzhour * 60);
+        }
 #endif
+    }
     /* TBD replace with more efficient printer */
-    out->cur += sprintf(out->cur,
-                        "%04d-%02d-%02dT%02d:%02d:%02d.%06ld%c%02d:%02d",
-                        tm->tm_year + 1900,
-                        tm->tm_mon + 1,
-                        tm->tm_mday,
-                        tm->tm_hour,
-                        tm->tm_min,
-                        tm->tm_sec,
-                        nsec / 1000,
-                        tzsign,
-                        tzhour,
-                        tzmin);
+    // A year outside four digits is longer than the sample above, so reserve
+    // what was actually formatted instead of a fixed 33. buf can not overflow:
+    // the largest time_t puts the year at 12 digits, and the rest of the format
+    // is a fixed 28 characters.
+    cnt = snprintf(buf,
+                   sizeof(buf),
+                   "%04lld-%02d-%02dT%02d:%02d:%02d.%06ld%c%02d:%02d",
+                   year,
+                   mon,
+                   day,
+                   hour,
+                   min,
+                   tsec,
+                   nsec / 1000,
+                   tzsign,
+                   tzhour,
+                   tzmin);
+    if (out->end - out->cur <= cnt) {
+        grow(out, cnt);
+    }
+    APPEND_CHARS(out->cur, buf, cnt);
 }
 
 static void dump_first_obj(VALUE obj, Out out) {

--- a/test/dump_time_xsd_test.rb
+++ b/test/dump_time_xsd_test.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: dump_time_xsd() dereferencing localtime()'s return value.
+#
+# localtime() returns NULL for a time it can not represent and dump_time_xsd()
+# read through it without checking, so Ox.dump crashed with SIGSEGV. The range
+# it rejects is platform specific, which is why both ends are covered here:
+#
+#   * the Microsoft CRT rejects every time before the epoch, so on Windows
+#     Ox.dump(Time.at(-1), xsd_date: true) was enough
+#   * glibc accepts those but rejects years too large for tm_year, so on Linux
+#     it took something like Time.at(2**62)
+#
+# A time outside localtime()'s range now falls back to UTC, which is why the
+# assertions below accept either the local or the UTC rendering of the instant
+# rather than one of them: which is used depends on where the platform draws
+# that line. Times inside the range are unaffected, verified byte for byte
+# identical over 7108 dumps in each of four timezones.
+#
+# Nothing here asserts the offset that gets written, because on a platform
+# without tm_gmtoff it is still "+00:00" for a local wall clock. That is a
+# separate defect and a separate fix.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class DumpTimeXsdTest < ::Test::Unit::TestCase
+  XSD = /\A(-?\d{4,})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)\.(\d{6})([-+]\d\d:\d\d)\z/
+
+  def setup
+    @opts = Ox.default_options
+    Ox.default_options = {mode: :object, xsd_date: true}
+  end
+
+  def teardown
+    Ox.default_options = @opts
+  end
+
+  def body(t)
+    Ox.dump(t).strip[%r{<t>(.*)</t>}, 1]
+  end
+
+  def rendering(t)
+    format('%04d-%02d-%02dT%02d:%02d:%02d.%06d', t.year, t.month, t.day, t.hour, t.min, t.sec, t.usec)
+  end
+
+  # The wall clock has to be the instant it was given, read either as local or
+  # as UTC. A wrong one would mean the fallback computed the wrong date.
+  def assert_dumps_instant(sec)
+    got = body(Time.at(sec))
+    assert_match(XSD, got, "sec=#{sec}")
+    t = Time.at(sec)
+    assert_include([rendering(t.getlocal), rendering(t.utc)], got[0, got.index(/[-+]\d\d:\d\d\z/)], "sec=#{sec}")
+  end
+
+  # The Windows end of the range. Before the fix these crashed the process
+  # there, and CI runs Windows, so this is the case that guards it.
+  def test_before_the_epoch_dumps
+    [-1, -14_215_340, -2_208_988_800, -(2**40)].each { |sec| assert_dumps_instant(sec) }
+  end
+
+  # The glibc end. Both signs, since the fallback splits the day differently
+  # for a negative remainder.
+  def test_year_too_large_for_localtime_dumps
+    assert_match(/\A\d{6,}-\d\d-\d\dT/, body(Time.at(2**62)))
+    assert_match(/\A-\d{6,}-\d\d-\d\dT/, body(Time.at(-(2**62))))
+  end
+
+  # 2**62 is outside every platform's localtime() range, so this is always the
+  # fallback and it has to agree with Ruby about which instant it is.
+  def test_fallback_matches_ruby_utc
+    [2**62, -(2**62), 2**62 - 12_345, -(2**62) + 98_765].each do |sec|
+      t = Time.at(sec).utc
+      assert_equal("#{rendering(t)}+00:00", body(Time.at(sec)), "sec=#{sec}")
+    end
+  end
+
+  # A year outside four digits makes the line longer than the 33 bytes the old
+  # code reserved, so the reservation is now taken from the formatted length.
+  # Dumping many of them in one document exercises the grow() path.
+  def test_long_years_do_not_truncate
+    times = (0..200).map { |i| Time.at(2**55 + i * 1_000_000_007) }
+    xml = Ox.dump(times)
+    assert_equal(201, xml.scan('<t>').size)
+    xml.scan(%r{<t>([^<]*)</t>}).flatten.each { |s| assert_match(/\A\d{10}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{6}[-+]\d\d:\d\d\z/, s) }
+  end
+
+  # Times localtime() can represent keep the local wall clock they always had,
+  # including across a DST transition.
+  def test_representable_times_keep_the_local_wall_clock
+    [0, 1, 951_782_400, 1_483_660_687, 1_616_893_200, 1_636_264_800, 2**31].each do |sec|
+      t = Time.at(sec)
+      assert_equal(rendering(t.getlocal), body(t)[0, 26], "sec=#{sec}")
+    end
+  end
+
+  def test_sub_second_digits_are_kept
+    assert_equal('123456', body(Time.at(1_483_660_687, 123_456.789))[20, 6])
+  end
+end


### PR DESCRIPTION
`dump_time_xsd()` passed `localtime()`'s return value straight to `sprintf` without checking it for NULL. `localtime()` returns NULL for any time it can not represent, so `Ox.dump` segfaulted.

```
$ ruby -Ilib -e 'require "ox"; Ox.dump(Time.at(2**62), mode: :object, xsd_date: true)'
[BUG] Segmentation fault at 0x0000000000000028
ox.so(dump_time_xsd+0x4b) ext/ox/dump.c:535
ox.so(dump_obj+0x743)     ext/ox/dump.c:787
```

## The range differs by platform, so the crashing input does too

- **Windows.** The Microsoft CRT rejects every time before the epoch, so `Ox.dump(Time.at(-1), xsd_date: true)` is enough. Confirmed on `ruby 3.3.12 [x64-mingw-ucrt]`, where the boundary matches `_localtime64`'s exactly: `Time.at(0)` dumps, `Time.at(-1)` crashes.
- **Linux (glibc).** Those are fine, but NULL comes back once the year no longer fits `tm_year`. That is where the `2**62` above comes from — `localtime(1<<55)` is still non-NULL, `localtime(1<<62)` is not.

Both branches of the `HAVE_ST_TM_GMTOFF` conditional dereference `tm`, so neither platform was protected. On glibc the fault address `0x28` is `tm_gmtoff`; on Windows it is `tm_year` inside `sprintf`.

`xsd_date: true` with a `Time` is the intended use of the option, and CI runs Windows, so the new test guards the more easily reached end of this.

## The fix

A time outside `localtime()`'s range falls back to UTC. That needs no timezone rules, and it is the same instant either way. The conversion is Howard Hinnant's `civil_from_days` — plain integer arithmetic, no libc call that can fail.

Times `localtime()` can represent still take the path they always did.

The reservation was a fixed 33 bytes, the length of the sample in the comment above the call. A year outside four digits is longer than that, so it now reserves what `snprintf` actually formatted. Nothing overflowed before — the ten extra bytes `grow()` allocates past `out->end` covered it — but it was relying on that margin rather than on the number.

## What this deliberately does not change

**The offset written on a platform without `tm_gmtoff` is still `+00:00` for a local wall clock.** On Windows, `Ox.dump(Time.gm(2017, 1, 5, 23, 58, 7))` in JST writes `2017-01-06T08:58:07.000000+00:00` — the wall clock is local but the offset claims UTC, so the document states an instant nine hours off to every other reader.

I left it out on purpose. Getting the offset without `tm_gmtoff` means going through `Time#utc_offset` or `Time#getlocal`, and the obvious form of that changes the output on Linux for a Time that carries the UTC flag. That is a behaviour change worth its own patch and its own discussion, not something to slip into a crash fix. Happy to send it separately if you want it.

## Verification

- New `test/dump_time_xsd_test.rb`, 6 tests, green in six timezones including half-hour (Australia/Adelaide) and +14:00 (Pacific/Kiritimati). On unpatched `develop` it exits 139.
- **Output for representable times is byte for byte identical.** 7108 dumps in each of `Asia/Tokyo`, `America/Los_Angeles`, `Europe/Berlin` and `UTC` — random values across 1700–2250, large years, DST transitions, both `xsd_date` settings — hash to the same SHA-256 before and after.
- The fallback agrees with Ruby: 207 values checked against `Time#utc`'s own decomposition, no mismatches.
- 401 dumps with the long-year form at every buffer offset from 0 to 400 under ASAN, to exercise the `grow()` boundary. No reports.
- `rake test_all` green. `rake test:valgrind` 318 tests, no leaks and no invalid accesses.
- ASAN shows nothing this branch introduces. The one report in `test/tests.rb` is present identically on `develop` and is an artifact of `rb_raise` longjmping out of `load_str`'s `ALLOCA_N` frame without `__asan_handle_no_return`; an uninstrumented build reports nothing.

## Background

Found while checking whether ox has the Windows time handling problem that oj hit in ohler55/oj#1088. It does, and there is more in that area — the offset above, plus the loader discarding the document's offset and `mktime()` returning -1 for pre-epoch times on Windows. Those need a compatibility decision, so they are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
