### PR TITLE
Fix SEGV when an object mode container is not what end_element expects

### DIFF
--- a/ext/ox/helper.h
+++ b/ext/ox/helper.h
@@ -6,14 +6,17 @@
 #ifndef OX_HELPER_H
 #define OX_HELPER_H
 
+#include <stdbool.h>
+
 #include "type.h"
 
 #define HELPER_STACK_INC 16
 
 typedef struct _helper {
-    ID    var;  /* Object var ID */
-    VALUE obj;  /* object created or Qundef if not appropriate */
-    Type  type; /* type of object in obj */
+    ID    var;   /* Object var ID, or a Struct member index when index is set */
+    VALUE obj;   /* object created or Qundef if not appropriate */
+    Type  type;  /* type of object in obj */
+    bool  index; /* var is a member index and not an ID */
 } *Helper;
 
 typedef struct _helperStack {
@@ -58,9 +61,10 @@ inline static Helper helper_stack_push(HelperStack stack, ID var, VALUE obj, Typ
         stack->tail = stack->head + toff;
         stack->end  = stack->head + len + HELPER_STACK_INC;
     }
-    stack->tail->var  = var;
-    stack->tail->obj  = obj;
-    stack->tail->type = type;
+    stack->tail->var   = var;
+    stack->tail->obj   = obj;
+    stack->tail->type  = type;
+    stack->tail->index = false;  // obj_load.c sets its own
     stack->tail++;
 
     return stack->tail - 1;

--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -17,6 +17,9 @@
 #include "ruby.h"
 #include "ruby/encoding.h"
 
+// No Struct has this many members, so a larger index is always out of range.
+#define MAX_STRUCT_INDEX (1 << 24)
+
 static void instruct(PInfo pi, const char *target, Attr attrs, const char *content);
 static void add_text(PInfo pi, char *text, size_t len, int closed);
 static void add_element(PInfo pi, const char *ename, Attr attrs, int hasChildren);
@@ -27,7 +30,7 @@ static VALUE parse_xsd_time(const char *text, VALUE clas);
 static VALUE parse_double_time(const char *text, VALUE clas);
 static VALUE parse_regexp(const char *text);
 
-static ID            get_var_sym_from_attrs(Attr a, void *encoding);
+static ID            get_var_sym_from_attrs(Attr a, void *encoding, bool *indexp);
 static VALUE         get_obj_from_attrs(Attr a, PInfo pi, VALUE base_class);
 static VALUE         get_class_from_attrs(Attr a, PInfo pi, VALUE base_class);
 static VALUE         classname2class(const char *name, PInfo pi, VALUE base_class);
@@ -179,13 +182,30 @@ static VALUE classname2class(const char *name, PInfo pi, VALUE base_class) {
     return clas;
 }
 
-static ID get_var_sym_from_attrs(Attr a, void *encoding) {
+// Returns a Struct member index as a Fixnum or an instance variable ID. An ID
+// is odd, so it satisfies FIXNUM_P too; indexp says which one it is.
+static ID get_var_sym_from_attrs(Attr a, void *encoding, bool *indexp) {
+    *indexp = false;
     for (; 0 != a->name; a++) {
         if ('a' == *a->name && '\0' == *(a->name + 1)) {
             const char *val = a->value;
 
             if ('0' <= *val && *val <= '9') {
-                return INT2NUM(atoi(val));
+                // atoi() wrapped past INT_MAX into a negative index, which Ruby
+                // counts from the end. Stopping at INT_MAX is no good either:
+                // FIXNUM_MAX is 2**30 - 1 where long is 32 bits, and INT2NUM of
+                // INT_MAX came back as -1 there.
+                int i = 0;
+
+                for (; '0' <= *val && *val <= '9'; val++) {
+                    i = i * 10 + (*val - '0');
+                    if (MAX_STRUCT_INDEX < i) {
+                        i = MAX_STRUCT_INDEX;
+                        break;
+                    }
+                }
+                *indexp = true;
+                return (ID)INT2NUM(i);
             }
             return ox_id_intern(val, strlen(val));
         }
@@ -442,7 +462,20 @@ static void add_text(PInfo pi, char *text, size_t len, int closed) {
         break;
     case BignumCode: h->obj = rb_cstr_to_inum(text, 10, 1); break;
     case BigDecimalCode: h->obj = rb_funcall(rb_cObject, ox_bigdecimal_id, 1, rb_str_new2(text)); break;
-    default: h->obj = Qnil; break;
+    default: {
+        // The rest are containers add_element() built. Replacing one with Qnil
+        // left end_element() reading the nil back as an Array or a Struct.
+        // skip_off delivers the indentation between children here.
+        size_t i;
+
+        for (i = 0; i < len; i++) {
+            if (' ' != text[i] && '\t' != text[i] && '\n' != text[i] && '\r' != text[i]) {
+                set_error(&pi->err, "Unexpected text", pi->str, pi->s);
+                return;
+            }
+        }
+        break;
+    }
     }
 }
 
@@ -450,6 +483,8 @@ static void add_element(PInfo pi, const char *ename, Attr attrs, int hasChildren
     Attr          a;
     Helper        h;
     unsigned long id;
+    bool          index;
+    ID            var;
 
     if (TRACE <= pi->options->trace) {
         char  buf[1024];
@@ -480,7 +515,9 @@ static void add_element(PInfo pi, const char *ename, Attr attrs, int hasChildren
         set_error(&pi->err, "Invalid element name", pi->str, pi->s);
         return;
     }
-    h = helper_stack_push(&pi->helpers, get_var_sym_from_attrs(attrs, (void *)pi->options->rb_enc), Qundef, *ename);
+    var      = get_var_sym_from_attrs(attrs, (void *)pi->options->rb_enc, &index);
+    h        = helper_stack_push(&pi->helpers, var, Qundef, *ename);
+    h->index = index;
     switch (h->type) {
     case NilClassCode: h->obj = Qnil; break;
     case TrueClassCode: h->obj = Qtrue; break;
@@ -553,7 +590,12 @@ static void add_element(PInfo pi, const char *ename, Attr attrs, int hasChildren
         }
         break;
     case StructCode:
-        h->obj = get_struct_from_attrs(attrs);
+        // Returns Qundef with no c attribute and, unlike the helpers above, does
+        // not set the error itself. The Qundef reached rb_struct_aset().
+        if (Qundef == (h->obj = get_struct_from_attrs(attrs))) {
+            set_error(&pi->err, "Invalid element for object mode", pi->str, pi->s);
+            return;
+        }
         if (0 != pi->circ_array) {
             circ_array_set(pi->circ_array, h->obj, get_id_from_attrs(pi, attrs));
         }
@@ -620,7 +662,9 @@ static void end_element(PInfo pi, const char *ename) {
             case ExceptionCode:
             case ObjectCode:
                 if (Qnil != ph->obj) {
-                    if (0 == h->var || NULL == rb_id2name(h->var)) {
+                    // An index is a valid ID too, so a numeric a attribute set an
+                    // instance variable named whatever was interned in that slot.
+                    if (0 == h->var || h->index || NULL == rb_id2name(h->var)) {
                         set_error(&pi->err, "Invalid element for object mode", pi->str, pi->s);
                         return;
                     }
@@ -632,7 +676,9 @@ static void end_element(PInfo pi, const char *ename) {
                 }
                 break;
             case StructCode:
-                if (0 == h->var) {
+                // An ID landed in rb_struct_aset() as a Fixnum, so a name picked
+                // whichever member that number happened to be.
+                if (0 == h->var || !h->index) {
                     set_error(&pi->err, "Invalid element for object mode", pi->str, pi->s);
                     return;
                 }
@@ -640,9 +686,14 @@ static void end_element(PInfo pi, const char *ename) {
                 break;
             case HashCode:
                 // put back h
-                helper_stack_push(&pi->helpers, h->var, h->obj, KeyCode);
+                helper_stack_push(&pi->helpers, h->var, h->obj, KeyCode)->index = h->index;
                 break;
             case RangeCode:
+                // An index can equal one of these IDs, so turn it away first.
+                if (h->index) {
+                    set_error(&pi->err, "Invalid range attribute", pi->str, pi->s);
+                    return;
+                }
                 if (ox_beg_id == h->var) {
                     rb_ary_store(ph->obj, 0, h->obj);
                 } else if (ox_end_id == h->var) {
@@ -834,7 +885,7 @@ static void debug_stack(PInfo pi, const char *comment) {
                 clas = rb_class2name(c);
             }
             if (0 != h->var) {
-                if (HashCode == h->type) {
+                if (h->index) {
                     VALUE v;
 
                     v   = rb_String(h->var);

--- a/test/objload_container_test.rb
+++ b/test/objload_container_test.rb
@@ -1,0 +1,167 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: object-mode containers that end_element() dereferences
+# without checking what they hold.
+#
+# add_element() builds the container -- an Array for <a>, a Hash for <h>, three
+# slots for <r>, a Struct for <u> -- and end_element() then uses it as that type.
+# Three ways the container was not what it expected:
+#
+#   * add_text()'s default arm set h->obj = Qnil for every container type, so
+#     text anywhere inside one left end_element() reading a nil back. <r>x</r>
+#     alone segfaulted in RARRAY_PTR.
+#   * skip: :skip_off hands the indentation between children to add_text(), so
+#     the same nil landed under Ox.dump's own output.
+#   * get_struct_from_attrs() returns Qundef when there is no c attribute to
+#     name the Struct, and StructCode was the one arm not checking for it.
+#
+# The fourth is a type mixup rather than a container: get_var_sym_from_attrs()
+# returns a Struct member index or an instance variable ID through one ID slot,
+# and an ID is odd, so it satisfies FIXNUM_P and passed for an index.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class ObjLoadContainerTest < ::Test::Unit::TestCase
+  # Named so it lands in Struct, which is the only place Ox looks a Struct up.
+  Struct.new('OxPoint', :x, :y) unless Struct.const_defined?(:OxPoint)
+  POINT = Struct::OxPoint
+
+  CONTAINERS = {
+    'Array'  => '<a>%s</a>',
+    'Hash'   => '<h>%s</h>',
+    'Range'  => '<r>%s</r>',
+    'Struct' => '<u c="Struct::OxPoint">%s</u>',
+  }.freeze
+
+  def setup
+    # The memcheck lane runs every file in one process, so do not inherit
+    # whatever mode ran before this.
+    @opts = Ox.default_options
+    Ox.default_options = {mode: :object}
+  end
+
+  def teardown
+    Ox.default_options = @opts
+  end
+
+  # Was a segfault for <r>, and a silent nil for the rest.
+  def test_text_inside_a_container_raises
+    CONTAINERS.each do |name, doc|
+      assert_raise(Ox::ParseError, "#{name} must reject text") { Ox.parse_obj(doc % 'x') }
+    end
+  end
+
+  def test_text_before_a_child_raises
+    CONTAINERS.each do |name, doc|
+      assert_raise(Ox::ParseError, "#{name} must reject text") do
+        Ox.parse_obj(doc % 'x<i>1</i>')
+      end
+    end
+  end
+
+  # A container nested in another container has to fail the same way rather than
+  # taking the parent down with it.
+  def test_text_inside_a_nested_container_raises
+    assert_raise(Ox::ParseError) { Ox.parse_obj('<a><r>x</r></a>') }
+    assert_raise(Ox::ParseError) { Ox.parse_obj('<h><r>x</r><i>1</i></h>') }
+  end
+
+  # skip_off delivers the indentation between children as text. Every one of
+  # these segfaulted, on Ox's own output.
+  def test_indented_output_round_trips_with_skip_off
+    # Setting the options replaces mode rather than merging it, so each call has
+    # to name every option it needs.
+    Ox.default_options = {mode: :object, indent: 2}
+    values = [[1, 2], {1 => 2}, (1..2), POINT.new(1, 2), Complex(1, 2), Rational(1, 2)]
+    dumped = values.map { |v| Ox.dump(v) }
+
+    Ox.default_options = {mode: :object, skip: :skip_off}
+    values.zip(dumped) { |v, xml| assert_equal(v, Ox.load(xml), "round trip of #{v.inspect}") }
+  end
+
+  # get_struct_from_attrs() returns Qundef here, which reached rb_struct_aset().
+  def test_struct_without_a_class_attribute_raises
+    assert_raise(Ox::ParseError) { Ox.parse_obj('<u><i a="0">1</i></u>') }
+    assert_raise(Ox::ParseError) { Ox.parse_obj('<u><i a="x">1</i></u>') }
+    assert_raise(Ox::ParseError) { Ox.parse_obj('<u/>') }
+  end
+
+  # An ID passed to rb_struct_aset() became FIX2LONG of itself, so a named
+  # member picked whichever slot that number happened to be and the IndexError
+  # reported the internal value.
+  def test_struct_member_named_instead_of_numbered_raises
+    %w[x foo @x].each do |name|
+      assert_raise(Ox::ParseError, "member #{name.inspect} must be rejected") do
+        Ox.parse_obj(%(<u c="Struct::OxPoint"><i a="#{name}">1</i></u>))
+      end
+    end
+  end
+
+  # atoi() wrapped these into a negative index, and Ruby counts a negative index
+  # from the end of the struct, so "2147483648" wrote to the last member. The
+  # values around 2**30 and 2**31 are here because FIXNUM_MAX is 2**30 - 1 where
+  # long is 32 bits, so an index that big can not be handed to INT2NUM.
+  def test_struct_index_past_int_max_does_not_wrap_negative
+    ['16777217', '1073741823', '1073741824', '2147483647',
+     '2147483648', '4294967296', '99999999999999999999'].each do |i|
+      err = assert_raise(IndexError, "index #{i} must not wrap") do
+        Ox.parse_obj(%(<u c="Struct::OxPoint"><i a="#{i}">1</i></u>))
+      end
+      assert_match(/too large/, err.message, "index #{i} became negative")
+    end
+  end
+
+  # A numeric attribute became INT2NUM(n), which is odd and so is a valid ID.
+  # Reaching rb_ivar_set() it named whatever had been interned into that slot.
+  def test_numeric_attribute_does_not_set_an_instance_variable
+    (1..40_000).step(1777) do |n|
+      assert_raise(Ox::ParseError, "a=#{n} must be rejected") do
+        Ox.parse_obj(%(<o c="Object"><i a="#{n}">1</i></o>))
+      end
+    end
+  end
+
+  # Same collision on the other side: <r> compares the attribute against @beg,
+  # @end and @excl, and an index can equal one of those IDs.
+  def test_numeric_attribute_is_not_a_range_bound
+    (1..40_000).step(1777) do |n|
+      assert_raise(Ox::ParseError, "a=#{n} must be rejected") do
+        Ox.parse_obj(%(<r><i a="#{n}">1</i><i a="@end">2</i></r>))
+      end
+    end
+  end
+
+  # Everything below must keep working.
+
+  def test_containers_still_load
+    assert_equal([1, 2], Ox.parse_obj('<a><i>1</i><i>2</i></a>'))
+    assert_equal({1 => 2}, Ox.parse_obj('<h><i>1</i><i>2</i></h>'))
+    assert_equal((1..2), Ox.parse_obj('<r><i a="@beg">1</i><i a="@end">2</i><n a="@excl"/></r>'))
+    assert_equal(POINT.new(1, 2),
+                 Ox.parse_obj('<u c="Struct::OxPoint"><i a="0">1</i><i a="1">2</i></u>'))
+  end
+
+  def test_empty_containers_still_load
+    assert_equal([], Ox.parse_obj('<a/>'))
+    assert_equal({}, Ox.parse_obj('<h/>'))
+  end
+
+  def test_instance_variables_still_load
+    o = Ox.parse_obj('<o c="Object"><i a="@a">1</i></o>')
+    assert_equal(1, o.instance_variable_get(:@a))
+  end
+
+  # The index parse stops at INT_MAX rather than at the first non digit, so a
+  # leading zero and a plain in range index have to keep working.
+  def test_struct_index_forms_that_stay_valid
+    doc = '<u c="Struct::OxPoint"><i a="%s">1</i></u>'
+    assert_equal(POINT.new(1, nil), Ox.parse_obj(doc % '0'))
+    assert_equal(POINT.new(1, nil), Ox.parse_obj(doc % '00'))
+    assert_equal(POINT.new(nil, 1), Ox.parse_obj(doc % '1'))
+  end
+end


### PR DESCRIPTION

`add_element()` builds the container — an Array for `<a>`, a Hash for `<h>`, three slots for `<r>`, a Struct for `<u>` — and `end_element()` then uses it as that type without asking. Three ways it was not that type.

## Text inside a container

`add_text()`'s `default:` arm set `h->obj = Qnil` for every container type, so text anywhere inside one replaced the container with a nil that `end_element()` then read back as an Array, a Hash or a Struct.

```
Ox.parse_obj('<r>x</r>')

[BUG] Segmentation fault at 0x0000000000000004
  ox.so(rb_array_const_ptr) rarray.h:301
  ox.so(RARRAY_PTR) rarray.h:371
  ox.so(end_element) obj_load.c:612
```

No options at all — `0x4` is `Qnil`.

## A Struct with no class to build

`get_struct_from_attrs()` returns `Qundef` when there is no `c` attribute to name the Struct. `ObjectCode`, `ExceptionCode` and `ClassCode` all check their helper for `Qundef`; `StructCode` was the one arm that did not, and the `Qundef` went to `rb_struct_aset()`.

```
Ox.parse_obj('<u><i a="0">1</i></u>')

[BUG] Segmentation fault at 0x0000000000000024
  libruby(internal_RSTRUCT_LEN) internal/struct.h:94
  libruby(rb_struct_pos) struct.c:1196
```

Also no options. **This one is not in the report** — it turned up while writing the regression test for the first.

## Ox cannot read its own output under skip_off

`skip: :skip_off` hands the indentation between children to `add_text()`, so the container became `Qnil` on a document Ox itself wrote:

| dumped with `indent: 2` | loaded with `skip: :skip_off` |
|---|---|
| `<a>\n  <i>1</i>\n  <i>2</i>\n</a>` | SIGSEGV at `obj_load.c:619`, `rb_ary_push` |
| `<h>\n  <i>1</i>\n  <i>2</i>\n</h>` | SIGSEGV, `rb_hash_aset` |
| `<u c="…">\n  <i a="0">1</i>…</u>` | SIGSEGV, `rb_struct_aset` |
| `<r>\n  <i a="@beg">1</i>…</r>` | SIGSEGV, `RARRAY_PTR` |

## Measured

1092 container shaped documents against both skip settings, each in its own process so one crash does not hide the next:

| | runs | died on a signal |
|---|---|---|
| develop | 2184 | **122** (35 of them with default options) |
| this branch | 2184 | **0** |

## The fix for those three

`add_text()` no longer replaces a container. Whitespace is ignored, since that is what `skip_off` delivers between children, and anything else is a parse error. `StructCode` checks for `Qundef` like the three arms next to it.

---

## A separate mixup in the same two functions

`get_var_sym_from_attrs()` returns **either** a Struct member index as a Fixnum **or** an instance variable ID, both through one `ID` typed slot, and the caller could not tell which it got.

`rb_intern` hands back a static symbol ID, which always has `RUBY_ID_STATIC_SYM` set and so is always odd. Measured for `"x"`:

| Ruby | 3.0.7 | 3.2.11 | 3.3.12 | 3.4.9 | 4.0.6 |
|---|---|---|---|---|---|
| `rb_intern("x")` | 39489 | 49073 | 56465 | 57201 | 48001 |
| `FIXNUM_P((VALUE)id)` | 1 | 1 | 1 | 1 | 1 |

So `(VALUE)id` passes `FIXNUM_P` on every supported Ruby and the two forms are indistinguishable. An ID reaching `rb_struct_aset()` was therefore read as `FIX2LONG` of itself:

```
Ox.parse_obj('<u c="Struct::Point"><i a="x">1</i></u>')
IndexError: offset 24000 too large for struct(size:2)
```

and an index reaching `rb_ivar_set()` named whatever had been interned into that slot:

```
Ox.parse_obj('<o c="Object"><i a="24001">1</i></o>')
#<Object:0x00007fa04d109380 x=1>
```

**The report has the mechanism wrong on this one.** It says the ID is dereferenced as an object pointer because local IDs are small even multiples of 8. No Ruby from 3.0 to 4.0 produces an even local ID, so the value is always a Fixnum and never dereferenced. What actually happens is that it picks the wrong member and prints an internal number in the error. I am not reporting it as a crash or as type confusion.

Which form it is now comes back in a separate argument and is kept in the helper, so a name is turned away from a Struct, a number from an instance variable, and a number from a Range bound — `<r>` compares the attribute against `ox_beg_id`, `ox_end_id` and `ox_excl_id`, and since those are odd an index can equal one.

The index parse also stopped using `atoi()`, which saturates at `LONG_MAX`; the truncation to `int` gave `-1`, and Ruby counts a negative index from the end:

```
Ox.parse_obj('<u c="Struct::Point"><i a="99999999999999999999">1</i></u>')
#<struct Struct::Point x=nil, y=1>
```

Saturating at `INT_MAX` instead was still wrong, and **only on Windows** — every windows cell of the first run of this PR failed with

```
Ox.parse_obj('<u c="Struct::Point"><i a="2147483648">1</i></u>')
IndexError: offset -1 too small for struct(size:2)
```

`FIXNUM_MAX` is `2**30 - 1` where `long` is 32 bits, so `INT_MAX` is past what `INT2NUM` can represent there and it came back as `-1`. The parse now stops at `2**24`, which no Struct reaches, so no valid index is ever clamped and the value stays well inside Fixnum on every platform.

## Verification

New `test/objload_container_test.rb` — the three container shapes, the `skip_off` round trip, both attribute forms and the index bound, plus the valid documents each rejection could over reach into. **It exits 139 on develop.**

`rake test_all` 100 tests green, `rake test:valgrind` 364 tests with no leaks and no invalid accesses, `clang-format` clean.

## About the ASAN report

ASAN reports a `dynamic-stack-buffer-overflow` in `to_obj()` while running the new test. **That is the known artifact, not a finding.** An exception raised inside the parse longjmps past `to_obj()`'s `ALLOCA_N` frame, GCC never runs `__asan_allocas_unpoison`, and the next parse trips the stale poison. `ox.c:729` allocates `len` bytes and copies exactly `len`, so it cannot overflow by construction. `develop` reports the same thing for the same script, and the already merged `test/objload_base64_test.rb` reports it too.

## Not included

`Ox.default_options=` resets `mode` and `encoding` when the key is absent but leaves `indent` and `trace` alone (`set_def_opts` in `ox.c`). That surprised me while writing the test and the test works around it. It is a separate question from this fix, so I have left it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
