### PR TITLE
Fix a document being able to switch a default Ox.load into object mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All changes to the Ox gem are documented here. Releases follow semantic versioning.
 
+## [Unreleased]
+
+### Changed
+
+- An `<?ox mode="object"?>` processing instruction in a document no
+  longer switches a default `Ox.load` into object mode. Object mode
+  allocates the classes the document names without calling `initialize`
+  and sets their instance variables, so a document can no longer ask for
+  that on its own. Pass `mode: :object` to load in object mode.
+  `mode="generic"` and `mode="limited"` are unaffected. See issue #446.
+
 ## [2.14.28] - 2026-06-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All changes to the Ox gem are documented here. Releases follow semantic versioni
   that on its own. Pass `mode: :object` to load in object mode.
   `mode="generic"` and `mode="limited"` are unaffected. See issue #446.
 
+### Fixed
+
+- Fixed a memory leak when an `<?ox mode?>` processing instruction
+  appears more than sixteen elements deep in a document.
+
 ## [2.14.28] - 2026-06-28
 
 ### Fixed

--- a/ext/ox/gen_load.c
+++ b/ext/ox/gen_load.c
@@ -26,8 +26,6 @@ static void add_element(PInfo pi, const char *ename, Attr attrs, int hasChildren
 static void end_element(PInfo pi, const char *ename);
 static void add_instruct(PInfo pi, const char *name, Attr attrs, const char *content);
 
-extern ParseCallbacks ox_obj_callbacks;
-
 struct _parseCallbacks _ox_gen_callbacks = {
     instruct, /* instruct, */
     add_doctype,
@@ -163,9 +161,10 @@ static void nomode_instruct(PInfo pi, const char *target, Attr attrs, const char
                 }
             } else if (0 == strcmp("mode", attrs->name)) {
                 if (0 == strcmp("object", attrs->value)) {
-                    pi->pcb = ox_obj_callbacks;
-                    pi->obj = Qnil;
-                    helper_stack_init(&pi->helpers);
+                    // Only the caller can select object mode.
+                    if (TRACE <= pi->options->trace) {
+                        printf("Object mode processing instruction ignored.\n");
+                    }
                 } else if (0 == strcmp("generic", attrs->value)) {
                     pi->pcb = ox_gen_callbacks;
                 } else if (0 == strcmp("limited", attrs->value)) {

--- a/ext/ox/gen_load.c
+++ b/ext/ox/gen_load.c
@@ -170,6 +170,9 @@ static void nomode_instruct(PInfo pi, const char *target, Attr attrs, const char
                 } else if (0 == strcmp("limited", attrs->value)) {
                     pi->pcb = ox_limited_callbacks;
                     pi->obj = Qnil;
+                    // The instruction can appear after the stack has grown, and
+                    // helper_stack_init() only moves head back to base.
+                    helper_stack_cleanup(&pi->helpers);
                     helper_stack_init(&pi->helpers);
                 } else {
                     ox_err_set(&pi->err,

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -967,6 +967,13 @@ static VALUE load(char *xml, size_t len, int argc, VALUE *argv, VALUE self, VALU
  *     - _:limited_ - read as a generic XML file but with callbacks on text and elements events only
  *     - _:hash_ - read and convert to a Hash and core class objects only
  *     - _:hash_no_attrs_ - read and convert to a Hash and core class objects only without capturing attributes
+ *
+ *     If neither this option nor Ox.default_options[:mode] is set the document
+ *     may pick the mode itself with an <?ox mode="generic"?> or an
+ *     <?ox mode="limited"?> processing instruction. A document can never pick
+ *     object mode. Only the caller can, with mode: :object, since object mode
+ *     allocates the classes the document names and sets their instance
+ *     variables without calling initialize.
  *   - *:effort* [:strict|:tolerant|:auto_define] effort to use when an undefined class is encountered, default: :strict
  *     - _:strict_ - raise an NameError for missing classes and modules
  *     - _:tolerant_ - return nil for missing classes and modules
@@ -1021,6 +1028,13 @@ static VALUE load_str(int argc, VALUE *argv, VALUE self) {
  *     - _:limited_ - read as a generic XML file but with callbacks on text and elements events only
  *     - _:hash_ - read and convert to a Hash and core class objects only
  *     - _:hash_no_attrs_ - read and convert to a Hash and core class objects only without capturing attributes
+ *
+ *     If neither this option nor Ox.default_options[:mode] is set the document
+ *     may pick the mode itself with an <?ox mode="generic"?> or an
+ *     <?ox mode="limited"?> processing instruction. A document can never pick
+ *     object mode. Only the caller can, with mode: :object, since object mode
+ *     allocates the classes the document names and sets their instance
+ *     variables without calling initialize.
  *   - *:effort* [:strict|:tolerant|:auto_define] effort to use when an undefined class is encountered, default: :strict
  *     - _:strict_ - raise an NameError for missing classes and modules
  *     - _:tolerant_ - return nil for missing classes and modules

--- a/test/nomode_instruct_test.rb
+++ b/test/nomode_instruct_test.rb
@@ -1,0 +1,146 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: a document must not be able to put a default Ox.load into
+# object mode.
+#
+# With no :mode option and no Ox.default_options[:mode] the parse runs the
+# NoMode callbacks, and nomode_instruct() used to honour every mode an
+# <?ox mode="..."?> processing instruction named -- including "object", which
+# swapped in the object callbacks mid-parse. Object mode allocates the classes
+# the document names without calling initialize and sets their instance
+# variables, so any Ox.load of untrusted XML reached that.
+#
+# The document may still pick :generic or :limited, since neither builds
+# anything the document names. Only the caller can pick :object.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'tempfile'
+
+require 'ox'
+
+class NoModeInstructTest < ::Test::Unit::TestCase
+  class Marker
+    attr_accessor :v
+
+    def initialize
+      raise 'initialize must not run'
+    end
+  end
+
+  # What Ox.dump(..., with_instructions: true) writes for a Marker.
+  OBJ_XML = %{<?ox version="1.0" mode="object" circular="no" xsd_date="no"?>\n} +
+            %{<o c="NoModeInstructTest::Marker">\n  <i a="@v">1</i>\n</o>\n}
+
+  # These tests are about what happens with no mode set, so they cannot inherit
+  # whatever the ambient defaults happen to be. tests.rb leaves them at
+  # mode: :object, and the memcheck lane loads every test file into one
+  # process, so that is what these would see there.
+  BASE_OPTIONS = {
+    mode:              nil,
+    effort:            :strict,
+    indent:            2,
+    with_xml:          false,
+    with_instructions: false,
+    circular:          false,
+    xsd_date:          false,
+    skip:              :skip_white
+  }.freeze
+
+  def setup
+    @default_options = Ox.default_options
+    Ox.default_options = BASE_OPTIONS
+  end
+
+  def teardown
+    Ox.default_options = @default_options
+  end
+
+  def test_dump_still_writes_the_object_instruction
+    # Nothing about what Ox writes changes; only what a bare load does with it.
+    obj    = Marker.allocate
+    obj.v  = 1
+    assert_equal(OBJ_XML, Ox.dump(obj, mode: :object, with_instructions: true))
+  end
+
+  def test_instruction_does_not_select_object_mode
+    doc = Ox.load(OBJ_XML)
+    assert_equal(Ox::Element, doc.class)
+    assert_equal('o', doc.name)
+    assert_equal('NoModeInstructTest::Marker', doc[:c])
+  end
+
+  def test_instruction_does_not_select_object_mode_from_a_file
+    file = Tempfile.new(['nomode_instruct', '.xml'])
+    begin
+      # binmode so the newlines are not expanded to CRLF on Windows.
+      # load_file() sizes the read from fstat but opens with fopen(path, "r"),
+      # so a CRLF file is read short and raises LoadError.
+      file.binmode
+      file.write(OBJ_XML)
+      file.close
+      assert_equal(Ox::Element, Ox.load_file(file.path).class)
+    ensure
+      file.unlink
+    end
+  end
+
+  def test_tolerant_effort_does_not_reopen_it
+    # :tolerant only relaxes what happens when a named class is missing.
+    assert_equal(Ox::Element, Ox.load(OBJ_XML, effort: :tolerant).class)
+  end
+
+  def test_caller_can_still_select_object_mode
+    obj = Ox.load(OBJ_XML, mode: :object)
+    assert_equal(Marker, obj.class)
+    assert_equal(1, obj.v)
+  end
+
+  def test_caller_can_still_select_object_mode_by_default_options
+    Ox.default_options = {mode: :object}
+    assert_equal(Marker, Ox.load(OBJ_XML).class)
+  end
+
+  # An <?ox mode="object"?> in a document loaded in an explicit mode was always
+  # ignored -- only NoMode read it. Pinned so a future fix does not restore it
+  # by way of the generic callbacks.
+  def test_generic_mode_still_ignores_the_instruction
+    assert_equal(Ox::Element, Ox.load(OBJ_XML, mode: :generic).class)
+  end
+
+  # The three modes a document may still pick, each with a visible difference:
+  # generic keeps the <?pro?> instruction as a node, NoMode drops it, and
+  # limited has no instruct or comment callback at all so it never builds the
+  # Ox::Document the <?xml?> prolog would.
+  DOC = %{<?xml version="1.0"?>%s<?pro cat="quick"?><a><!--c--><b>x</b></a>}
+
+  def test_document_can_still_select_generic
+    doc = Ox.load(format(DOC, %{<?ox version="1.0" mode="generic"?>}))
+    assert_equal(Ox::Document, doc.class)
+    assert_equal([Ox::Instruct, Ox::Element], doc.nodes.map(&:class))
+  end
+
+  def test_no_instruction_stays_in_nomode
+    doc = Ox.load(format(DOC, ''))
+    assert_equal(Ox::Document, doc.class)
+    assert_equal([Ox::Element], doc.nodes.map(&:class))
+  end
+
+  def test_document_can_still_select_limited
+    doc = Ox.load(format(DOC, %{<?ox version="1.0" mode="limited"?>}))
+    assert_equal(Ox::Element, doc.class)
+    assert_equal('a', doc.name)
+    assert_equal([Ox::Element], doc.nodes.map(&:class))
+  end
+
+  def test_unknown_mode_still_raises
+    assert_raise(Ox::SyntaxError) { Ox.load(%{<?ox version="1.0" mode="bogus"?><a/>}) }
+  end
+
+  def test_unsupported_version_still_raises
+    assert_raise(Ox::SyntaxError) { Ox.load(%{<?ox version="10" mode="object"?><a/>}) }
+  end
+end

--- a/test/nomode_instruct_test.rb
+++ b/test/nomode_instruct_test.rb
@@ -136,6 +136,29 @@ class NoModeInstructTest < ::Test::Unit::TestCase
     assert_equal([Ox::Element], doc.nodes.map(&:class))
   end
 
+  # nomode_instruct() reset the helper stack when the instruction named a mode,
+  # and helper_stack_init() only moves head back to base -- so an instruction
+  # deeper than the 16 slot base abandoned the grown array. Valgrind is the
+  # grader here; without it these only check the parse still finishes.
+  DEEP = 40
+
+  def deep_document(instruct)
+    (0...DEEP).map { |i| "<e#{i}>" }.join +
+      instruct +
+      (DEEP - 1).downto(0).map { |i| "</e#{i}>" }.join
+  end
+
+  def test_object_instruction_below_the_base_stack_does_not_leak
+    doc = deep_document(%{<?ox version="1.0" mode="object"?>})
+    20.times { assert_equal('e0', Ox.load(doc).name) }
+  end
+
+  def test_limited_instruction_below_the_base_stack_does_not_leak
+    doc = deep_document(%{<?ox version="1.0" mode="limited"?>})
+    # The reset leaves nothing to return, which is what it did before as well.
+    20.times { assert_nil(Ox.load(doc)) }
+  end
+
   def test_unknown_mode_still_raises
     assert_raise(Ox::SyntaxError) { Ox.load(%{<?ox version="1.0" mode="bogus"?><a/>}) }
   end


### PR DESCRIPTION
Closes #446.

---

## What this is

`Ox.load` with no `:mode` option, and with no `Ox.default_options[:mode]`, runs the `NoMode` callbacks, and `nomode_instruct()` honoured every mode an `<?ox mode="..."?>` processing instruction named. `"object"` swapped in the object callbacks mid-parse, so any `Ox.load` of untrusted XML was an object mode load if the XML said so.

```ruby
class Marker; attr_accessor :v; end

xml = %{<?ox version="1.0" mode="object"?>\n<o c="Marker">\n  <i a="@v">1</i>\n</o>\n}
Ox.load(xml).class    # => Marker    (before)
                      # => Ox::Element (after)
```

Object mode allocates the classes the document names without calling `initialize` and sets their instance variables from the document, fills a `Struct` by member index, and interns symbols without bound — 2000 `<s a="@vN">` elements leave 2000 symbols alive after a full GC. The default `effort: :strict` limits it to already loaded classes, which is `Marshal`'s model, and `effort: :tolerant` does not restrict any of it. `Ox.load_file` behaves the same.

The asymmetry is what makes it worth changing rather than just documenting: the instruction is opt-in for the writer (`with_instructions` defaults to `false`) and has no opt-out for the reader, so a process that never writes it still honours it on every document it loads.

This is options **A** and **B** from #446. **C** was dropped, as agreed.

## What changes

**B — `ext/ox/gen_load.c`.** The `object` arm of `nomode_instruct()` no longer swaps the callbacks. A document may still name `generic` or `limited`, since neither builds anything the document names, and an unknown mode still raises `Ox::SyntaxError` exactly as before. Only the caller can select object mode now.

**A — `ext/ox/ox.c`.** The rdoc for `load` and `load_file` listed the `:mode` values and never said what omitting `:mode` means. It does now, including that the document can never pick object mode. A and B are not independent — after B the text has to say that `generic` and `limited` are still selectable while `object` is not — so they are one PR.

## The compatibility cost, stated plainly

`Ox.dump(obj, mode: :object, with_instructions: true)` followed by a bare `Ox.load` no longer round trips. It returns an `Ox::Element` rather than raising, so a caller who relies on it finds out from a `NoMethodError` further down.

The migration is one keyword: `Ox.load(xml, mode: :object)` returns the same object whether or not the instruction is present. Nothing about what `Ox.dump` writes changes — a test pins that byte for byte.

If the silent form weighs more with you than the default does, the same spot can warn once and keep working, with the switch removed in the next major. Say the word and I will send that instead.

## Also in this PR — a leak found while making the change

Second commit, `Z16`, same function, no relation to the escalation.

`nomode_instruct()` calls `helper_stack_init()` when the instruction names a mode, and `helper_stack_init()` only points `head` back at the 16 slot base (`helper.h:29`). Once the stack has grown past that base the grown array is heap allocated (`helper_stack_push`'s `ALLOC_N`, `helper.h:56`), so the reset drops it.

A processing instruction may appear anywhere, so the stack is grown whenever the instruction sits below the 16th nested element:

```ruby
deep = (0...40).map { |i| "<e#{i}>" }.join +
       %{<?ox version="1.0" mode="limited"?>} +
       39.downto(0).map { |i| "</e#{i}>" }.join
200.times { Ox.load(deep) }
```

```
definitely lost: 230,400 bytes in 200 blocks
  by helper_stack_push (helper.h:59)
  by add_element (gen_load.c:286)
```

1152 bytes a parse, no options needed, repeatable without bound. `mode="object"` leaked the identical 230,400 bytes on develop; removing that arm takes one of the two away and this commit pairs the remaining one with `helper_stack_cleanup()`. Both are 0 after.

There is no underflow to go with it — `end_element()` and `helper_stack_pop()` both check `head < tail`, and the same run reports no invalid reads or writes.

I kept it in this PR rather than a separate one because it is three lines away in the same function and the first commit already removes one of the two instances; splitting them would have left the PR fixing one arm of an identical pair. Happy to pull it out if you would rather see it on its own.

## Verification

- `rake test_all` — 0 failures across all five blocks. The `rake test` block goes from 129 tests / 3692 assertions to 143 / 3751.
- **The new test is a gate.** Copying `test/nomode_instruct_test.rb` onto unpatched develop gives 4 of 14 red — 3 failures on the escalation itself plus a `NoMethodError` on the deep instruction test, where the mid-parse reset leaves `Ox.load` returning `nil`. The other 10 pass there, which are the ones pinning behaviour that does not change.
- Valgrind on the new test file: 24,192 bytes in 21 blocks definitely lost on develop, 0 after. The 200 parse driver above gives 230,400 → 0.
- `clang-format` reports no diff on either C file.
- Ruby 2.7 syntax check on the new test passes (the CI floor).

`test/nomode_instruct_test.rb` pins, in both directions:

- a bare `Ox.load` and `Ox.load_file` of an instruction carrying document return `Ox::Element`, and `effort: :tolerant` does not reopen it
- `mode: :object`, and `Ox.default_options = {mode: :object}`, still return the object
- `Ox.dump(..., with_instructions: true)` still writes the instruction unchanged
- `mode="generic"` and `mode="limited"` are still selectable by the document, checked against a document that tells the three apart: generic keeps a `<?pro?>` instruction as a node, NoMode drops it, and limited never builds the `Ox::Document` the prolog would
- an unknown mode and an unsupported version still raise `Ox::SyntaxError`

## CHANGELOG

I normally leave `CHANGELOG.md` alone, since every entry in it is yours and written at release time. This one is a behaviour change, though, and by the time you cut a release the reason for it will be several PRs back, so I have written the entries under a `## [Unreleased]` heading — one per commit, each in the commit that makes the change.

**Rename that heading to whatever version you pick.** I have not touched `lib/ox/version.rb`, and I did not want to choose the number: a change that stops a documented round trip from working is at least a minor under semver, but where the line falls in a 2.x gem is your call, not mine.

## One thing the Windows cells taught me

The `load_file` test in this PR calls `file.binmode` before writing, with a comment saying why. It is there because without it the test fails on all seven Windows cells, and the reason turns out to be `load_file` itself rather than the test:

```
LoadError: Failed to read 125 bytes from D:/a/_temp/nomode_instruct20260802-4428-rew8e0.xml.
```

`load_file` sizes the read from `fstat` — the binary size on disk — but opens the file with `fopen(path, "r")`, which is text mode on Windows and collapses `CRLF` back to `LF` on the way in. `fread` then returns one byte short per line ending and the read is treated as a failure. The content here is 121 bytes with 4 newlines, which is exactly 125 as CRLF, so the numbers line up.

That means **`Ox.load_file` cannot read a CRLF file on Windows at all**, which is most XML files written there. Linux and macOS cannot see it, since `"r"` and `"rb"` are the same on POSIX — I put a CRLF file through `Ox.load_file` on Linux and it loads fine.

The fix looks like one word, `"rb"`, but it changes Windows behaviour — files that used to raise would start parsing, with `\r\n` reaching the parser — so it does not belong in this PR and I have not tested it on Windows. Say the word and I will send it separately. I also have not checked whether the SAX file path has the same shape.

## Not included

**The trace line.** The `object` arm prints `Object mode processing instruction ignored.` at `TRACE`, matching the ignored-instruction message just below it in the same function. It is there because the behaviour change is otherwise silent. Drop it if you would rather not have it.

**`load`'s `:mode` summary line** still reads `[:object|:generic|:limited]` while the list below it also documents `:hash` and `:hash_no_attrs`. Left alone to keep this diff to one subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
