### PR TITLE
Fix Ox.load_file sizing the read from whatever the path reports

### DIFF
--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -11,6 +11,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+// Not defined by every C library, and it is only these three bits.
+#ifndef S_ISREG
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#endif
 
 #include "intern.h"
 #include "ruby.h"
@@ -1030,6 +1037,7 @@ static VALUE load_file(int argc, VALUE *argv, VALUE self) {
     char       *xml;
     FILE       *f;
     off_t       len;
+    struct stat st;
     VALUE       obj;
     struct _err err;
 
@@ -1039,14 +1047,21 @@ static VALUE load_file(int argc, VALUE *argv, VALUE self) {
     if (0 == (f = fopen(path, "r"))) {
         rb_raise(rb_eIOError, "%s\n", strerror(errno));
     }
-    fseek(f, 0, SEEK_END);
-    len = ftello(f);
-    if (SMALL_XML < len) {
-        xml = ALLOC_N(char, len + 1);
-    } else {
-        xml = ALLOCA_N(char, len + 1);
+    // A stream that can not seek leaves len at -1, which allocates nothing and
+    // then asks fread for SIZE_MAX bytes.
+    // Only a regular file has a size worth sizing a read from. A FIFO reports
+    // -1, and a directory can report anything at all, including off_t's
+    // maximum.
+    if (0 != fstat(fileno(f), &st) || !S_ISREG(st.st_mode)) {
+        fclose(f);
+        rb_raise(rb_eIOError, "%s is not a regular file.\n", path);
     }
-    fseek(f, 0, SEEK_SET);
+    len = st.st_size;
+    if (SMALL_XML < len) {
+        xml = ALLOC_N(char, (size_t)len + 1);
+    } else {
+        xml = ALLOCA_N(char, (size_t)len + 1);
+    }
     if ((size_t)len != fread(xml, 1, len, f)) {
         ox_err_set(&err, rb_eLoadError, "Failed to read %ld bytes from %s.\n", (long)len, path);
         obj = Qnil;

--- a/test/load_file_test.rb
+++ b/test/load_file_test.rb
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: Ox.load_file sizing the read from an unchecked ftello().
+#
+# fseek() fails on a stream that can not seek -- a FIFO, a socket, /dev/stdin
+# when stdin is a pipe -- and ftello() then returns -1. load_file() did not
+# check either, so ALLOCA_N(char, len + 1) allocated nothing and fread() was
+# asked for (size_t)-1 bytes into it.
+#
+# On glibc 2.44 that fread returns 0 with EFAULT and writes nothing, so what
+# came out was "Failed to read -1 bytes". Nothing here depends on that: the
+# point is that the size is now checked before it is used.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'fileutils'
+require 'tmpdir'
+require 'test/unit'
+require 'ox'
+
+class LoadFileTest < ::Test::Unit::TestCase
+  def setup
+    @dir = Dir.mktmpdir('ox-load-file')
+    # The memcheck lane runs every file in one process, so do not inherit
+    # whatever mode ran before this.
+    @opts = Ox.default_options
+    Ox.default_options = {mode: nil}
+  end
+
+  def teardown
+    Ox.default_options = @opts
+    FileUtils.remove_entry(@dir)
+  end
+
+  def path(name)
+    File.join(@dir, name)
+  end
+
+  def test_regular_file
+    p = path('doc.xml')
+    File.write(p, '<top><a>x</a></top>')
+    assert_equal('x', Ox.load_file(p).nodes[0].nodes[0])
+  end
+
+  # Bigger than SMALL_XML so it takes the heap path rather than the stack one.
+  def test_file_larger_than_the_stack_threshold
+    p = path('big.xml')
+    File.write(p, "<top>#{'x' * 10_000}</top>")
+    assert_equal(10_000, Ox.load_file(p).nodes[0].size)
+  end
+
+  def test_empty_file
+    p = path('empty.xml')
+    File.write(p, '')
+    assert_nothing_raised { Ox.load_file(p) }
+  end
+
+  def test_missing_file_raises_io_error
+    assert_raise(IOError) { Ox.load_file(path('nope.xml')) }
+  end
+
+  # The case the check is for. Opening the FIFO read-write keeps both ends open
+  # so neither this nor load_file blocks waiting for the other; fopen inside
+  # load_file does not release the GVL, so a writer thread would deadlock.
+  def test_unseekable_stream_raises_instead_of_sizing_from_minus_one
+    omit('no mkfifo on this platform') unless File.respond_to?(:mkfifo)
+
+    p = path('fifo')
+    File.mkfifo(p)
+    holder = File.open(p, File::RDWR | File::NONBLOCK)
+    begin
+      holder.write("<top>#{'A' * 3000}</top>")
+      # Was LoadError "Failed to read -1 bytes" before the size was checked.
+      assert_raise(IOError) { Ox.load_file(p) }
+    ensure
+      holder.close
+    end
+  end
+
+  # fopen succeeds on a directory, and what it then reports as the size is up to
+  # the platform: zero on tmpfs, 64 on macOS, and off_t's maximum on the CI's
+  # Ubuntu, where allocating it hung Ruby 2.7 and 3.0 outright. Asking whether
+  # it is a regular file takes all of that out of the picture.
+  def test_directory_raises
+    assert_raise(IOError) { Ox.load_file(@dir) }
+  end
+end


### PR DESCRIPTION
`load_file()` called `fseek()` and `ftello()` without checking either, then used the result for both the allocation and the read size:

```c
    fseek(f, 0, SEEK_END);
    len = ftello(f);
    ...
    xml = ALLOCA_N(char, len + 1);
    ...
    fread(xml, 1, len, f)
```

Neither number is trustworthy unless the path is a regular file, and `fopen()` opens more than those.

## A stream that can not seek

A FIFO, a socket, `/dev/stdin` when stdin is a pipe — `fseek` fails and `ftello` returns -1. The allocation becomes `ALLOCA_N(char, 0)` and `fread` is asked for `(size_t)-1` bytes.

Measured on glibc 2.44:

```
  fseek=-1 errno=Illegal seek  ftello=-1
  fread(buf,1,18446744073709551615) = 0  errno=Bad address
  canary bytes clobbered: 0 / 64
```

So 1 MB through a FIFO comes out as `LoadError: Failed to read -1 bytes` rather than a smashed frame. **I am not reporting this as a stack overflow, because on this platform it is not one.** That is the kernel refusing a read of `SIZE_MAX` into a mapping that small — not the code being right, and it says nothing about a libc that loops reading in chunks.

## A directory is worse

`fopen()` succeeds on a directory, and the size it then reports is whatever the platform feels like. Three seen while testing this:

| | reported size | what `Ox.load_file(dir)` did |
|---|---|---|
| tmpfs | `fseek` fails | loaded as `nil` |
| macOS | 64 | `LoadError` |
| the CI's Ubuntu | `off_t` max | `len + 1` overflowed to `INT64_MIN` |

On the last one Valgrind reported:

```
Argument 'size' of function malloc has a fishy (possibly negative) value: -9223372036854775808
  malloc (...)
 *load_file (ox.c:1049)
```

And that is not only undefined behaviour. Casting to `size_t` first, so the request became 2^63 rather than a negative, **still hung Ruby 2.7 and 3.0 on Ubuntu outright** — both cells ran past the 20 minute job timeout while every other cell finished in under 30 seconds. So on those versions `Ox.load_file(any_directory)` is enough to stop the process.

## The fix

Rather than keep guessing at the size, ask whether there is one to guess: `fstat` the descriptor and require `S_ISREG`. That covers the FIFO, the directory, sockets and devices in one check, and it takes the answer away from the platform — all of the above raise `IOError` now, everywhere. The size then comes from `st_size`, so the seek to the end is gone too.

`S_ISREG` is defined locally where the C library does not supply it.

## Verification

New `test/load_file_test.rb`: a regular file, one over `SMALL_XML` so it takes the heap path rather than the stack one, an empty file, a missing file, a FIFO, and a directory. **The last two fail on `develop`.**

The FIFO is opened read-write and held for the duration, since `fopen()` inside `load_file()` does not release the GVL and a writer thread would deadlock against it. `File.respond_to?(:mkfifo)` guards the platforms without one.

`rake test_all` green, `rake test:valgrind` 318 tests with no leaks, no invalid accesses and no fishy sizes, ASAN clean.

## Not included

A file that reports size zero but has content — `/proc/self/status`, for instance — is a regular file and still returns `nil`, since the read is sized from `st_size`. Reading the stream instead of sizing it first would fix that, and would also let a FIFO work rather than raise, but that is a change in what `load_file` does rather than a fix. Happy to send it separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
