### PR TITLE
Fix Ox.load_file failing on Windows for files ox wrote itself

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -445,7 +445,7 @@ static VALUE builder_file(int argc, VALUE *argv, VALUE self) {
         rb_raise(ox_arg_error_class, "missing filename");
     }
     Check_Type(*argv, T_STRING);
-    if (NULL == (f = fopen(StringValuePtr(*argv), "w"))) {
+    if (NULL == (f = fopen(StringValuePtr(*argv), "wb"))) {
         xfree(b);
         rb_raise(rb_eIOError, "%s\n", strerror(errno));
     }

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -1390,7 +1390,7 @@ void ox_write_obj_to_file(VALUE obj, const char *path, Options copts) {
 
     dump_obj_to_xml(obj, copts, &out);
     size = out.cur - out.buf;
-    if (0 == (f = fopen(path, "w"))) {
+    if (0 == (f = fopen(path, "wb"))) {
         xfree(out.buf);
         rb_raise(rb_eIOError, "%s\n", strerror(errno));
     }

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -1044,7 +1044,7 @@ static VALUE load_file(int argc, VALUE *argv, VALUE self) {
     err_init(&err);
     Check_Type(*argv, T_STRING);
     path = StringValuePtr(*argv);
-    if (0 == (f = fopen(path, "r"))) {
+    if (0 == (f = fopen(path, "rb"))) {
         rb_raise(rb_eIOError, "%s\n", strerror(errno));
     }
     // A stream that can not seek leaves len at -1, which allocates nothing and

--- a/test/file_binary_mode_test.rb
+++ b/test/file_binary_mode_test.rb
@@ -1,0 +1,110 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: ox opened its files in text mode, so on Windows it could not
+# read back what it had written.
+#
+# All three of ox's own fopen() calls used "r" / "w":
+#
+#   ox.c       load_file()             fopen(path, "r")
+#   dump.c     ox_write_obj_to_file()  fopen(path, "w")
+#   builder.c  builder_file()          fopen(..., "w")
+#
+# On Windows that is text mode. The writers turned every \n into \r\n on the
+# way out, and load_file() -- which sizes the read from fstat, the size on
+# disk, but reads through the text-mode translation -- came back one byte short
+# per line ending and raised
+#
+#   LoadError: Failed to read N bytes from ...
+#
+# so any document with a newline in it, which is every document at the default
+# indent, could not be loaded back. POSIX makes "rb" and "wb" identical to "r"
+# and "w", so **these tests only bite on the Windows CI cells**; on Linux and
+# macOS they are guards that pass either way.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'tmpdir'
+
+require 'ox'
+
+class FileBinaryModeTest < ::Test::Unit::TestCase
+  DOC = Ox::Element.new('top').tap do |top|
+    top[:a] = '1'
+    inner = Ox::Element.new('mid')
+    inner << 'hello'
+    top << inner
+    top << Ox::Comment.new('note')
+  end
+
+  def in_tmp
+    Dir.mktmpdir { |dir| yield File.join(dir, 'o.xml') }
+  end
+
+  # The round trip that could not work on Windows.
+  def test_to_file_then_load_file
+    [-1, 0, 2, 4].each do |indent|
+      in_tmp do |path|
+        Ox.to_file(path, DOC, indent: indent)
+        assert_nothing_raised("indent #{indent}") { Ox.load_file(path) }
+        assert_equal(Ox.dump(DOC, indent: indent), Ox.dump(Ox.load_file(path), indent: indent), "indent #{indent}")
+      end
+    end
+  end
+
+  def test_builder_file_then_load_file
+    [-1, 0, 2, 4].each do |indent|
+      in_tmp do |path|
+        Ox::Builder.file(path, indent: indent) do |b|
+          b.element('top', 'a' => '1') { b.element('mid') { b.text('hello') } }
+        end
+        assert_nothing_raised("indent #{indent}") { Ox.load_file(path) }
+      end
+    end
+  end
+
+  # What the writers put on disk must be what the string form says, with no
+  # line endings rewritten under them.
+  def test_to_file_bytes_match_dump
+    [-1, 0, 2, 4].each do |indent|
+      in_tmp do |path|
+        Ox.to_file(path, DOC, indent: indent)
+        assert_equal(Ox.dump(DOC, indent: indent), File.binread(path), "indent #{indent}")
+      end
+    end
+  end
+
+  def test_builder_file_bytes_match_builder_string
+    blk = proc { |b| b.element('top') { b.element('mid') { b.text('hello') } } }
+    [-1, 0, 2, 4].each do |indent|
+      in_tmp do |path|
+        Ox::Builder.file(path, indent: indent, &blk)
+        assert_equal(Ox::Builder.new(indent: indent, &blk), File.binread(path), "indent #{indent}")
+      end
+    end
+  end
+
+  # A file that already holds CRLF, whoever wrote it, must load. The parser
+  # folds \r\n to \n itself (fix_newlines, parse.c), so the result is the same
+  # document either way.
+  def test_a_crlf_file_loads_and_matches_the_lf_one
+    lf = "<?xml version=\"1.0\"?>\n<!-- c1\nc2 -->\n<n a=\"v\">\n  text\n  <m>y</m>\n</n>\n"
+    in_tmp do |path|
+      File.binwrite(path, lf)
+      from_lf = Ox.dump(Ox.load_file(path))
+      File.binwrite(path, lf.gsub("\n", "\r\n"))
+      assert_nothing_raised { Ox.load_file(path) }
+      assert_equal(from_lf, Ox.dump(Ox.load_file(path)))
+    end
+  end
+
+  # A lone \r is folded too, so a classic Mac file is not a special case.
+  def test_a_cr_only_file_loads
+    in_tmp do |path|
+      File.binwrite(path, "<n>\r  <m>y</m>\r</n>\r")
+      assert_equal('n', Ox.load_file(path).name)
+    end
+  end
+end


### PR DESCRIPTION

## What happens

All three of ox's own `fopen()` calls opened in text mode:

| | | |
|---|---|---|
| `ox.c` | `load_file()` | `fopen(path, "r")` |
| `dump.c` | `ox_write_obj_to_file()` | `fopen(path, "w")` |
| `builder.c` | `builder_file()` | `fopen(..., "w")` |

On Windows the writers turn every `\n` into `\r\n` on the way out. `load_file()` then sizes its read from `fstat` — the size on disk, counting those added bytes — but reads back through the text-mode translation that removes them again. `fread()` comes back one byte short per line ending and the read is treated as a failure:

```
LoadError: Failed to read N bytes from ...
```

So **`Ox.load_file` could not load a file that `Ox.to_file` or `Ox::Builder.file` had just written**, for any document holding a newline — which is every document at the default indent.

## Both halves are measured, on this repository's CI

I did not infer either direction from reading the code.

- **Read side, from #448.** A 121-byte fixture with four newlines failed all seven Windows cells with `Failed to read 125 bytes`. 125 is exactly its CRLF length, which identifies the mechanism with nothing left to guess.
- **Write side, from #451.** Comparing a builder-written file against the same builder's string output failed all seven Windows cells, and passed 23/23 once the test normalised `\r\n`.

What has *not* been run is the round trip itself on a Windows machine. The two halves compose, but I want to be straight that the composition is the inferred step.

## Why the two directions have to move together

`"wb"` alone leaves files already on disk unreadable. `"rb"` alone starts handing `\r\n` to the parser with nothing having asked for it. Neither is a state worth shipping, so this is one change.

The parser was already ready for the second: `fix_newlines()` in `parse.c` folds `\r\n` and a lone `\r` to `\n`, per the XML line-end rules you cite in the 2.14.7 and 2.14.9 entries. A CRLF document loads to the same tree as its LF twin — the new test pins that, and a CR-only file too.

## Verification

- **Nothing changes on Linux or macOS.** POSIX makes `"rb"` and `"wb"` identical to `"r"` and `"w"`. 16 outputs over four indent settings, both writers plus a reload of each, **SHA-256 identical to develop**.
- `rake test_all` — 0 failures across all five blocks; the `rake test` block goes from 129 tests / 3692 assertions to 135 / 3715.
- `clang-format` clean, Ruby 2.7 syntax check passes.

**The new tests are guards on Linux and macOS and only bite on the Windows cells** — they pass on unpatched develop here, because here there is nothing to fail. I have said so in the test file itself so nobody later reads them as a gate that never bit. The CI runs above are the evidence that they bite where it matters.

## Not included

`Ox.sax_parse` takes its file descriptor from a Ruby `File` the caller opened, so its mode is the caller's choice and not ox's to change. Worth knowing that a caller who opens in text mode on Windows will hand translated bytes to the SAX parser, but that is a documentation question rather than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
