### PR TITLE
Fix the out-of-bounds read and write in the base64 decode

### DIFF
--- a/ext/ox/base64.c
+++ b/ext/ox/base64.c
@@ -61,30 +61,30 @@ void to_base64(const uchar *src, int len, char *b64) {
     *b64 = '\0';
 }
 
+// Bytes from_base64() will write, not counting the terminator. It stops where
+// from_base64() stops instead of measuring the string, so the two can not
+// disagree about where the encoding ends.
 unsigned long b64_orig_size(const char *text) {
     const char   *start = text;
-    unsigned long size  = 0;
+    unsigned long cnt;
 
-    if ('\0' != *text) {
-        for (; 0 != *text; text++) {
-        }
-        size = (text - start) * 3 / 4;
-        text--;
-        if ('=' == *text) {
-            size--;
-            text--;
-            if ('=' == *text) {
-                size--;
-            }
-        }
+    for (; 'X' != s_digits[(uchar)*text]; text++) {
     }
-    return size;
+    cnt = (unsigned long)(text - start);
+
+    // Four characters carry three bytes. A trailing pair or triple carries one
+    // or two, a trailing single character none.
+    return cnt / 4 * 3 + (2 <= cnt % 4 ? cnt % 4 - 1 : 0);
 }
 
-void from_base64(const char *b64, uchar *str) {
-    uchar b0, b1, b2, b3;
+// size counts the terminator. It is honoured even if it disagrees with
+// b64_orig_size(), so the two can not drift back into an overflow.
+unsigned long from_base64(const char *b64, uchar *str, unsigned long size) {
+    uchar *start = str;
+    uchar *end   = str + size - 1;
+    uchar  b0, b1, b2, b3;
 
-    while (1) {
+    while (str < end) {
         if ('X' == (b0 = s_digits[(uchar)*b64++])) {
             break;
         }
@@ -92,14 +92,21 @@ void from_base64(const char *b64, uchar *str) {
             break;
         }
         *str++ = (b0 << 2) | ((b1 >> 4) & 0x03);
+        if (end <= str) {
+            break;
+        }
         if ('X' == (b2 = s_digits[(uchar)*b64++])) {
             break;
         }
         *str++ = (b1 << 4) | ((b2 >> 2) & 0x0F);
+        if (end <= str) {
+            break;
+        }
         if ('X' == (b3 = s_digits[(uchar)*b64++])) {
             break;
         }
         *str++ = (b2 << 6) | b3;
     }
     *str = '\0';
+    return (unsigned long)(str - start);
 }

--- a/ext/ox/base64.h
+++ b/ext/ox/base64.h
@@ -13,6 +13,7 @@ typedef unsigned char uchar;
 extern unsigned long b64_orig_size(const char *text);
 
 extern void to_base64(const uchar *src, int len, char *b64);
-extern void from_base64(const char *b64, uchar *str);
+// size counts the terminator, so pass b64_orig_size() + 1.
+extern unsigned long from_base64(const char *b64, uchar *str, unsigned long size);
 
 #endif /* BASE64_H */

--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -400,11 +400,12 @@ static void add_text(PInfo pi, char *text, size_t len, int closed) {
     case TimeCode: h->obj = parse_time(text, ox_time_class); break;
     case String64Code: {
         unsigned long str_size = b64_orig_size(text);
-        VALUE         v;
-        char         *str = ALLOCA_N(char, str_size + 1);
+        // Decode straight into the String. The size comes from the document, so
+        // an ALLOCA_N of it is an unbounded stack allocation, and the heap the
+        // String already needs costs nothing extra.
+        VALUE v = rb_str_new(0, (long)str_size);
 
-        from_base64(text, (uchar *)str);
-        v = rb_str_new(str, str_size);
+        from_base64(text, (uchar *)RSTRING_PTR(v), str_size + 1);
         if (0 != pi->options->rb_enc) {
             rb_enc_associate(v, pi->options->rb_enc);
         }
@@ -417,10 +418,12 @@ static void add_text(PInfo pi, char *text, size_t len, int closed) {
     }
     case Symbol64Code: {
         unsigned long str_size = b64_orig_size(text);
-        char         *str      = ALLOCA_N(char, str_size + 1);
+        VALUE         v        = rb_str_new(0, (long)str_size);
+        char         *str      = RSTRING_PTR(v);
 
-        from_base64(text, (uchar *)str);
+        from_base64(text, (uchar *)str, str_size + 1);
         h->obj = ox_sym_intern(str, strlen(str), NULL);
+        RB_GC_GUARD(v);
         break;
     }
     case RegexpCode:
@@ -428,10 +431,12 @@ static void add_text(PInfo pi, char *text, size_t len, int closed) {
             h->obj = parse_regexp(text);
         } else {
             unsigned long str_size = b64_orig_size(text);
-            char         *str      = ALLOCA_N(char, str_size + 1);
+            VALUE         v        = rb_str_new(0, (long)str_size);
+            char         *str      = RSTRING_PTR(v);
 
-            from_base64(text, (uchar *)str);
+            from_base64(text, (uchar *)str, str_size + 1);
             h->obj = parse_regexp(str);
+            RB_GC_GUARD(v);
         }
         break;
     case BignumCode: h->obj = rb_cstr_to_inum(text, 10, 1); break;

--- a/test/objload_base64_test.rb
+++ b/test/objload_base64_test.rb
@@ -1,0 +1,128 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: the base64 decode path in object mode.
+#
+# add_text() sized a buffer with b64_orig_size() and filled it with
+# from_base64(). The two did not agree, because one measured the whole string
+# and the other stopped at the first character outside the alphabet:
+#
+#   * "AAAA=" measured 2 bytes but decoded 3, so the write and its terminator
+#     went past the end of the buffer
+#   * "=" and "==" took the size below zero, so it wrapped to ULONG_MAX, and
+#     the measuring also read the byte before the string
+#
+# On top of that the size came from the document and went straight into
+# ALLOCA_N, so a large enough element sized an unbounded stack allocation.
+#
+# All three call sites are covered here: <b> String, <d> Symbol and <g> Regexp.
+# Ox itself never writes base64 (USE_B64 is 0 in dump.c), so every one of these
+# documents is hand written, which is exactly the untrusted case.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class ObjLoadBase64Test < ::Test::Unit::TestCase
+  # Base64.strict_encode64 without the require. base64 stopped being a default
+  # gem in Ruby 3.4, so using it here would mean adding it to the Gemfile.
+  def b64(str)
+    [str].pack('m0')
+  end
+
+  def load64(code, text)
+    Ox.parse_obj("<#{code}>#{text}</#{code}>")
+  end
+
+  # Valid base64 has to decode to exactly what it encoded, at every length
+  # around the three character grouping. Verified byte for byte against the
+  # pre-fix behaviour over these same 200 lengths.
+  def test_valid_base64_round_trips
+    (1..200).each do |n|
+      raw = (0...n).map { |i| ((i * 37 + n) & 0xFF).chr }.join
+      assert_equal(raw, load64('b', b64(raw)).b, "length #{n}")
+    end
+  end
+
+  # "AAAA=" is a complete four character group with a stray pad after it. The
+  # decoder stops at the '=' having written three bytes; the size said two.
+  def test_padding_after_a_complete_group
+    assert_equal("\x00\x00\x00".b, load64('b', 'AAAA=').b)
+    assert_equal("\x00\x00\x00".b, load64('b', 'AAAA==').b)
+    assert_equal('hello', load64('b', 'aGVsbG8='))
+  end
+
+  # Nothing decodable before the first pad, which used to take the size below
+  # zero and read one byte in front of the text.
+  def test_padding_only
+    assert_equal('', load64('b', '='))
+    assert_equal('', load64('b', '=='))
+    assert_equal('', load64('b', '==='))
+    assert_equal('', load64('b', '=A'))
+  end
+
+  # A pad in the middle stops the decode there, and a lone leading character
+  # carries no byte at all.
+  def test_truncated_and_interrupted
+    assert_equal('', load64('b', 'A'))
+    assert_equal("\x00".b, load64('b', 'AA').b)
+    assert_equal("\x00\x00".b, load64('b', 'AAA').b)
+    assert_equal('', load64('b', '=AAAA'))
+    assert_equal('', load64('b', 'A=AAAA'))
+    assert_equal('h', load64('b', 'aA=BCDEF'))
+  end
+
+  # Characters outside the alphabet end the encoding, the same as a pad.
+  def test_characters_outside_the_alphabet
+    assert_equal('', load64('b', '!!!!'))
+    assert_equal("\x00".b, load64('b', 'AA!!').b)
+  end
+
+  # The size used to come from the text length and go into ALLOCA_N. A megabyte
+  # of base64 is an ordinary document but was a megabyte of stack.
+  def test_large_input_does_not_use_the_stack
+    raw = 'x' * 1_000_000
+    assert_equal(raw, load64('b', b64(raw)))
+  end
+
+  # Symbols and Regexps decode through the same pair of functions.
+  def test_symbol_and_regexp_paths
+    assert_equal(:foo, load64('d', b64('foo')))
+    assert_equal(:'Ox::Bar', load64('d', b64('Ox::Bar')))
+    assert_equal(/a.c/i, load64('g', b64('/a.c/i')))
+  end
+
+  def test_symbol_survives_bad_padding
+    assert_nothing_raised { load64('d', '=') }
+    assert_nothing_raised { load64('d', 'AAAA=') }
+    assert_equal(:'', load64('d', '='))
+  end
+
+  # A Regexp element only decodes to something usable when the result is a
+  # /.../ literal. Anything else reaches parse_regexp() with no closing slash
+  # to find, and it hands rb_reg_new a negative length. That is its own defect,
+  # unrelated to the decode -- <g>/</g> does it with no base64 at all -- and it
+  # raises the same way before and after this change.
+  def test_regexp_without_a_literal_raises_as_before
+    ['=', 'AAAA=', b64('nope')].each do |text|
+      assert_raise(ArgumentError, text) { load64('g', text) }
+    end
+    assert_raise(ArgumentError) { Ox.parse_obj('<g>/</g>') }
+  end
+
+  # Decoding into the String means the encoding is applied to the object the
+  # bytes already live in rather than to a copy.
+  def test_encoding_is_applied
+    xml = "<b>#{b64('héllo')}</b>"
+    assert_equal(Encoding::UTF_8, Ox.load(xml, mode: :object, encoding: 'UTF-8').encoding)
+  end
+
+  # A base64 String is still registered in the circular reference table.
+  def test_circular_reference_to_a_base64_string
+    a = Ox.parse_obj('<a i="1"><b i="2">aGVsbG8=</b><p i="2"/></a>')
+    assert_equal(%w[hello hello], a)
+    assert_same(a[0], a[1])
+  end
+end


### PR DESCRIPTION
`add_text()` sized a buffer with `b64_orig_size()` and filled it with `from_base64()`. The two disagreed about where the encoding ends, because one measured the whole string and the other stopped at the first character outside the alphabet. Both are reached from a hand written document in object mode, and they are separate violations.

## Out-of-bounds read, from the sizing

```ruby
Ox.parse_obj('<b>=</b>')
```

```
AddressSanitizer: stack-buffer-overflow
READ of size 1
  #1 add_text ext/ox/obj_load.c:402      <- b64_orig_size
```

`b64_orig_size()` stepped back from the end looking for padding. With nothing but padding in the text it walked past the start and read the byte in front of it. Without ASAN the same document raises

```
negative string size (or size too big) (ArgumentError)
```

which is the size having gone below zero and wrapped to `ULONG_MAX` on the way to `rb_str_new`.

## Out-of-bounds write, from the decode

```ruby
Ox.parse_obj('<b>AAAA=</b>')
```

```
AddressSanitizer: dynamic-stack-buffer-overflow
WRITE of size 1
  #1 add_text ext/ox/obj_load.c:406      <- from_base64
```

`"AAAA="` is a complete four character group with a stray pad after it. `from_base64()` stops at the `=` having written three bytes; the buffer was sized for two, so the third byte and the terminator landed past the end. Without ASAN it returns `"\x00\x00"` for what it just decoded as three bytes.

## The fix

`b64_orig_size()` now counts what `from_base64()` will decode instead of measuring the string, so neither steps outside the text and the two stop at the same place by construction. `from_base64()` also takes the buffer size and honours it, so the two drifting apart again can not turn back into an overflow.

## The stack allocation

Separately, the size came from the document and went straight into `ALLOCA_N`. With an 8 MB stack a String element of 8 MB raises

```
stack level too deep (SystemStackError)
```

and 4 MB is the largest that loads. The three call sites decode into a Ruby String instead, and the same 8, 16 and 64 MB elements now load. For `<b>` that also drops a copy, since the String was being built from the buffer anyway.

## Verification

Valid base64 is unaffected:

- Encoding every length from 0 to 300 bytes, the old and new size agree with each other and with the original length in all 301 cases.
- Decoding through `<b>`, `<d>` and `<g>` hashes identically before and after over 209 documents.

Malformed base64:

- Over 400,000 random malformed inputs the old size was short of what gets written 3,256 times; the new one never is.
- Sweeping every string of one to four characters over `"ABZaz09+/=!"` through `<b>` and `<d>`, 32,208 documents, is clean under ASAN. On `develop` that sweep aborts on the 19th, which is `"="`.

New `test/objload_base64_test.rb`, 11 tests. On `develop` three fail and one errors. `rake test_all` green, `rake test:valgrind` 323 tests with no leaks and no invalid accesses.

Ox never writes base64 itself — `USE_B64` is 0 in `dump.c` — so every document that reaches this code is one it did not produce.

## Found while doing this, not fixed here

`parse_regexp()` computes `te = text + strlen(text) - 1`, which points in front of the text when the text is empty, and then passes `te - text - 1` to `rb_reg_new` as a length. For `<g>/</g>` that length is -1 and for an empty decode it is -2, so Ruby raises `negative string size` rather than a parse error. It needs no base64 to reach and it behaves the same before and after this change, so it is left alone here and pinned by a test. Happy to send it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
