### PR TITLE
Fix the thin time format losing times before 1970 and after 2038

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -476,14 +476,37 @@ static void dump_time_thin(Out out, VALUE obj) {
     long            nsec = ts.tv_nsec;
     char           *dot  = b - 10;
     long            size;
+    bool            neg = 0 > sec;
 
+    // tv_nsec is never negative, so a time before the epoch is a negative
+    // second count carrying a positive fraction. Writing those two out as they
+    // are would read as -1.5 for what is really -0.5, so move the fraction over
+    // and write the magnitude with a sign in front of it.
+    if (neg && 0 < nsec) {
+        sec++;
+        nsec = 1000000000L - nsec;
+    }
     *b-- = '\0';
     for (; dot < b; b--, nsec /= 10) {
         *b = '0' + (nsec % 10);
     }
     *b-- = '.';
-    for (; 0 < sec; b--, sec /= 10) {
-        *b = '0' + (sec % 10);
+    if (0 == sec) {
+        *b-- = '0';
+    } else if (neg) {
+        // sec is left negative instead of negated so that the most negative
+        // time_t does not overflow. C truncates the quotient toward zero, so
+        // the remainder carries the sign with it.
+        for (; 0 != sec; b--, sec /= 10) {
+            *b = (char)('0' - sec % 10);
+        }
+    } else {
+        for (; 0 < sec; b--, sec /= 10) {
+            *b = '0' + (sec % 10);
+        }
+    }
+    if (neg) {
+        *b-- = '-';
     }
     b++;
     size = sizeof(buf) - (b - buf) - 1;

--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -5,6 +5,7 @@
 
 #include <errno.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -702,17 +703,23 @@ static void end_element(PInfo pi, const char *ename) {
 }
 
 static VALUE parse_double_time(const char *text, VALUE clas) {
-    long        v   = 0;
+    time_t      v   = 0;
     long        v2  = 0;
     const char *dot = 0;
     char        c;
+    bool        neg = false;
 
+    // A time before the epoch is written as a sign followed by the magnitude.
+    if ('-' == *text) {
+        neg = true;
+        text++;
+    }
     for (; '.' != *text; text++) {
         c = *text;
         if (c < '0' || '9' < c) {
             return Qnil;
         }
-        v = 10 * v + (long)(c - '0');
+        v = 10 * v + (time_t)(c - '0');
     }
     dot = text++;
     for (; '\0' != *text && text - dot <= 6; text++) {
@@ -724,6 +731,17 @@ static VALUE parse_double_time(const char *text, VALUE clas) {
     }
     for (; text - dot <= 9; text++) {
         v2 *= 10;
+    }
+    if (neg) {
+        // rb_time_nano_new() wants a non negative nanosecond count, so the
+        // fraction goes back into the second count the way dump_time_thin()
+        // took it out.
+        if (0 == v2) {
+            v = -v;
+        } else {
+            v  = -v - 1;
+            v2 = 1000000000L - v2;
+        }
     }
     return rb_time_nano_new(v, v2);
 }

--- a/ext/ox/sax_as.c
+++ b/ext/ox/sax_as.c
@@ -20,17 +20,23 @@
 #include "sax.h"
 
 static VALUE parse_double_time(const char *text) {
-    long        v   = 0;
+    time_t      v   = 0;
     long        v2  = 0;
     const char *dot = 0;
     char        c;
+    bool        neg = false;
 
+    // A time before the epoch is written as a sign followed by the magnitude.
+    if ('-' == *text) {
+        neg = true;
+        text++;
+    }
     for (; '.' != *text; text++) {
         c = *text;
         if (c < '0' || '9' < c) {
             return Qnil;
         }
-        v = 10 * v + (long)(c - '0');
+        v = 10 * v + (time_t)(c - '0');
     }
     dot = text++;
     for (; '\0' != *text && text - dot <= 6; text++) {
@@ -42,6 +48,17 @@ static VALUE parse_double_time(const char *text) {
     }
     for (; text - dot <= 9; text++) {
         v2 *= 10;
+    }
+    if (neg) {
+        // rb_time_nano_new() wants a non negative nanosecond count, so the
+        // fraction goes back into the second count the way dump_time_thin()
+        // took it out.
+        if (0 == v2) {
+            v = -v;
+        } else {
+            v  = -v - 1;
+            v2 = 1000000000L - v2;
+        }
     }
     return rb_time_nano_new(v, v2);
 }

--- a/test/dump_time_thin_test.rb
+++ b/test/dump_time_thin_test.rb
@@ -1,0 +1,147 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: the thin time format losing every time before the epoch.
+#
+# dump_time_thin() emitted the seconds with `for (; 0 < sec; ...)`, which runs
+# zero times for a negative count, so the whole integer part disappeared:
+#
+#   Ox.dump(Time.at(-14_215_340), mode: :object)  =>  <t>.000000000</t>
+#   Ox.load(that)                                 =>  1970-01-01 00:00:00 UTC
+#
+# No crash and no warning, just 1970 for anything older. This is the default
+# path, since xsd_date defaults to false.
+#
+# The loaders could not read a sign either, so both halves are fixed together.
+# There are two copies of parse_double_time(), one in obj_load.c and one in
+# sax_as.c, and both are covered here.
+#
+# tv_nsec is never negative, so a time before the epoch is a negative second
+# count carrying a positive fraction: Time.at(-0.5) is (-1, 500_000_000). It is
+# written as the magnitude with a sign, "-0.500000000", rather than as those two
+# fields, which would read as -1.5.
+#
+# Covering that turned up a second range defect at the other end. Both loaders
+# accumulated the seconds into a long, which is 32 bits on Windows, so a time
+# past 2038-01-19 came back with its sign flipped. Same two functions, so it is
+# fixed here as well.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'stringio'
+require 'test/unit'
+require 'ox'
+
+class DumpTimeThinTest < ::Test::Unit::TestCase
+  def setup
+    @opts = Ox.default_options
+    Ox.default_options = {mode: :object, xsd_date: false}
+  end
+
+  def teardown
+    Ox.default_options = @opts
+  end
+
+  def body(t)
+    Ox.dump(t).strip[%r{<t>(.*)</t>}, 1]
+  end
+
+  def test_before_the_epoch_keeps_the_seconds
+    assert_equal('-14215340.000000000', body(Time.at(-14_215_340)))
+    assert_equal('-2209021200.000000000', body(Time.at(-2_209_021_200)))
+    assert_equal('-1.000000000', body(Time.at(-1)))
+  end
+
+  def test_before_the_epoch_round_trips
+    [-1, -86_400, -14_215_340, -2_209_021_200, -(2**40), -(2**62)].each do |sec|
+      assert_equal(sec, Ox.load(Ox.dump(Time.at(sec))).to_i, "sec=#{sec}")
+    end
+  end
+
+  # The fraction has to end up on the right side of the decimal point, which is
+  # what makes this more than a sign character.
+  def test_negative_fractions_round_trip
+    [[-1, 500_000], [-2, 250_000], [-1, 999_999], [-1, 1], [0, 1], [1, 500_000]].each do |sec, usec|
+      t = Time.at(sec, usec)
+      assert_equal(t.to_r, Ox.load(Ox.dump(t)).to_r, "Time.at(#{sec}, #{usec})")
+    end
+  end
+
+  def test_negative_fraction_reads_as_a_decimal
+    assert_equal('-0.500000000', body(Time.at(-1, 500_000)))
+    assert_equal('-1.750000000', body(Time.at(-2, 250_000)))
+  end
+
+  # The seconds loop used to emit nothing for zero as well, leaving a bare
+  # ".000000000". It loaded back as zero, so this was only a malformed number,
+  # but it is a number now.
+  def test_the_epoch_has_an_integer_part
+    assert_equal('0.000000000', body(Time.at(0)))
+    assert_equal(0, Ox.load(Ox.dump(Time.at(0))).to_i)
+  end
+
+  # What older versions wrote for the epoch still has to load.
+  def test_a_missing_integer_part_still_loads
+    assert_equal(0, Ox.load('<t>.000000000</t>').to_i)
+  end
+
+  def test_after_the_epoch_is_unchanged
+    assert_equal('1483660687.000000000', body(Time.at(1_483_660_687)))
+    assert_equal('0.000001000', body(Time.at(0, 1)))
+    [1, 86_400, 951_782_400, 2**31, 2**40].each do |sec|
+      assert_equal(sec, Ox.load(Ox.dump(Time.at(sec))).to_i, "sec=#{sec}")
+    end
+  end
+
+  # The loaders accumulated the seconds into a long, which is 32 bits on
+  # Windows, so anything past 2038-01-19 came back with the sign flipped and
+  # anything before 1901-12-13 did the same. Only visible on an LLP64 platform;
+  # long is 64 bits everywhere else ox is built.
+  def test_seconds_outside_32_bits_do_not_wrap
+    {
+      2**31 => '2038-01-19',           # first second a 32 bit long can not hold
+      4_102_444_800 => '2100-01-01',
+      -2_208_988_800 => '1900-01-01',  # magnitude is also past 2**31
+      -(2**40) => '-46-05-11'
+    }.each do |sec, _label|
+      assert_equal(sec, Ox.load(Ox.dump(Time.at(sec))).to_i, "sec=#{sec}")
+      assert_equal(sec, Ox.load("<t>#{sec}.000000000</t>").to_i, "text sec=#{sec}")
+      assert_equal(sec, sax_time("#{sec}.000000000").to_i, "sax sec=#{sec}")
+    end
+  end
+
+  # sax_as.c has its own copy of parse_double_time().
+  def sax_time(s)
+    handler = Class.new(::Ox::Sax) do
+      attr_reader :got
+
+      def attr_value(_name, value)
+        @got = value.as_time
+      end
+    end.new
+    Ox.sax_parse(handler, StringIO.new(%(<top t="#{s}"/>)))
+    handler.got
+  end
+
+  def test_sax_as_time_reads_before_the_epoch
+    assert_equal(-14_215_340, sax_time('-14215340.000000000').to_i)
+    assert_equal(Rational(-1, 2), sax_time('-0.500000000').to_r)
+    assert_equal(1_483_660_687, sax_time('1483660687.000000000').to_i)
+  end
+
+  # A leading '-' must not swallow an xsd time with a negative year, which the
+  # loader hands to parse_xsd_time() instead.
+  def test_negative_year_xsd_time_is_not_taken_as_a_double
+    assert_nothing_raised { Ox.load('<t>-0044-03-15T12:00:00.000000+00:00</t>') }
+  end
+
+  # Text the sign does not make into a number still falls through to Time.parse
+  # and raises there, the same as it always did. Consuming the '-' must not turn
+  # any of it into a silent zero.
+  def test_text_that_is_not_a_number_still_raises
+    ['-', '-abc', 'abc'].each do |s|
+      assert_raise(ArgumentError, s) { Ox.load("<t>#{s}</t>") }
+    end
+  end
+end


### PR DESCRIPTION
Two range defects in the same pair of functions. They are here together because covering the first one is what exposed the second on the Windows cells.

## 1. Nothing before the epoch survived a round trip

`dump_time_thin()` wrote the seconds with

```c
for (; 0 < sec; b--, sec /= 10) {
```

which runs zero times for a negative count, so the whole integer part was dropped.

```ruby
Ox.dump(Time.at(-14_215_340), mode: :object)  # => <t>.000000000</t>
Ox.load(that)                                 # => 1970-01-01 00:00:00
```

No crash and no warning, just 1970 for anything older. This is the default path — `xsd_date` defaults to false — and it is plain integer arithmetic rather than anything the platform supplies, so it happens everywhere.

`parse_double_time()` could not read a sign either. Fixing only the dump side would send `-14215340.000000000` through to the `Time.parse` fallback, which answers with a date in the current month:

```ruby
Time.parse("-14215340.000000000")  # => 2026-08-14 21:53:40 +0900
```

So both halves move together. There are two copies of `parse_double_time()`, in `obj_load.c` and `sax_as.c`, and both are updated.

### How a negative time is written

`tv_nsec` is never negative, so a time before the epoch is a negative second count carrying a positive fraction: `Time.at(-0.5)` is the pair `(-1, 500_000_000)`.

Writing those two fields out as they are would produce `-1.500000000` for a value that is really -0.5. Anything reading the field as a decimal — including a reader that is not ox — would get it wrong. So the fraction is carried over and the magnitude is written with a sign in front of it:

```
Time.at(-1, 500_000)   =>  <t>-0.500000000</t>
Time.at(-2, 250_000)   =>  <t>-1.750000000</t>
Time.at(-14_215_340)   =>  <t>-14215340.000000000</t>
```

The loader reverses it. In the digit loop the seconds are left negative rather than negated, so the most negative `time_t` does not overflow on the way out.

## 2. Both loaders wrapped at 2**31 on Windows

The seconds were accumulated into a `long`. `long` is 32 bits on Windows, so every time past 2038-01-19 came back with its sign flipped.

```ruby
Ox.load(Ox.dump(Time.at(2**31)))  # => -2147483648  (Windows)
```

It was invisible until now because no test dumped a time that large in thin mode. The new test for 1900-01-01 does, since 2209021200 is past 2\*\*31 as well, and that is what the Windows cells caught.

`rb_time_nano_new()` takes a `time_t`, so the accumulator is a `time_t` now. `long` is 64 bits on every other platform ox builds on, so nothing changes there.

## Two smaller changes that come with it

- **The epoch itself.** The same loop emitted nothing for zero, so `Time.at(0)` came out as a bare `.000000000`. It is `0.000000000` now. What older versions wrote still loads, and there is a test pinning that.
- **`-.000000000` now loads as the epoch** instead of raising, matching what `.000000000` already did. Text that does not become a number at all still falls through to `Time.parse` and raises there as before — `<t>-</t>`, `<t>-abc</t>` and `<t>abc</t>` are unchanged.

## Verification

- New `test/dump_time_thin_test.rb`, 11 tests, green in four timezones. On unpatched `develop` 7 of them fail on Linux, and the 32 bit ones fail on Windows.
- **Times between 1970 and 2038 are untouched:** 5008 dumps, integers and fractions, hash to the same SHA-256 before and after.
- Round trip holds at the extremes, including `Time.at(-(2**63))` and `Time.at(2**63 - 1)`.
- An xsd time with a negative year still reaches `parse_xsd_time()` rather than being taken for a signed double — `<t>-0044-03-15T12:00:00.000000+00:00</t>` loads as it did before.
- SAX `as_time` covered too, since it has its own copy of the parser.
- `rake test_all` green. `rake test:valgrind` 322 tests, no leaks and no invalid accesses.
- Under ASAN the new test file produces one report, and it is not from this change: it is the known artifact of `rb_raise` longjmping out of `load_str`'s `ALLOCA_N` frame without `__asan_handle_no_return`, so stale poison is left for whatever uses that stack next. It reproduces on plain `develop` with six lines that touch none of this code, needs the test that raises to run first, and disappears entirely when ox is built without instrumentation.

## Background

Found while checking whether ox has the Windows time handling problem that oj hit in ohler55/oj#1088. The first one turned out not to be Windows specific at all; the second one is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
