### PR TITLE
Fix the SAX parser reading uninitialised memory after EOF on a file

### DIFF
--- a/ext/ox/sax_buf.c
+++ b/ext/ox/sax_buf.c
@@ -193,9 +193,11 @@ static int read_from_fd(Buf buf) {
     if (cnt < 0) {
         ox_sax_drive_error(buf->dr, "failed to read from file");
         return -1;
-    } else if (0 != cnt) {
-        buf->read_end = buf->tail + cnt;
+    } else if (0 == cnt) {  // EOF
+        return -1;
     }
+    buf->read_end = buf->tail + cnt;
+
     return 0;
 }
 

--- a/test/sax_eof_test.rb
+++ b/test/sax_eof_test.rb
@@ -1,0 +1,138 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: read_from_fd() reporting EOF as a successful read.
+#
+# When read() returns 0 the function left read_end where it was and returned 0,
+# so buf_get() fell through and handed back *buf->tail anyway, pushing tail past
+# read_end. Every later buf_get() then returned bytes read() never wrote --
+# whatever the previous parse left in the 4096 byte buf.base array, which lives
+# in the _saxDrive struct on the C stack.
+#
+# It is reachable because parse() reads seven characters unconditionally after
+# "<!", and read_name_token() keeps going after that. A three byte file is
+# enough. read_from_str() already returns non-zero at EOF for this reason; the
+# fd path now does the same.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'tempfile'
+require 'ox'
+
+class SaxEofTest < ::Test::Unit::TestCase
+  class Collect < ::Ox::Sax
+    attr_reader :seen
+
+    def initialize
+      @seen = []
+    end
+
+    def start_element(name)
+      @seen << name.to_s
+    end
+
+    def end_element(name)
+      @seen << name.to_s
+    end
+
+    def text(value)
+      @seen << value.to_s
+    end
+
+    def attr(name, value)
+      @seen << "#{name}=#{value}"
+    end
+
+    def error(_message, _line, _column); end
+  end
+
+  MARKER = 'CANARY_LEAK_TEXT'
+
+  def sax_file(body)
+    handler = Collect.new
+    Tempfile.create(['sax_eof', '.xml']) do |f|
+      f.write(body)
+      f.flush
+      File.open(f.path) { |io| Ox.sax_parse(handler, io) }
+    end
+    handler.seen
+  end
+
+  # The marker has to reach buf.base and it needs a '>' in front of it, because
+  # the over-read resumes inside read_name_token() and that is what ends the
+  # token it is scanning.
+  def prime_the_buffer
+    sax_file("<top><a>#{'P' * 20}>#{MARKER}</a></top>")
+  end
+
+  # The gate: on develop this one fails with ["CANARY_LEAK_TEXT"]. The parse of
+  # a three byte file read 413 bytes past the end of it.
+  def test_truncated_file_does_not_leak_the_previous_parse
+    prime_the_buffer
+    seen = sax_file('<!D')
+    assert(seen.none? { |v| v.include?(MARKER) },
+           "content of an earlier parse came back: #{seen.inspect[0, 200]}")
+  end
+
+  # Guards rather than gates: how far the over-read gets depends on where the
+  # buffer happens to sit, and these two pass on develop even though the reads
+  # past read_end are there (8 of them for <!DOCTYPE).
+  def test_truncated_doctype_does_not_leak
+    prime_the_buffer
+    seen = sax_file('<!DOCTYPE')
+    assert(seen.none? { |v| v.include?(MARKER) },
+           "content of an earlier parse came back: #{seen.inspect[0, 200]}")
+  end
+
+  def test_every_truncation_of_the_bang_forms
+    prime_the_buffer
+    ['<!DOCTYPE html>', '<!--comment-->', '<![CDATA[body]]>'].each do |whole|
+      (1..whole.length).each do |n|
+        seen = sax_file(whole[0, n])
+        assert(seen.none? { |v| v.include?(MARKER) },
+               "#{whole[0, n].inspect} leaked: #{seen.inspect[0, 120]}")
+      end
+    end
+  end
+
+  # Everything below must keep working.
+
+  def test_complete_document_from_a_file
+    assert_equal(%w[top a x a top], sax_file('<top><a>x</a></top>'))
+  end
+
+  def test_empty_file
+    assert_equal([], sax_file(''))
+  end
+
+  def test_document_larger_than_the_initial_buffer
+    body = "<top>#{'x' * 20_000}</top>"
+    seen = sax_file(body)
+    assert_equal('top', seen.first)
+    assert_equal(20_000, seen.select { |v| v.start_with?('x') }.map(&:length).sum)
+  end
+
+  def test_doctype_and_comment_still_parse
+    assert_equal(%w[top top], sax_file("<!DOCTYPE html>\n<!--c-->\n<top/>"))
+  end
+
+  def test_cdata_still_parses
+    handler = Collect.new
+    Tempfile.create(['cdata', '.xml']) do |f|
+      f.write('<top><![CDATA[body]]></top>')
+      f.flush
+      File.open(f.path) { |io| Ox.sax_parse(handler, io) }
+    end
+    assert_equal(%w[top top], handler.seen)
+  end
+
+  # The string and StringIO paths never had the bug; they must be unchanged.
+  def test_string_input_matches_file_input
+    body = '<top><a>x</a></top>'
+    from_string = Collect.new
+    Ox.sax_parse(from_string, body)
+    assert_equal(from_string.seen, sax_file(body))
+  end
+end


### PR DESCRIPTION

`Ox.sax_parse` on a `File` reads uninitialised memory once the file runs out, and hands it to the handler.

`read_from_fd()` left `read_end` where it was when `read()` returned 0 and still returned 0, so `buf_get()` fell through and returned `*buf->tail` anyway. That pushes `tail` past `read_end`, and every `buf_get()` after it returns bytes `read()` never wrote — the gap between `read_end` and `end` in the 4096 byte `buf.base` array, which lives in the `_saxDrive` struct on the C stack.

```c
    cnt = read(buf->in.fd, buf->tail, max);
    if (cnt < 0) {
        ...
        return -1;
    } else if (0 != cnt) {
        buf->read_end = buf->tail + cnt;
    }
    return 0;        // <- also the EOF path
```

`parse()` reads seven characters unconditionally after `<!`, and `read_name_token()` keeps going after that, so **a three byte file gets there**. Instrumenting `buf_get()` to count the calls where `read_end < tail`:

| file | reads past the end of it |
|---|---|
| `<!D` | **413** |
| `<!DOCTYPE` | 8 |

## What those 413 bytes are

They are the previous parse. Parse a document whose text is a marker, then parse a three byte file in the same process, and the marker comes back through the handler's `text()` callback:

```
#1  File containing "<top><a>PPPPPPPPPPPPPPPPPPPP>CANARY_LEAK_TEXT</a></top>"
#2  File containing "<!D"

handler events from #2:
  [:err,  "Unexpected Character: DO"]
  [:err,  "Not Terminated: text not"]
  [:text, "CANARY_LEAK_TEXT"]
```

So it is one document's content handed to the handler parsing another. In a service that SAX parses uploaded files, that is one upload's contents surfacing in the parse of the next.

The `>` in front of the marker is what makes it come out whole — the stale reads resume inside `read_name_token()` and that is where the token it is scanning ends — but the reads happen either way.

## Not an out of bounds read

Worth being exact about, because it decides which tools can see it. Recording `tail`, `read_end` and `end` on every one of those 413 calls:

| | |
|---|---|
| highest `tail` offset | 415 |
| `buf->end` offset | 4092, then 8188 after the buffer doubles |
| calls with `tail < end` | **413 / 413** |

`ox_sax_buf_read()` grows the buffer whenever `end - tail` drops under 4096, so `tail` cannot leave the allocation. What is read is the gap between `read_end` and `end` — allocated, but not data.

So **neither ASAN nor Valgrind reports anything here**: ASAN sees nothing outside an allocation, and the bytes are leftovers from earlier stack use, so memcheck considers them defined. The instrumented count and the marker are what show it.

## Only the fd path

`read_from_str()` already returns non-zero at EOF, which is why a String or a StringIO is fine. The IO paths raise `EOFError` or return `nil`, `rescue_cb` turns that into `Qfalse`, and `read_from_io` returns non-zero, so they are fine too. This makes the fd path agree with them.

After the change: **0 reads past `read_end`** for both inputs above, and the marker no longer appears.

## Verification

New `test/sax_eof_test.rb`, 9 tests. The first is the gate and fails on develop with `["CANARY_LEAK_TEXT"]`. **The other two leak tests pass on develop** even though the stale reads are there, because how far it gets depends on where the buffer happens to sit — so they are guards, and the file says so rather than implying more coverage than they give.

`rake test_all` 109 tests green, `rake test:valgrind` 373 tests with no leaks and no invalid accesses, `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
