### PR TITLE
Remove the dead buf_reset() from the builder's buf.h

### DIFF
--- a/ext/ox/buf.h
+++ b/ext/ox/buf.h
@@ -57,11 +57,6 @@ inline static void buf_init(Buf buf, int fd, long initial_size) {
     buf->err  = false;
 }
 
-inline static void buf_reset(Buf buf) {
-    buf->head = buf->base;
-    buf->tail = buf->head;
-}
-
 inline static void buf_cleanup(Buf buf) {
     if (buf->base != buf->head) {
         xfree(buf->head);


### PR DESCRIPTION

This is the follow-up I offered at the end of #451. Nothing here is reachable from Ruby, so it is housekeeping rather than a fix — but the thing being removed is a live trap for whoever edits `buf.h` next, which is why I think it is worth the diff rather than a comment.

## It is dead, and always has been

```c
inline static void buf_reset(Buf buf) {
    buf->head = buf->base;
    buf->tail = buf->head;
}
```

- `buf.h` is included by **`builder.c` and nothing else** (`grep -rn '#include "buf.h"' ext/`).
- `builder.c` never calls `buf_reset`.
- The `buf_reset` that `sax.c` calls on lines 470 and 542 is a **different function of the same name** in `sax_buf.h`, operating on a different `struct _buf`. No translation unit sees both.

Both have been true since `f840193` (2016-04-08) added `buf.h`. `git log -S 'buf_reset(' -- ext/ox/builder.c` is empty for every commit, so it has never had a caller in the ten years the file has existed.

## It is also wrong, which is why removing beats keeping

`buf_reset` points `head` and `tail` back at `base` but leaves `end` inside the old allocation. `buf_append_string` derives the capacity from `end - head`, so after a reset that number describes neither region.

I added a caller to reach it — there is no other way — and built with AddressSanitizer:

```
before: base=0x7e86ad60321d head=0x7dd7d244e400 tail=0x7dd7d2455c6a end=0x7dd7d24578da  cap=38106
after : base=0x7e86ad60321d head=0x7e86ad60321d tail=0x7e86ad60321d end=0x7dd7d24578da  cap=137439299261
```

A 38 KB buffer becomes a 128 GB one. The bounds test in `buf_append_string` can then never fire, so the next append writes into `base[]` with nothing stopping it:

```
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 40000 at 0x7e86ad609e88
  #1 buf_append_string ext/ox/buf.h:113
  #3 builder_text     ext/ox/builder.c:792
0x7e86ad609e88 is located 0 bytes after 27784-byte region [0x7e86ad603200,0x7e86ad609e88)
```

That 27784-byte region is the `Builder` allocation itself, so the write leaves the object entirely.

Separately, `head == base` again makes `buf_cleanup`'s `base != head` test false, so the grown buffer is never freed. Same script with and without the call, three runs each, identical every time:

| | leaked at exit |
|---|---|
| without `buf_reset` | 2752822 bytes in 23806 allocations |
| with `buf_reset` | 2791010 bytes in 23807 allocations |

One extra allocation, 38188 bytes — the grown buffer. (The ~2.75 MB baseline is Ruby's own at-exit allocations, which is why the delta rather than the total is the number that means anything.)

## Worth noting: oj has the same helper and it is correct there

`oj/ext/oj/buf.h` has a `buf_reset` too, and it is one line:

```c
inline static void buf_reset(Buf buf) {
    buf->tail = buf->head;
}
```

That one is used, by `parser.c`. ox's copy is the same idea plus `buf->head = buf->base;`, and that added line is the whole problem. **So if you would rather keep the helper than delete it, the alternative fix is to drop just that one line** and bring ox's back in line with oj's. I went with deletion because it still has no callers either way, but I would be equally happy with the one-liner — say which and I will re-cut it.

## Verification

- **No behaviour change, and I can show it rather than assert it.** An unused `static inline` function is never emitted, so the built extension is identical: `size lib/ox/ox.so` gives `text 229083  data 15608  bss 4000` on both `develop` and this branch.
- `rake test_all` — 0 failures across all five blocks (20 / 22 / 170 / 94 / 171 tests).
- `rake compile` clean, no new warnings; `clang-format --dry-run --Werror ext/ox/buf.h` clean.

**No test is added.** There is nothing to observe from Ruby before or after, and a test that pinned the absence of a C function would be noise. The `size` comparison above is the closest thing to a gate that this change admits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
