### PR TITLE
Fix buffer over-read of an Ox::Builder element name that holds a NUL

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -623,10 +623,8 @@ static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
     }
     i_am_a_child(b, false);
     append_indent(b);
-    if (MAX_DEPTH <= b->depth + 1) {
-        rb_raise(ox_arg_error_class, "XML too deeply nested");
-    }
-    b->depth++;
+    // Everything that can raise has to run before b->depth++ or the raise
+    // leaves a stack slot that was never filled in.
     switch (rb_type(*argv)) {
     case T_STRING:
         name = StringValuePtr(*argv);
@@ -638,6 +636,14 @@ static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
         break;
     default: rb_raise(ox_arg_error_class, "expected a Symbol or String for an element name"); break;
     }
+    // strdup() below stops at an embedded NUL but len does not.
+    if (NULL != memchr(name, '\0', (size_t)len)) {
+        rb_raise(ox_arg_error_class, "element name can not contain a null character");
+    }
+    if (MAX_DEPTH <= b->depth + 1) {
+        rb_raise(ox_arg_error_class, "XML too deeply nested");
+    }
+    b->depth++;
     e = &b->stack[b->depth];
     if (sizeof(e->buf) <= (size_t)len) {
         e->name = strdup(name);

--- a/test/builder_name_test.rb
+++ b/test/builder_name_test.rb
@@ -1,0 +1,125 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: Ox::Builder#element did not validate the element name.
+#
+# Two defects, both in builder_element().
+#
+#   * A name of 64 bytes or more is copied with strdup(), which stops at the
+#     first embedded NUL, but e->len keeps the full RSTRING_LEN. append_string()
+#     then runs xml_str_len() over len bytes of a strlen()+1 sized block, so the
+#     read runs as far past the allocation as the caller cares to make the name.
+#     ASAN reports heap-buffer-overflow READ of size 8 in xml_str_len().
+#
+#   * The "expected a Symbol or String" raise happened after b->depth++, so a
+#     rescued call left the Builder holding a stack slot that was never filled
+#     in. The next call wrote through it and builder_free() later free()d
+#     whatever the uninitialised name pointer happened to be. Same shape as the
+#     depth raise in builder_depth_test.rb, reached by a different raise.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class BuilderNameTest < ::Test::Unit::TestCase
+  # struct _element's inline buf. At or above this the name is strdup'd.
+  INLINE_BUF = 64
+
+  def test_nul_in_a_short_element_name_raises
+    b = Ox::Builder.new
+    assert_raise(Ox::ArgError) { b.element("a\0bcd") }
+  end
+
+  def test_nul_in_a_strdup_length_element_name_raises
+    b = Ox::Builder.new
+    assert_raise(Ox::ArgError) { b.element("\0#{'x' * 200_000}") }
+    assert_raise(Ox::ArgError) { b.element("#{'a' * 70}\0#{'b' * 200_000}") }
+  end
+
+  # The bug lives on the strdup side of this boundary, so pin both sides of it
+  # and make sure the fix did not move the threshold.
+  def test_names_around_the_inline_buffer_boundary
+    [INLINE_BUF - 2, INLINE_BUF - 1, INLINE_BUF, INLINE_BUF + 1, 200, 5000].each do |n|
+      name = 'a' * n
+      xml  = Ox::Builder.new { |b| b.element(name) { b.text('t') } }
+      assert_equal("<#{name}>t</#{name}>\n", xml, "name length #{n}")
+    end
+  end
+
+  def test_symbol_names_still_work
+    assert_equal("<abc/>\n", Ox::Builder.new { |b| b.element(:abc) })
+  end
+
+  # On the unfixed code the raise leaves b->depth pointing at a slot that was
+  # never written, so the next element() reads its has_child and closes that
+  # phantom element with a stray '>' ahead of its own tag.
+  def test_builder_is_usable_after_a_rescued_name_type_raise
+    b = Ox::Builder.new
+    assert_raise(Ox::ArgError) { b.element(123) }
+    b.element('x')
+    b.pop
+    assert_equal("<x/>\n", b.to_s)
+  end
+
+  def test_builder_is_usable_after_a_rescued_nul_name_raise
+    b = Ox::Builder.new
+    assert_raise(Ox::ArgError) { b.element("a\0b") }
+    b.element('x')
+    b.pop
+    assert_equal("<x/>\n", b.to_s)
+  end
+
+  def test_many_rescued_name_raises_then_reuse
+    b = Ox::Builder.new
+    200.times do
+      begin
+        b.element(123)
+      rescue Ox::ArgError
+        nil
+      end
+    end
+    b.element('x')
+    b.pop
+    assert_equal("<x/>\n", b.to_s)
+  end
+
+  # builder_free() walks the stack down from b->depth and free()s any name that
+  # is not the inline buffer, so a slot left uninitialised by a rescued raise is
+  # only released here.
+  def test_gc_after_rescued_name_raises
+    assert_nothing_raised do
+      50.times do
+        b = Ox::Builder.new
+        begin
+          b.element(:not_a_name_type.to_proc)
+        rescue Ox::ArgError
+          nil
+        end
+        b = nil
+        GC.start
+      end
+    end
+  end
+
+  def test_valid_output_unchanged
+    xml = Ox::Builder.new do |b|
+      b.instruct('xml', version: '1.0')
+      b.element('top', 'a' => '1') do
+        b.element('mid') { b.text('hello') }
+        b.comment('note')
+        b.void_element('br')
+      end
+    end
+    expected = <<~XML
+      <?xml version="1.0"?>
+      <top a="1">
+        <mid>hello</mid>
+        <!--note-->
+        <br>
+      </top>
+    XML
+    assert_equal(expected, xml)
+  end
+end


### PR DESCRIPTION

## The out-of-bounds read

`builder_element()` copies a name of 64 bytes or more with `strdup()`, which stops at the first embedded NUL, but `e->len` keeps the full `RSTRING_LEN`. `append_string()` then runs `xml_str_len()` over `len` bytes of a `strlen()+1` sized block, so the read runs as far past the allocation as the caller makes the name long. `pop()` reads it a second time for the closing tag.

```ruby
Ox::Builder.new { |b| b.element("\0" + 'x' * 200_000) }
```

Under ASAN:

```
ERROR: AddressSanitizer: heap-buffer-overflow READ of size 8
    #0 xml_str_len      ext/ox/xml_str.h:129
    #1 append_string    ext/ox/builder.c:114
    #2 builder_element  ext/ox/builder.c:656
```

Nothing raises, because `append_string`'s escape loop stops at the leading NUL — the only visible effect is the segfault once the name is long enough to walk off the mapping, and until then whatever it reads feeds the escape-length calculation. An element name can not contain a NUL in XML, so it raises `Ox::ArgError` now.

## The second defect the fix uncovered

The NUL check has to sit before `b->depth++`, which is what made it obvious that the **"expected a Symbol or String" raise was already on the wrong side of the increment**. A rescued call leaves the builder holding a stack slot that was never written:

```ruby
b = Ox::Builder.new
begin; b.element(123); rescue Ox::ArgError; end
b.element('x')
```

The next call reads that slot's `has_child`, and `builder_free()` later `free()`s its `name` pointer, both uninitialised. 200 rescued calls plus one reuse die **10/10 runs** with `free(): invalid pointer` on develop. The stray `>` that the phantom element writes into the output is nondeterministic — 9/40 — because it depends on what the uninitialised `has_child` byte happens to hold; the `free()` is what makes it fatal.

This is the same shape as the depth raise fixed in #430, reached by a different raise. The fix is to move everything that can raise ahead of the increment.

## Verification

- `rake test_all` — 0 failures across all five blocks. The `rake test` block goes from 129 tests / 3692 assertions to 138 / 3709.
- **Gate.** `test/builder_name_test.rb` on unfixed develop: the two NUL tests fail, the reuse-after-a-NUL-raise test fails, `test_many_rescued_name_raises_then_reuse` kills the process 10/10, and `test_gc_after_rescued_name_raises` kills it 6/10. Run them one at a time there — the file aborts before the suite can report.
- ASAN: the `heap-buffer-overflow` above, 0 reports after.
- Names of 62, 63, 64, 65, 200 and 5000 bytes still build unchanged, so the `strdup` threshold has not moved.
- `clang-format` clean, Ruby 2.7 syntax check passes, no Valgrind leaks.

## Not included

`void_element`, attribute names, attribute values and `text` all truncate silently at an embedded NUL as well — `b.void_element("a\0bcd")` writes `<a>`. Those read from the Ruby String itself, so they stay in bounds and there is no memory bug; making them raise is a wider behaviour change than this fix, so I left them. Worth noting that `append_string` raises `Ox::SyntaxError` for every other invalid XML character and silently stops at this one, which is the underlying inconsistency.

Happy to send that as a follow-up if you want the API uniform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
