### PR TITLE
Fix the heap overflow and the stale element name in dump_gen_element

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -1126,6 +1126,11 @@ static void dump_gen_element(VALUE obj, int depth, Out out) {
         indent = depth * out->indent;
     }
     size = indent + 4 + nlen + out->opts->margin_len;
+    if (0 == depth && 0 < out->indent) {
+        // The margin is written here and again by fill_indent(), so reserve it
+        // twice.
+        size += out->opts->margin_len;
+    }
     if (out->end - out->cur <= (long)size) {
         grow(out, size);
     }
@@ -1139,11 +1144,24 @@ static void dump_gen_element(VALUE obj, int depth, Out out) {
     if (Qnil != attrs) {
         rb_hash_foreach(attrs, dump_gen_attr, (VALUE)out);
     }
+    // The attribute loop runs Ruby, so both the reservation above and the name
+    // pointer are spent: dump_gen_attr() calls rb_String() on each value, and
+    // growing the name String there frees the buffer name points at.
+    name = StringValuePtr(rname);
+    nlen = RSTRING_LEN(rname);
+    size = indent + 5 + nlen + out->opts->margin_len;
+    if (out->end - out->cur <= (long)size) {
+        grow(out, size);
+    }
     if (Qnil != nodes && 0 < RARRAY_LEN(nodes)) {
         int do_indent;
 
         *out->cur++ = '>';
         do_indent   = dump_gen_nodes(nodes, depth, out);
+        // The children run Ruby as well.
+        name = StringValuePtr(rname);
+        nlen = RSTRING_LEN(rname);
+        size = indent + 5 + nlen + out->opts->margin_len;
         if (out->end - out->cur <= (long)size) {
             grow(out, size);
         }

--- a/test/dump_gen_element_test.rb
+++ b/test/dump_gen_element_test.rb
@@ -1,0 +1,148 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: dump_gen_element() writing past its output buffer, and
+# writing through an element name that Ruby moved out from under it.
+#
+# The reservation at the top of the function covers the opening tag only, and
+# three things then wrote without a fresh one:
+#
+#   * the :no_empty branch wrote "></" + name + ">" after the attribute loop had
+#     already spent the reservation. dump_gen_attr() reserves only its own
+#     bytes, so it can return with out->cur == out->end.
+#   * at depth 0 the margin is written once directly and once inside
+#     fill_indent(), but was reserved once.
+#   * name = StringValuePtr(rname) was taken before rb_hash_foreach(), which
+#     calls rb_String() on every attribute value and so runs arbitrary Ruby.
+#     Growing the name String there reallocs it and the closing tag was written
+#     from the freed buffer.
+#
+# The first two abort the process on glibc with "realloc(): invalid next size".
+# The third does not: it puts freed heap bytes in the output XML, which is what
+# the assertions below look at.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class DumpGenElementTest < ::Test::Unit::TestCase
+  # Called through rb_String() from dump_gen_attr, inside rb_hash_foreach, and
+  # so from inside the dump.
+  class Grower
+    def initialize(str)
+      @str = str
+    end
+
+    def to_s
+      @str << ('B' * 100_000)
+      'v'
+    end
+  end
+
+  def setup
+    # The memcheck lane runs every file in one process, so do not inherit
+    # whatever options ran before this.
+    @opts = Ox.default_options
+  end
+
+  def teardown
+    Ox.default_options = @opts
+  end
+
+  # The reservation counts the name once and the :no_empty branch writes it
+  # twice, so a name long enough to fill the initial 65336 byte buffer past the
+  # halfway point is on its own enough. No attributes and no options but
+  # :no_empty.
+  def test_no_empty_closing_tag_of_a_long_name
+    [32_700, 40_000, 60_000].each do |nlen|
+      name = 'a' * nlen
+      assert_equal("\n<#{name}></#{name}>\n", Ox.dump(Ox::Element.new(name), no_empty: true))
+    end
+  end
+
+  # The attribute value is sized so the attribute loop leaves out->cur just
+  # short of out->end, which is where the unchecked closing tag overflows.
+  def test_no_empty_closing_tag_does_not_overrun_the_buffer
+    name = 'a' * 200
+
+    (64_800..65_120).step(7) do |vlen|
+      el = Ox::Element.new(name)
+      el['k'] = 'v' * vlen
+      xml = Ox.dump(el, no_empty: true)
+
+      assert(xml.start_with?("\n<#{name} k=\""), "value length #{vlen}")
+      assert(xml.end_with?("\"></#{name}>\n"), "value length #{vlen}")
+    end
+  end
+
+  # A margin longer than the 13 bytes of slack the old reservation happened to
+  # leave. The first node sizes the buffer so the second element starts near the
+  # end of it.
+  def test_margin_at_depth_zero_is_reserved_for_both_writes
+    margin = ' ' * 126
+    name   = 'e' * 60
+
+    (64_700..65_000).step(7) do |fill|
+      doc = Ox::Document.new
+      a   = Ox::Element.new('a')
+      a << ('x' * fill)
+      doc << a
+      doc << Ox::Element.new(name)
+      xml = Ox.dump(doc, margin: margin, indent: 2, with_xml: false)
+
+      assert(xml.end_with?("#{margin}<#{name}/>\n"), "filler length #{fill}")
+    end
+  end
+
+  # The name has to be long enough to be heap allocated rather than embedded in
+  # the RVALUE, so 1000 bytes and not 100.
+  def test_name_moved_by_the_attribute_loop_is_not_written_from_freed_memory
+    el = Ox::Element.new('a' * 1000)
+    el.attributes[:k] = Grower.new(el.value)
+
+    xml = Ox.dump(el, no_empty: true)
+
+    # el.value is the grown name by now, since to_s ran during the dump.
+    assert(xml.end_with?("></#{el.value}>\n"), 'closing tag is not the element name')
+  end
+
+  # Same, with the closing tag written by the nodes branch instead.
+  def test_name_moved_before_the_closing_tag_of_a_parent
+    el = Ox::Element.new('a' * 1000)
+    el << 'text'
+    el.attributes[:k] = Grower.new(el.value)
+
+    xml = Ox.dump(el)
+
+    assert(xml.end_with?("</#{el.value}>\n"), 'closing tag is not the element name')
+  end
+
+  # Everything below must keep working.
+
+  def test_plain_element_unchanged
+    el = Ox::Element.new('top')
+    el['a'] = '1'
+    el << 'text'
+    assert_equal(%(\n<top a="1">text</top>\n), Ox.dump(el))
+  end
+
+  def test_empty_element_forms
+    el = Ox::Element.new('top')
+    assert_equal("\n<top/>\n", Ox.dump(el))
+    assert_equal("\n<top></top>\n", Ox.dump(el, no_empty: true))
+  end
+
+  def test_margin_and_indent_unchanged
+    doc = Ox::Document.new
+    doc << Ox::Element.new('a')
+    doc << Ox::Element.new('b')
+    assert_equal("--\n--<a/>--\n--<b/>\n", Ox.dump(doc, margin: '--', indent: 2, with_xml: false))
+  end
+
+  def test_nested_elements_round_trip
+    xml = "<top>\n  <a x=\"1\">t</a>\n  <b/>\n</top>\n"
+    assert_equal("\n#{xml}", Ox.dump(Ox.parse(xml), indent: 2))
+  end
+end


### PR DESCRIPTION

The reservation at the top of `dump_gen_element()` covers the opening tag, and three things then wrote without a fresh one.

## A long element name is enough on its own

No attributes, no options but `:no_empty`:

```
Ox.dump(Ox::Element.new('a' * 32666), no_empty: true)

Fatal glibc error: malloc.c:2199 (sysmalloc): assertion failed:
  (old_top == initial_top (av) && old_size == 0)
```

32665 comes back fine at 65337 bytes. The reservation counts the name once and the `:no_empty` branch writes it twice, so the second write leaves the 65336 byte buffer as soon as two names no longer fit in it.

Attributes make it worse rather than being required. `dump_gen_attr()` reserves only its own bytes, so it can return with `out->cur == out->end` and then any name at all overruns. Under ASAN, a 200 byte name with a 65018 byte attribute value:

```
heap-buffer-overflow, WRITE of size 200
  fill_value        ext/ox/dump.c:185
  dump_gen_element  ext/ox/dump.c:1157
```

## The margin has the same shape

At depth 0 the margin is written once directly and once inside `fill_indent()`, but reserved once. A margin longer than the 13 bytes of slack the old reservation happened to leave writes out of bounds:

```
heap-buffer-overflow, WRITE of size 60
  fill_value        ext/ox/dump.c:185
  dump_gen_element  ext/ox/dump.c:1138
```

## The name can be freed mid-dump

`name = StringValuePtr(rname)` was taken before `rb_hash_foreach()`, which calls `rb_String()` on every attribute value and so runs arbitrary Ruby. Growing the name String there reallocs it, and the closing tag was written from the freed buffer:

```
heap-use-after-free, READ of size 1000
  fill_value        ext/ox/dump.c:185
  dump_gen_element  ext/ox/dump.c:1157
```

**This one does not abort.** It puts the freed bytes in the output XML, so it is an information disclosure rather than a crash:

```
"aaaaaaaaa k=\"v\"></\xC8\xDA\xA4\xB3F\x7F"
```

The appendix B entry for this says the nodes branch was not reached. It is — the same input with a child node reports the same use-after-free through `dump_gen_nodes()`, because the children run Ruby as well.

The precondition is an application that puts a non-String into `@attributes` directly, bypassing `[]=` (which would force it through `to_s` before the dump). That is a footgun rather than an attacker path, and the fix is the same either way.

## The fix

Reserve the margin twice where it is written twice, and take the name and the capacity again before the closing tag in every branch. 18 lines, no deletions.

## Measured

A grid of 400 cases over name length, attribute value length, margin length and indent, under ASAN with `halt_on_error=0` and `suppress_equal_pcs=0` so one process reports them all:

| | out of bounds accesses |
|---|---|
| develop | **243** |
| this branch | **0** |

Sites on develop: `fill_value` (63), the three closing tag writes in `dump_gen_element` (152), `fill_indent` (14), the opening name write (14).

**The output for valid documents is unchanged**: 6 documents × 4 margins × 4 indents × `:no_empty` × `:with_xml`, 320 cases, SHA-256 identical to develop.

## Verification

New `test/dump_gen_element_test.rb`, 9 tests. The first two shapes abort the process on develop — `realloc(): invalid next size` and a SIGSEGV — and the crash reporter then hangs on the corrupted heap, so run them one at a time to see both. The two use-after-free tests fail as plain assertions there, since the freed bytes are in the string `Ox.dump` returns.

`rake test_all` 95 tests green, `rake test:valgrind` 360 tests with no leaks and no invalid accesses, `clang-format` clean.

## Not included

The same shape exists for `e->clas.str` from `rb_class2name()` in `dump_obj()`, which the threat model also flagged. It is a different function with a different lifetime question, so it wants its own change rather than being folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
