### PR TITLE
Fix the double free of the hash mode mark list

### DIFF
--- a/ext/ox/hash_load.c
+++ b/ext/ox/hash_load.c
@@ -239,7 +239,12 @@ static void end_element_no_attrs(PInfo pi, const char *ename) {
 }
 
 static void finish(PInfo pi) {
+    // Called once per yielded entity and once after the loop, so the pointer
+    // and the count have to go with the block.
     xfree(pi->marked);
+    pi->marked    = NULL;
+    pi->mark_size = 0;
+    pi->mark_cnt  = 0;
 }
 
 static void set_encoding_from_instruct(PInfo pi, Attr attrs) {

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -238,6 +238,11 @@ static VALUE ox_parse_ensure(VALUE ctxv) {
         ox_circ_array_free(ctx->pi->circ_array);
         ctx->pi->circ_array = 0;
     }
+    // Same for hash mode's mark list, freed by finish() only if the loop ends.
+    xfree(ctx->pi->marked);
+    ctx->pi->marked    = NULL;
+    ctx->pi->mark_size = 0;
+    ctx->pi->mark_cnt  = 0;
     return Qnil;
 }
 

--- a/test/hash_load_test.rb
+++ b/test/hash_load_test.rb
@@ -1,0 +1,116 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: hash mode's finish() callback freeing pi->marked without
+# clearing it.
+#
+# parse.c calls pcb->finish once for every top level entity it yields and once
+# more after the loop. The callback freed the mark list but left the pointer,
+# mark_cnt and mark_size behind, so:
+#
+#   * the second call freed the same block again -- "double free or corruption
+#     (!prev)" on glibc, and the caller's block runs between the two frees, so
+#     the chunk can be reallocated and the second free then releases a live
+#     Ruby owned buffer.
+#   * a second top level entity had mark_value() write into the freed block, at
+#     the stale mark_cnt index.
+#
+# The other half is the opposite mistake: nothing freed the list at all when the
+# parse left early. ox_parse_ensure() handles the helper stack and the circular
+# reference table that way and now handles this too. That leak is only visible
+# under Valgrind, so test:valgrind is what gates it.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class HashLoadTest < ::Test::Unit::TestCase
+  def setup
+    # The memcheck lane runs every file in one process, so do not inherit
+    # whatever options ran before this.
+    @opts = Ox.default_options
+  end
+
+  def teardown
+    Ox.default_options = @opts
+  end
+
+  # finish() runs before the yield and again after the loop.
+  def test_block_form_frees_the_mark_list_once
+    got = []
+    Ox.load('<top a="1"/>', mode: :hash) { |h| got << h }
+    assert_equal([{top: [{a: '1'}]}], got)
+  end
+
+  # The block reallocates between the two frees, so the second one released a
+  # buffer Ruby was using.
+  def test_block_that_allocates_between_the_frees
+    got = 0
+    Ox.load('<top a="1"/>', mode: :hash) do |_h|
+      200.times { ' ' * 64 }
+      got += 1
+    end
+    assert_equal(1, got)
+  end
+
+  # mark_value() wrote into the freed block for the second entity.
+  def test_two_top_level_entities
+    got = []
+    Ox.load('<a x="1"/><b y="2"/>', mode: :hash) { |h| got << h }
+    assert_equal(2, got.size)
+    assert_equal({a: [{x: '1'}], b: [{y: '2'}]}, got.last)
+  end
+
+  def test_many_top_level_entities
+    xml = (1..20).map { |i| %(<e#{i} k="#{i}"/>) }.join
+    got = []
+    Ox.load(xml, mode: :hash) { |h| got << h }
+    assert_equal(20, got.size)
+    assert_equal('20', got.last[:e20][0][:k])
+  end
+
+  def test_cdata_callbacks_take_the_same_path
+    got = []
+    Ox.load('<top a="1"><![CDATA[x]]></top>', mode: :hash, with_cdata: true) { |h| got << h }
+    assert_equal(1, got.size)
+  end
+
+  # The mark list is only built for elements that have attributes, so this is
+  # the shape that allocates it and then leaves through the error path.
+  # ox_parse_ensure() has to free it; Valgrind is what sees that.
+  def test_error_after_the_mark_list_is_allocated
+    20.times do
+      assert_raise(Ox::ParseError) { Ox.load('<top a="1"><b', mode: :hash) }
+    end
+  end
+
+  def test_error_in_the_block_leaves_nothing_behind
+    20.times do
+      assert_raise(RuntimeError) do
+        Ox.load('<top a="1"/>', mode: :hash) { |_h| raise 'from the block' }
+      end
+    end
+  end
+
+  # Everything below must keep working.
+
+  def test_without_a_block
+    assert_equal({top: [{a: '1'}]}, Ox.load('<top a="1"/>', mode: :hash))
+  end
+
+  def test_nested_elements
+    assert_equal({top: [{a: '1'}, {c: 't'}]},
+                 Ox.load('<top a="1"><c>t</c></top>', mode: :hash))
+  end
+
+  def test_hash_no_attrs_mode
+    assert_equal({top: 't'}, Ox.load('<top a="1"><top>t</top></top>', mode: :hash_no_attrs)[:top])
+  end
+
+  def test_string_keys
+    assert_equal({'top' => [{'a' => '1'}]},
+                 Ox.load('<top a="1"/>', mode: :hash, symbolize_keys: false))
+  end
+end


### PR DESCRIPTION

`parse.c` calls `pcb->finish` once for every top level entity it yields and once more after the loop. Hash mode's `finish()` freed `pi->marked` and left the pointer, `mark_cnt` and `mark_size` behind, so the second call freed the same block again.

```
Ox.load('<top a="1"/>', mode: :hash) { |h| h.to_s }

double free or corruption (!prev)
```

**The caller's block runs between the two frees**, so the chunk can be handed back out in between and the second free then releases a live Ruby owned buffer rather than a dead one:

```
Ox.load('<top a="1"/>', mode: :hash) { |_h| 200.times { ' ' * 64 } }
```

A second top level entity is the other way in. `mark_value()` finds a non NULL pointer, skips the allocation and writes at the stale `mark_cnt`:

```
Ox.load('<a x="1"/><b y="2"/>', mode: :hash) { |h| h.to_s }

heap-use-after-free, WRITE of size 8
  mark_value  ext/ox/hash_load.c:38
  add_element ext/ox/hash_load.c:143
```

The list is built only for elements that have attributes, and `finish()` is the only non NULL callback of its kind, so `mode: :hash` with a block is the whole reach. Without a block `finish()` runs once and nothing goes wrong.

## The fix

`finish()` clears the pointer and the bookkeeping. **Clearing the count matters as much as clearing the pointer** — with the pointer NULLed but `mark_cnt` left alone, `mark_value()` would allocate a fresh `MARK_INC` array and write past the end of it at the old index.

## The opposite mistake, on the way out

While measuring this, the other half turned up: **nothing frees the list when the parse leaves early**, because `ox_parse_body` returns before the post loop `finish()` on an error. `ox_parse_ensure()` already covers the helper stack and the circular reference table for exactly this reason and now covers the mark list too.

Valgrind over 400 failed parses of `<top a="1"><b`:

| | definitely lost |
|---|---|
| develop | **819,200 bytes in 400 blocks**, all from `mark_value` (`hash_load.c:32`) |
| this branch | **0** |

## Verification

New `test/hash_load_test.rb`, 11 tests. The three double free shapes take the process down on develop — two exit 139, and the reallocating one corrupts the heap badly enough that it hangs at exit — so they gate without any tool. The leak needs Valgrind: that test passes on develop, and `rake test:valgrind` reports 40,960 bytes from its 20 parses there.

`rake test_all` 111 tests green, `rake test:valgrind` 375 tests with no leaks and no invalid accesses, `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
