### PR TITLE
Fix a CDATA value being able to close its own section

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -797,29 +797,41 @@ static VALUE builder_cdata(VALUE self, VALUE data) {
     const char    *str;
     const char    *s;
     const char    *end;
+    const char    *from;
+    const char    *split;
+    size_t         extra = 0;
     int            len;
 
     TypedData_Get_Struct(self, struct _builder, &ox_builder_type, b);
 
-    v   = rb_String(v);
-    str = StringValuePtr(v);
-    len = (int)RSTRING_LEN(v);
-    s   = str;
-    end = str + len;
+    v    = rb_String(v);
+    str  = StringValuePtr(v);
+    len  = (int)RSTRING_LEN(v);
+    s    = str;
+    end  = str + len;
+    from = str;
     i_am_a_child(b, false);
     append_indent(b);
     buf_append_string(&b->buf, "<![CDATA[", 9);
     b->col += 9;
     b->pos += 9;
-    buf_append_string(&b->buf, str, len);
-    b->col += len;
+    // See xml_cdata_end(). The ']]' stays in this section and the '>' opens the
+    // next one, so from lands on the '>' each time round.
+    while (NULL != (split = xml_cdata_end(from, end))) {
+        buf_append_string(&b->buf, from, (split + 2) - from);
+        buf_append_string(&b->buf, "]]><![CDATA[", CDATA_SPLIT_EXTRA);
+        extra += CDATA_SPLIT_EXTRA;
+        from = split + 2;
+    }
+    buf_append_string(&b->buf, from, end - from);
+    b->col += len + extra;
     s = strchr(s, '\n');
     while (NULL != s) {
         b->line++;
         b->col = end - s;
         s      = strchr(s + 1, '\n');
     }
-    b->pos += len;
+    b->pos += len + extra;
     buf_append_string(&b->buf, "]]>", 3);
     b->col += 3;
     b->pos += 3;

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -1286,8 +1286,12 @@ static void
 dump_gen_val_node(VALUE obj, int depth, const char *pre, size_t plen, const char *suf, size_t slen, Out out) {
     volatile VALUE v = rb_attr_get(obj, ox_at_value_id);
     const char    *val;
+    const char    *end;
+    const char    *from;
+    const char    *split;
     size_t         vlen;
     size_t         size;
+    size_t         cdata_cnt = 0;
     int            indent;
 
     if (T_STRING != rb_type(v)) {
@@ -1295,6 +1299,8 @@ dump_gen_val_node(VALUE obj, int depth, const char *pre, size_t plen, const char
     }
     val  = StringValuePtr(v);
     vlen = RSTRING_LEN(v);
+    from = val;
+    end  = val + vlen;
     if (0 > out->indent) {
         indent = -1;
     } else if (0 == out->indent) {
@@ -1303,12 +1309,24 @@ dump_gen_val_node(VALUE obj, int depth, const char *pre, size_t plen, const char
         indent = depth * out->indent;
     }
     size = indent + plen + slen + vlen + out->opts->margin_len;
+    // Only a CDATA section can be closed by its own value; see xml_cdata_end().
+    if (9 == plen && 0 == strncmp("<![CDATA[", pre, 9)) {
+        cdata_cnt = xml_cdata_end_cnt(val, end);
+        size += cdata_cnt * CDATA_SPLIT_EXTRA;
+    }
     if (out->end - out->cur <= (long)size) {
         grow(out, size);
     }
     fill_indent(out, indent);
     fill_value(out, pre, plen);
-    fill_value(out, val, vlen);
+    // The ']]' stays in this section and the '>' opens the next one, so from
+    // lands on the '>' each time round.
+    while (0 < cdata_cnt && NULL != (split = xml_cdata_end(from, end))) {
+        fill_value(out, from, (size_t)((split + 2) - from));
+        fill_value(out, "]]><![CDATA[", CDATA_SPLIT_EXTRA);
+        from = split + 2;
+    }
+    fill_value(out, from, (size_t)(end - from));
     fill_value(out, suf, slen);
     *out->cur = '\0';
 }

--- a/ext/ox/xml_str.h
+++ b/ext/ox/xml_str.h
@@ -144,4 +144,30 @@ inline static size_t xml_str_len(const unsigned char *str, size_t len, const cha
     return size - len * (size_t)'0';
 }
 
+/* A CDATA section ends at the first "]]>", so a value holding one closes its
+ * own section and the rest is read as markup. Both writers split each
+ * occurrence into "]]" + "]]>" + "<![CDATA[" + ">", which reads back as the
+ * same three characters, so this is what they scan with.
+ */
+#define CDATA_SPLIT_EXTRA 12
+
+inline static const char *xml_cdata_end(const char *str, const char *end) {
+    for (; str + 3 <= end; str++) {
+        if (']' == *str && ']' == str[1] && '>' == str[2]) {
+            return str;
+        }
+    }
+    return NULL;
+}
+
+inline static size_t xml_cdata_end_cnt(const char *str, const char *end) {
+    size_t cnt = 0;
+
+    while (NULL != (str = xml_cdata_end(str, end))) {
+        cnt++;
+        str += 2;
+    }
+    return cnt;
+}
+
 #endif /* OX_XML_STR_H */

--- a/test/cdata_escape_test.rb
+++ b/test/cdata_escape_test.rb
@@ -1,0 +1,114 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: a CDATA value containing "]]>" closed its own section and the
+# rest of the value was written as markup.
+#
+# Both writers put the value between a literal "<![CDATA[" and "]]>" with no
+# scan of their own -- builder_cdata() in builder.c and dump_gen_val_node() in
+# dump.c. A CDATA section ends at the first "]]>", so
+#
+#   Ox::Builder.new { |b| b.element('note') { b.cdata(params[:msg]) } }
+#
+# with a msg of ']]><script>alert(1)</script>' produced
+#
+#   <note><![CDATA[]]><script>alert(1)</script>]]></note>
+#
+# and the script was markup by the time anything read it back.
+#
+# Each occurrence is now split into "]]" + "]]>" + "<![CDATA[" + ">", the
+# standard encoding, which reads back as the same three characters. A value that
+# holds no "]]>" is written exactly as before.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class CDataEscapeTest < ::Test::Unit::TestCase
+  ESCAPES = [
+    ']]>',
+    ']]><script>alert(1)</script>',
+    'a]]>b]]>c',
+    ']]]>',
+    ']]]]>>',
+    "line1\nline2]]>tail",
+    ']]>' * 50,
+    "]]>あ"
+  ].freeze
+
+  # Values that hold no terminator, so nothing about them may change.
+  UNCHANGED = ['plain', 'a b c', "multi\nline", '<&>"', ']]', '>', 'x' * 5000, '', "あい"].freeze
+
+  def build(text, indent: -1)
+    Ox::Builder.new(indent: indent) { |b| b.element('n') { b.cdata(text) } }
+  end
+
+  def dump(text, indent: -1)
+    e = Ox::Element.new('n')
+    e << Ox::CData.new(text)
+    Ox.dump(e, indent: indent)
+  end
+
+  # Ox parses adjacent CDATA sections into separate nodes, which is what a split
+  # value comes back as, so join them.
+  def loaded_text(xml)
+    Ox.load(xml).nodes.map { |n| n.respond_to?(:value) ? n.value : n.to_s }.join.force_encoding('UTF-8')
+  end
+
+  def test_builder_output_is_a_single_cdata_section
+    assert_equal('<n><![CDATA[]]]]><![CDATA[><script>alert(1)</script>]]></n>',
+                 build(']]><script>alert(1)</script>'))
+  end
+
+  def test_dump_output_is_a_single_cdata_section
+    assert_equal('<n><![CDATA[]]]]><![CDATA[><script>alert(1)</script>]]></n>',
+                 dump(']]><script>alert(1)</script>'))
+  end
+
+  def test_every_occurrence_is_split
+    assert_equal('<n><![CDATA[a]]]]><![CDATA[>b]]]]><![CDATA[>c]]></n>', build('a]]>b]]>c'))
+  end
+
+  def test_builder_round_trips_the_terminator
+    ESCAPES.each do |t|
+      [-1, 0, 2].each { |i| assert_equal(t, loaded_text(build(t, indent: i)), "#{t.inspect} indent #{i}") }
+    end
+  end
+
+  def test_dump_round_trips_the_terminator
+    ESCAPES.each do |t|
+      [-1, 0, 2].each { |i| assert_equal(t, loaded_text(dump(t, indent: i)), "#{t.inspect} indent #{i}") }
+    end
+  end
+
+  # Nothing is injected: every child of <n> is still a CDATA node. On the
+  # unfixed code the tail of the value comes back as an Ox::Element.
+  def test_no_markup_escapes_the_section
+    ESCAPES.each do |t|
+      [build(t), dump(t)].each do |xml|
+        kinds = Ox.load(xml).nodes.map(&:class).uniq
+        assert_equal([Ox::CData], kinds, "#{t.inspect} produced #{kinds.inspect}")
+      end
+    end
+  end
+
+  def test_values_without_the_terminator_are_untouched
+    UNCHANGED.each do |t|
+      [-1, 0, 2, 4].each do |i|
+        section = build(t, indent: i)[/<!\[CDATA\[.*?\]\]>/m].force_encoding('UTF-8')
+        assert_equal("<![CDATA[#{t}]]>", section, "#{t.inspect} indent #{i}")
+        assert_equal(t, loaded_text(build(t, indent: i)), "#{t.inspect} indent #{i}")
+      end
+    end
+  end
+
+  def test_line_and_column_still_track
+    b = Ox::Builder.new(indent: -1)
+    b.element('n')
+    b.cdata("a]]>b\nc")
+    b.pop
+    assert_equal(2, b.line)
+  end
+end


### PR DESCRIPTION

## What happens

Both writers put the value between a literal `<![CDATA[` and `]]>` with no scan of their own — `builder_cdata()` in `builder.c` and `dump_gen_val_node()` in `dump.c`. A CDATA section ends at the first `]]>`, so a value holding one closes the section and everything after it is markup.

```ruby
Ox::Builder.new { |b| b.element('note') { b.cdata(params[:msg]) } }
# params[:msg] = ']]><script>alert(1)</script>'
# => <note><![CDATA[]]><script>alert(1)</script>]]></note>
```

`Ox.dump` of an `Ox::CData` node built the same way produces the identical string. It is not only a problem for whoever renders the output: `Ox.load` of either reads the tail back as an `Ox::Element`, so the structure of the document has changed.

## The fix

Each occurrence is split into `]]` + `]]>` + `<![CDATA[` + `>`, the standard encoding. A parser reads the two adjacent sections back as the same three characters:

```
<note><![CDATA[]]]]><![CDATA[><script>alert(1)</script>]]></note>
```

The scan lives in `xml_str.h` next to the other helper both writers share.

## Verification

- Round trip over 12 values containing `]]>` (bare, repeated, `]]]>`, `]]]]>>`, with newlines, with multibyte, 50 in a row) through **both ox and REXML**, for the Builder and for `Ox.dump`, at three indents: all 12 return the original text from all four readers. On develop 5 of the 12 come back altered.
- **Values with no `]]>` are untouched**: 72 outputs over 4 indent settings × 9 values × both writers, SHA-256 **identical** to develop.
- **Gate.** `test/cdata_escape_test.rb` fails 6 of 8 on develop. The 2 that pass are the ones pinning behaviour that does not change.
- `rake test_all` — 0 failures across all five blocks; the `rake test` block goes from 129 tests / 3692 assertions to 137 / 3832.
- `clang-format` clean, Ruby 2.7 syntax check passes, no Valgrind leaks.

## One visible consequence

A split value parses back as **two adjacent `Ox::CData` nodes** rather than one, because that is what the document now holds — `Ox.load` returns one node per section. Anything doing `element.nodes.first.value` on such a value gets the first part. The alternative is to leave the injection in place, so I do not think this is avoidable, but it is a change and it belongs in the release notes.

## Not included — three more of the same shape, and why I stopped

`Ox::Comment`, `Ox::DocType` and `Ox::Instruct` values can close their constructs the same way when dumped:

```ruby
e = Ox::Element.new('note')
e << Ox::Comment.new('a--><b/>')
Ox.dump(e)   # => "\n<note>\n  <!--a--><b/>-->\n</note>\n"
```

`Ox::DocType.new('a><b/>')` and `Ox::Instruct.new('a?><b/>')` behave the same. `Ox::Builder` is not affected — `append_string` escapes `>` for comments and doctypes there — so this is the DOM dumper only.

I left them because **XML gives no way to escape `--` inside a comment**. Unlike CDATA there is no transparent encoding, so the fix has to either raise or drop bytes, and which one is right is your call rather than a mechanical change. Tell me which you want and I will send it.

`Ox::Raw` is deliberately raw and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
