### PR TITLE
Fix the name cache pointer held across callbacks and the unchecked allocations

### DIFF
--- a/ext/ox/cache.c
+++ b/ext/ox/cache.c
@@ -117,14 +117,19 @@ static uint64_t hash_calc(const uint8_t *key, size_t len) {
 }
 
 static void rehash(Cache c) {
-    uint64_t osize;
+    uint64_t osize = c->size;
+    Slot    *slots;
     Slot    *end;
     Slot    *sp;
 
-    osize    = c->size;
+    // Growing is only an optimization, and rehash() runs with the lock held, so
+    // on failure keep the current size rather than raising.
+    if (NULL == (slots = realloc((void *)c->slots, sizeof(Slot) * osize * 4))) {
+        return;
+    }
     c->size  = osize * 4;
     c->mask  = c->size - 1;
-    c->slots = realloc((void *)c->slots, sizeof(Slot) * c->size);
+    c->slots = slots;
     memset((Slot *)c->slots + osize, 0, sizeof(Slot) * osize * 3);
     end = (Slot *)c->slots + osize;
     for (sp = (Slot *)c->slots; sp < end; sp++) {
@@ -170,7 +175,10 @@ static VALUE ox_lockless_intern(Cache c, const char *key, size_t len, const char
     }
     rkey = c->form(key, len);
     if (NULL == (b = c->reuse)) {
-        b = calloc(1, sizeof(struct _slot));
+        if (NULL == (b = calloc(1, sizeof(struct _slot)))) {
+            // Nothing modified yet and no lock held, so raising is safe.
+            rb_memerror();
+        }
     } else {
         c->reuse = b->next;
         c->rcnt--;
@@ -232,8 +240,8 @@ static VALUE ox_locking_intern(Cache c, const char *key, size_t len, const char 
         c->rcnt--;
     }
     CACHE_UNLOCK(c);
-    if (NULL == b) {
-        b = calloc(1, sizeof(struct _slot));
+    if (NULL == b && NULL == (b = calloc(1, sizeof(struct _slot)))) {
+        rb_memerror();  // the lock was released above
     }
     rkey    = c->form(key, len);
     b->hash = h;
@@ -267,6 +275,9 @@ Cache ox_cache_create(size_t size, VALUE (*form)(const char *str, size_t len), b
     Cache c     = calloc(1, sizeof(struct _cache));
     int   shift = 0;
 
+    if (NULL == c) {
+        rb_memerror();
+    }
     for (; REHASH_LIMIT < size; size /= 2, shift++) {
     }
     if (shift < MIN_SHIFT) {
@@ -277,9 +288,12 @@ Cache ox_cache_create(size_t size, VALUE (*form)(const char *str, size_t len), b
 #else
     c->mutex = rb_mutex_new();
 #endif
-    c->size  = 1 << shift;
-    c->mask  = c->size - 1;
-    c->slots = calloc(c->size, sizeof(Slot));
+    c->size = 1 << shift;
+    c->mask = c->size - 1;
+    if (NULL == (c->slots = calloc(c->size, sizeof(Slot)))) {
+        free(c);
+        rb_memerror();
+    }
     c->form  = form;
     c->xrate = 1;  // low
     c->mark  = mark;

--- a/ext/ox/sax.c
+++ b/ext/ox/sax.c
@@ -879,16 +879,17 @@ static char read_element_start(SaxDrive dr) {
             }
         }
     }
-    name = str2sym(dr, dr->buf.str, nlen, &ename);
-    if (NULL == ename) {
-        if (sizeof(ebuf) <= nlen) {
-            ename = ox_strndup(dr->buf.str, nlen);
-            efree = true;
-        } else {
-            memcpy(ebuf, dr->buf.str, nlen);
-            ebuf[nlen] = '\0';
-            ename      = ebuf;
-        }
+    name = str2sym(dr, dr->buf.str, nlen, NULL);
+    // ename lives until stack_push() copies it, across the start_element
+    // callback and read_attrs. The cache's key is inside a Slot, which a GC can
+    // retire and a later intern free, so copy it instead.
+    if (sizeof(ebuf) <= nlen) {
+        ename = ox_strndup(dr->buf.str, nlen);
+        efree = true;
+    } else {
+        memcpy(ebuf, dr->buf.str, nlen);
+        ebuf[nlen] = '\0';
+        ename      = ebuf;
     }
     if (dr->has_start_element && 0 >= dr->blocked &&
         (NULL == h || ActiveOverlay == h->overlay || NestOverlay == h->overlay)) {

--- a/test/sax_element_name_test.rb
+++ b/test/sax_element_name_test.rb
@@ -1,0 +1,106 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: the element name read_element_start() carries to stack_push().
+#
+# That name used to come from the name cache as a pointer into a Slot. The Slot
+# is only reachable through the cache, and its lifetime ends when a GC retires
+# it onto the reuse list and a later intern trims that list. In between,
+# read_element_start() holds the pointer across the start_element callback --
+# arbitrary Ruby -- and all of read_attrs. It now copies the name instead.
+#
+# The lengths below cover both copy paths: ebuf for a short name and
+# ox_strndup() for one that does not fit, either side of the 128 byte boundary.
+#
+# The GC stress case is a guard, not a gate: it passes on the unpatched parser
+# too. Whether the freed Slot is the one being read depends on where it lands in
+# the reuse list, which follows the hash of the name, and that could not be
+# forced. What was measured is that the Slot does get retired inside the window.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'stringio'
+require 'test/unit'
+require 'ox'
+
+class SaxElementNameTest < ::Test::Unit::TestCase
+  class Watch < ::Ox::Sax
+    attr_reader :starts, :ends, :errors
+
+    def initialize(gcs = 0)
+      @gcs = gcs
+      @starts = []
+      @ends = []
+      @errors = []
+    end
+
+    def start_element(name)
+      @starts << name
+      @gcs.times { GC.start(full_mark: true, immediate_sweep: true) }
+    end
+
+    def end_element(name)
+      @ends << name
+    end
+
+    def error(message, line, column)
+      @errors << "#{message} @#{line}:#{column}"
+    end
+  end
+
+  def parse(xml, gcs = 0)
+    w = Watch.new(gcs)
+    Ox.sax_parse(w, StringIO.new(xml))
+    w
+  end
+
+  # 34 is the last length the cache keeps in a Slot, 127 the last that fits
+  # ebuf. Both sides of each matter because they pick different copy paths.
+  def test_names_of_every_relevant_length
+    [1, 10, 34, 35, 36, 63, 64, 127, 128, 129, 300].each do |n|
+      name = 'e' + ('x' * (n - 1))
+      w = parse("<r><#{name}/></r>")
+      assert_equal([:r, name.to_sym], w.starts, "length #{n}")
+      assert_equal([name.to_sym, :r], w.ends, "length #{n}")
+      assert_empty(w.errors, "length #{n}")
+    end
+  end
+
+  # The name has to survive the attributes, which intern names of their own.
+  def test_name_survives_many_attributes
+    attrs = (0...300).map { |i| %(a#{i}="v") }.join(' ')
+    w = parse("<r><wrapper #{attrs}><c/></wrapper></r>")
+    assert_equal(%i[r wrapper c], w.starts)
+    assert_equal(%i[c wrapper r], w.ends)
+    assert_empty(w.errors)
+  end
+
+  # And across a callback that collects, which is what retires cache Slots.
+  def test_name_survives_gc_in_the_callback
+    attrs = (0...50).map { |i| %(b#{i}="v") }.join(' ')
+    doc = +'<r>'
+    30.times { |i| doc << "<gc#{i} #{attrs}><c/></gc#{i}>" }
+    doc << '</r>'
+
+    w = parse(doc, 6)
+    assert_empty(w.errors)
+    assert_equal(w.starts.sort, w.ends.sort)
+    30.times { |i| assert_include(w.starts, :"gc#{i}") }
+  end
+
+  # Names that only differ past the cache's key limit must not be confused for
+  # each other, since the copy is what the end tag is matched against.
+  def test_long_names_that_share_a_prefix
+    a = 'p' * 40 + 'a'
+    b = 'p' * 40 + 'b'
+    w = parse("<r><#{a}/><#{b}/></r>")
+    assert_equal([:r, a.to_sym, b.to_sym], w.starts)
+    assert_empty(w.errors)
+  end
+
+  def test_mismatched_end_tag_is_still_reported
+    w = parse('<r><abc></xyz></r>')
+    assert(!w.errors.empty?, 'a mismatched end tag should be reported')
+  end
+end


### PR DESCRIPTION
Two things in the same file pair, both about Slot lifetime.

## 1. `read_element_start()` held a pointer into a cache Slot

`str2sym()` can hand back the cache's own key, a pointer into a malloc'd Slot. `read_element_start()` took it as `ename` and kept it until `stack_push()` copies the name — which is after the `start_element` callback, arbitrary Ruby, and after all of `read_attrs`.

A Slot is reachable only through the cache, and its lifetime ends in two steps that both happen inside that window:

- `ox_cache_mark()` moves a Slot whose `use_cnt` has decayed to 0 onto `c->reuse`
- the next intern frees from the head of that list while `rcnt` is over `REUSE_MAX`

### What I measured, and what I did not

Printing the pointer at each step:

```
str2sym ename=0x...dbd              <- inside Slot 0x...da0
RETIRED fresh slot 0x...da0         <- onto the reuse list, rcnt=12112
stack_push ename=0x...dbd nlen=16   <- the read
FREED fresh slot 0x...da0
```

So `ename` does point inside a Slot, and that Slot does get retired between `str2sym()` and `stack_push()`. Slots are freed throughout a parse — 9,792 of them in one run.

**What I could not force is the free landing between the retire and the read.** In every instance I observed it came after `stack_push()`, as above. Whether it lands earlier depends on where the Slot sits in the reuse list, which follows the hash of the name, and the trim only frees `rcnt - REUSE_MAX` entries from the head. 1,600 windows under ASAN produced no report.

So: the dangling window is measured, the read of freed memory is not demonstrated. I would rather say that plainly than imply a crash I did not produce.

It still does not seem like a pointer worth keeping — its lifetime is decided by a GC and a trim loop, and it is held across arbitrary Ruby. `read_element_start()` already had the copy it needs for when the cache declines to supply a key, so it now always takes that path and asks for no key at all. `sax.c:882` was the only caller passing a non-NULL `keyp`, so nothing else changes.

Worth noting: after this, **no caller anywhere passes a non-NULL `keyp`**. The parameter could come out of `ox_cache_intern`, the two intern variants, `ox_str_intern`, `ox_sym_intern`, `str2sym` and the four `get_name` functions. That is a wider change than a fix wants to be, so I left it — happy to send it if you want it. (`ox_enc_sym`/`ox_enc_name` set `*strp` to the interior of a Ruby String that nothing retains, which has the same shape of problem and would go with it.)

## 2. `cache.c` did not check its allocations

The `realloc` in `rehash()` and the `calloc` for a Slot, the Cache and the slot table were all dereferenced without a check, turning OOM into SIGSEGV instead of NoMemoryError.

As the comment at the top of the file says, these have to stay stdlib allocations rather than `ALLOC_N`, since Ruby's could trigger a GC. So each gets a check instead:

- **`rehash()`** keeps the table at its current size. Growing is only an optimization, and it is called with the lock held, where raising would strand it.
- **the two Slot allocations** call `rb_memerror()`. Neither has modified anything at that point, and neither holds the lock — the locking variant releases it before allocating.
- **`ox_cache_create()`** calls `rb_memerror()`, freeing the Cache first if it is the slot table that failed.

## Verification

New `test/sax_element_name_test.rb`: element names either side of both copy boundaries (34/35 for the cache, 127/128 for `ebuf`), names carried across 300 attributes, names carried across a collecting callback, long names sharing a prefix, and a mismatched end tag still being reported.

**It is a guard rather than a gate — it passes on `develop` too**, for the reason given above.

`rake test_all` green, `rake test:valgrind` 317 tests with no leaks and no invalid accesses, ASAN clean on the new test and on `sax_test.rb`.

The allocation checks have no test, since failing an allocation needs an injector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
