### PR TITLE
Fix parse_regexp building a pointer before the start of its text

### DIFF
--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -28,7 +28,7 @@ static void end_element(PInfo pi, const char *ename);
 static VALUE parse_time(const char *text, VALUE clas);
 static VALUE parse_xsd_time(const char *text, VALUE clas);
 static VALUE parse_double_time(const char *text, VALUE clas);
-static VALUE parse_regexp(const char *text);
+static VALUE parse_regexp(const char *text, PInfo pi);
 
 static ID            get_var_sym_from_attrs(Attr a, void *encoding, bool *indexp);
 static VALUE         get_obj_from_attrs(Attr a, PInfo pi, VALUE base_class);
@@ -327,11 +327,19 @@ static VALUE circ_array_get(CircArray ca, unsigned long id) {
     return obj;
 }
 
-static VALUE parse_regexp(const char *text) {
+static VALUE parse_regexp(const char *text, PInfo pi) {
     const char *te;
+    size_t      len     = strlen(text);
     int         options = 0;
 
-    te = text + strlen(text) - 1;
+    // The text is Regexp#inspect output, so the shortest it can be is "//".
+    // Below that te would be built from text - 1, which is not a pointer the
+    // string owns.
+    if (len < 2 || '/' != *text) {
+        set_error(&pi->err, "Invalid regexp format", pi->str, pi->s);
+        return Qundef;
+    }
+    te = text + len - 1;
 #ifdef ONIG_OPTION_IGNORECASE
     for (; text < te && '/' != *te; te--) {
         switch (*te) {
@@ -342,6 +350,13 @@ static VALUE parse_regexp(const char *text) {
         }
     }
 #endif
+    // The scan above stops on the opening / when there is no closing one, and
+    // without ONIG_OPTION_IGNORECASE it never runs at all. Either way the
+    // length below goes negative if this is not checked.
+    if (te <= text || '/' != *te) {
+        set_error(&pi->err, "Invalid regexp format", pi->str, pi->s);
+        return Qundef;
+    }
     return rb_reg_new(text + 1, te - text - 1, options);
 }
 
@@ -447,19 +462,26 @@ static void add_text(PInfo pi, char *text, size_t len, int closed) {
         RB_GC_GUARD(v);
         break;
     }
-    case RegexpCode:
+    case RegexpCode: {
+        VALUE re;
+
         if ('/' == *text) {
-            h->obj = parse_regexp(text);
+            re = parse_regexp(text, pi);
         } else {
             unsigned long str_size = b64_orig_size(text);
             VALUE         v        = rb_str_new(0, (long)str_size);
             char         *str      = RSTRING_PTR(v);
 
             from_base64(text, (uchar *)str, str_size + 1);
-            h->obj = parse_regexp(str);
+            re = parse_regexp(str, pi);
             RB_GC_GUARD(v);
         }
+        if (Qundef == re) {
+            return;
+        }
+        h->obj = re;
         break;
+    }
     case BignumCode: h->obj = rb_cstr_to_inum(text, 10, 1); break;
     case BigDecimalCode: h->obj = rb_funcall(rb_cObject, ox_bigdecimal_id, 1, rb_str_new2(text)); break;
     default: {

--- a/test/objload_base64_test.rb
+++ b/test/objload_base64_test.rb
@@ -101,15 +101,16 @@ class ObjLoadBase64Test < ::Test::Unit::TestCase
   end
 
   # A Regexp element only decodes to something usable when the result is a
-  # /.../ literal. Anything else reaches parse_regexp() with no closing slash
-  # to find, and it hands rb_reg_new a negative length. That is its own defect,
-  # unrelated to the decode -- <g>/</g> does it with no base64 at all -- and it
-  # raises the same way before and after this change.
-  def test_regexp_without_a_literal_raises_as_before
+  # /.../ literal. Anything else is a malformed value rather than a decode
+  # failure -- <g>/</g> does it with no base64 at all -- so parse_regexp()
+  # reports it the way the rest of object mode reports one. It used to reach
+  # rb_reg_new() with a negative length and raise ArgumentError from inside
+  # Ruby; see regexp_literal_test.rb.
+  def test_regexp_without_a_literal_is_a_parse_error
     ['=', 'AAAA=', b64('nope')].each do |text|
-      assert_raise(ArgumentError, text) { load64('g', text) }
+      assert_raise(Ox::ParseError, text) { load64('g', text) }
     end
-    assert_raise(ArgumentError) { Ox.parse_obj('<g>/</g>') }
+    assert_raise(Ox::ParseError) { Ox.parse_obj('<g>/</g>') }
   end
 
   # Decoding into the String means the encoding is applied to the object the

--- a/test/regexp_literal_test.rb
+++ b/test/regexp_literal_test.rb
@@ -1,0 +1,113 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: parse_regexp() built a pointer before the start of its text.
+#
+#   te = text + strlen(text) - 1;
+#
+# is text - 1 for an empty text, and the backward scan that follows stops on the
+# opening '/' when there is no closing one, so
+#
+#   rb_reg_new(text + 1, te - text - 1, options)
+#
+# was handed a negative length. Ruby checked it and raised
+#
+#   ArgumentError: negative string size (or size too big)
+#
+# which is not a parse error the caller can tell apart from a real one. Object
+# mode reports a malformed value with set_error(), the way FixnumCode does for
+# "bad number format", so this does too.
+#
+# The text is Regexp#inspect output, which always starts with '/', so nothing
+# ox itself wrote is affected.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class RegexpLiteralTest < ::Test::Unit::TestCase
+  def load_obj(text)
+    Ox.parse_obj("<g>#{text}</g>")
+  end
+
+  def b64(str)
+    [str].pack('m0')
+  end
+
+  # The gate. On develop every one of these raises ArgumentError from deep
+  # inside Ruby instead of an Ox parse error.
+  def test_a_malformed_literal_is_a_parse_error
+    ['/', 'x', 'abc', '/a', 'a/', '\\'].each do |text|
+      assert_raise(Ox::ParseError, text.inspect) { load_obj(text) }
+    end
+  end
+
+  # Same through the base64 arm, which never checked for a leading '/' at all.
+  def test_a_malformed_base64_literal_is_a_parse_error
+    ['', '/', 'x', 'abc', '/a', 'a/', 'a/b/'].each do |text|
+      assert_raise(Ox::ParseError, text.inspect) { load_obj(b64(text)) }
+    end
+  end
+
+  def test_the_parse_error_names_the_problem
+    load_obj('abc')
+  rescue Ox::ParseError => e
+    assert_match(/Invalid regexp format/, e.message)
+  end
+
+  # Everything a Regexp#inspect can produce still loads, and to the same
+  # Regexp. These pass on develop too.
+
+  # A '/' in the pattern and a non-ASCII source do not survive the trip, on
+  # develop and here alike -- Regexp#inspect writes '/' as '\/' and nothing
+  # unescapes it, and rb_reg_new() leaves the source ASCII-8BIT. Both are
+  # separate from the length calculation, so they are not pinned either way.
+  ROUND_TRIP = [
+    //, /a/, /a/i, /a/m, /a/x, /a/mix,
+    /\A\d+\z/, /[[:alpha:]]+/i,
+    /</, /a&b/, /"q"/, />/m, /a{2,3}/
+  ].freeze
+
+  def test_every_literal_ox_writes_loads_back
+    ROUND_TRIP.each do |re|
+      back = Ox.parse_obj(Ox.dump(re))
+      assert_instance_of(Regexp, back, re.inspect)
+      assert_equal(re.source, back.source, re.inspect)
+      assert_equal(re.options, back.options, re.inspect)
+    end
+  end
+
+  def test_an_empty_regexp_still_loads
+    assert_equal(//, load_obj('//'))
+  end
+
+  def test_flags_are_still_parsed
+    assert_equal(Regexp::IGNORECASE, load_obj('/a/i').options)
+    assert_equal(Regexp::MULTILINE, load_obj('/a/m').options)
+    assert_equal(Regexp::EXTENDED, load_obj('/a/x').options)
+    assert_equal(Regexp::IGNORECASE | Regexp::MULTILINE | Regexp::EXTENDED,
+                 load_obj('/a/mix').options)
+  end
+
+  # An unknown flag letter was ignored before and still is; only the length
+  # calculation moved.
+  def test_an_unknown_flag_is_still_ignored
+    assert_equal(/a/, load_obj('/a/z'))
+  end
+
+  # Regexp#inspect escapes a '/' in the pattern, so scanning back from the end
+  # still lands on the delimiter and the length covers the whole pattern.
+  def test_an_escaped_slash_in_the_pattern
+    re = load_obj('/a\\/b/')
+    assert_instance_of(Regexp, re)
+    assert_equal('a\\/b', re.source)
+    assert_match(re, 'a/b')
+  end
+
+  def test_a_regexp_inside_a_larger_document
+    doc = Ox.dump({a: /x/i, b: [/y/, 'z']})
+    assert_equal({a: /x/i, b: [/y/, 'z']}, Ox.parse_obj(doc))
+  end
+end


### PR DESCRIPTION

## What is wrong

```c
te = text + strlen(text) - 1;
```

is `text - 1` when the text is empty, which is not a pointer the string owns. The backward scan that follows is guarded by `text < te`, so it does not run, and

```c
return rb_reg_new(text + 1, te - text - 1, options);
```

is handed a length of `-2`. The same thing happens whenever there is no closing `/` at all: the scan walks back to the opening one and stops there, giving `-1`.

Ruby checks the length, so nothing is read out of bounds. What a caller actually sees is:

```ruby
Ox.parse_obj('<g>abc</g>')
#=> ArgumentError: negative string size (or size too big)
```

which is not something the caller can tell apart from a genuine `ArgumentError` raised by their own code. Object mode already reports a malformed value with `set_error()` — `FixnumCode` does it for `"bad number format"`, `parse_ulong` for `"Invalid number for a julian day"` — so this now does the same:

```ruby
#=> Ox::ParseError: Invalid regexp format at line 1, column 7
```

## Why both slashes are required

The text is `Regexp#inspect` output. So it is a `/.../` literal or it is not a Regexp at all, and checking that before computing a length is the whole fix.

Requiring the *opening* slash also makes the two arms agree. `add_text()` already tests `'/' == *text` to decide between the literal and the base64 path — but the string the base64 path decodes was never checked, so it reached `parse_regexp` unvalidated.

## What changes, measured rather than argued

Every string up to four characters over `/aimx\`, each through both arms, plus thirteen round trips of real Regexps — 3123 cases, compared against `develop`:

| develop → this branch | |
|---|---|
| `ArgumentError` → `Ox::ParseError` | 2359 |
| **returned a Regexp → `Ox::ParseError`** | **483** |
| `RegexpError` → `Ox::ParseError` | 60 |
| unchanged | 221 |

The 483 is the row that matters, so here is exactly what is in it. **Every one is a text that does not begin with `/`**, so it is not `Regexp#inspect` output and ox can never have written it. And what `develop` returned for them was a *different* regexp from the one the text spells:

| text | develop returned |
|---|---|
| `a/` | `//` |
| `aa/` | `/a/` |
| `a/i` | `//i` |
| `a//` | `/\//` |

It found a `/` scanning from the right, called everything before it a delimiter, and dropped the rest. So these are not working inputs that now break — they are malformed documents that were being silently mis-parsed and now say so. All thirteen round trips are byte-identical.

**If you would rather keep even that**, dropping `'/' != *text` from the first check is a two-word edit and takes the 483 back to `develop`'s answers; the negative length is fixed either way. I went with the stricter form because the silent mis-parse looked worse than the incompatibility, but it is your call.

## One existing test changes

`test/objload_base64_test.rb` pinned the `ArgumentError` deliberately, in #439, with a comment calling it "its own defect, unrelated to the decode". That defect is this one, so the test now expects the parse error and the comment says where the fix is.

## Verification

- `test/regexp_literal_test.rb` — 9 tests. On `develop` **2 fail and 1 errors**; all 9 pass here. The guards cover the empty regexp, each flag letter, an unknown flag letter still being ignored, an escaped `/` inside the pattern, and a Regexp nested in a larger document.
- `rake test_all` — 0 failures across all five blocks; the `rake test` block goes from 171 tests / 3936 assertions to 180 / 3999.
- The error path exercised in ten nesting positions under `GC.stress = true`, including inside `<o>`, `<u>`, a circular-reference document and an unterminated one: no crash. Clean under Valgrind.
- `rake compile` clean, no new warnings; `clang-format --dry-run --Werror ext/ox/obj_load.c` clean; Ruby 2.7 syntax check on the new test passes.

## Two things I found next door and did **not** touch

Both are on `develop` exactly as they are here, so neither belongs in this diff. Mentioning them because the round-trip test is where they surfaced.

1. **A `/` inside the pattern does not survive.** `Regexp#inspect` escapes it and nothing unescapes it, so `%r{a/b}` dumps to `/a\/b/` and loads back with source `a\/b`. It matches the same strings but `==` is false. 3 of 17 real regexps.
2. **The source of a loaded Regexp is always `ASCII-8BIT`.** `rb_reg_new` does not promote it the way `Regexp.new` does, and the document's `encoding` does not reach it. `/\p{Hiragana}+/` comes back as `RegexpError: invalid character property name`, and `/あ/` comes back as `/\xE3\x81\x82/` — a different regexp. The `n` (NOENCODING) flag is dropped too, since only `i`, `m` and `x` are scanned for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
