### PR TITLE
Fix a loaded Regexp ignoring the document's encoding

### DIFF
--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -330,6 +330,7 @@ static VALUE circ_array_get(CircArray ca, unsigned long id) {
 
 static VALUE parse_regexp(const char *text, PInfo pi) {
     const char *te;
+    VALUE       src;
     size_t      len     = strlen(text);
     int         options = 0;
 
@@ -358,7 +359,15 @@ static VALUE parse_regexp(const char *text, PInfo pi) {
         set_error(&pi->err, "Invalid regexp format", pi->str, pi->s);
         return Qundef;
     }
-    return rb_reg_new(text + 1, te - text - 1, options);
+    // rb_reg_new() takes bytes, so it can not be told the document's encoding
+    // and leaves the source ASCII-8BIT. Going through the String also gets
+    // Ruby's own rule, which promotes an ASCII only source to US-ASCII the way
+    // a literal is.
+    src = rb_str_new(text + 1, te - text - 1);
+    if (0 != pi->options->rb_enc) {
+        rb_enc_associate(src, pi->options->rb_enc);
+    }
+    return rb_reg_new_str(src, options);
 }
 
 static void instruct(PInfo pi, const char *target, Attr attrs, const char *content) {

--- a/test/regexp_encoding_test.rb
+++ b/test/regexp_encoding_test.rb
@@ -1,0 +1,131 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: a loaded Regexp ignored the document's encoding.
+#
+# parse_regexp() called rb_reg_new(), which takes bytes and so can not be told
+# an encoding. The source came back ASCII-8BIT no matter what the document
+# said, which is not a cosmetic difference:
+#
+#   * /\p{Hiragana}+/ raised RegexpError, because a binary regexp has no
+#     Unicode properties to look the name up in
+#   * /あ/ loaded as /\xE3\x81\x82/ -- a different Regexp, and == says so
+#   * even an ASCII only source came back ASCII-8BIT where Ruby gives US-ASCII
+#
+# Regexp was the only value type doing this. String and Symbol have always
+# taken pi->options->rb_enc, which is set from <?xml encoding?>, from
+# Ox.default_options[:encoding], or from the encoding of the String handed to
+# Ox.load. Going through rb_reg_new_str() also applies Ruby's own rule, which
+# promotes an ASCII only source to US-ASCII the way a literal is written.
+#
+# Nothing changes when the document carries no encoding at all: the source is
+# still ASCII-8BIT, which is exactly what a String does in the same document.
+
+$: << File.join(File.dirname(__FILE__), '../lib')
+$: << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class RegexpEncodingTest < ::Test::Unit::TestCase
+  # tests.rb leaves mode: :object behind, and :encoding is what this file is
+  # about, so both are established here rather than saved and restored.
+  BASE_OPTIONS = {mode: :object, encoding: nil}.freeze
+
+  def setup
+    @opts = Ox.default_options
+    Ox.default_options = BASE_OPTIONS
+  end
+
+  def teardown
+    Ox.default_options = @opts
+  end
+
+  ASCII = [//, /abc/, /a.c/i, /a/mix, /\A[[:alpha:]]+\z/].freeze
+  WIDE = [/あ/, /\p{Hiragana}+/, /héllo/i, /日本語|한국어/].freeze
+
+  def utf8_doc(re)
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>#{Ox.dump(re)}"
+  end
+
+  # The gate. On develop every one of these raises RegexpError or comes back as
+  # a different Regexp.
+  def test_a_declared_encoding_reaches_the_regexp
+    WIDE.each do |re|
+      back = Ox.parse_obj(utf8_doc(re))
+      assert_instance_of(Regexp, back, re.inspect)
+      assert_equal(Encoding::UTF_8, back.source.encoding, re.inspect)
+      assert_equal(re, back, re.inspect)
+    end
+  end
+
+  def test_the_default_encoding_option_reaches_it_too
+    Ox.default_options = BASE_OPTIONS.merge(encoding: 'UTF-8')
+    WIDE.each { |re| assert_equal(re, Ox.parse_obj(Ox.dump(re)), re.inspect) }
+  end
+
+  # Ox.load takes rb_enc from the String it is handed when nothing else says,
+  # which is the third way in. Ox.parse_obj does not look at its argument's
+  # encoding at all, so it is not the entry point to use here.
+  def test_the_input_strings_encoding_reaches_it_too
+    WIDE.each do |re|
+      xml = Ox.dump(re).dup.force_encoding('UTF-8')
+      assert_equal(re, Ox.load(xml, mode: :object), re.inspect)
+    end
+  end
+
+  # An ASCII only source is US-ASCII, the way Regexp.new makes it, rather than
+  # ASCII-8BIT. This is what made a loaded Regexp compare unequal to the same
+  # literal on a Ruby whose Regexp#== looks at the source encoding.
+  def test_an_ascii_source_is_promoted_to_us_ascii
+    ASCII.each do |re|
+      back = Ox.parse_obj(Ox.dump(re))
+      assert_equal(Encoding::US_ASCII, back.source.encoding, re.inspect)
+      assert_equal(re.source.encoding, back.source.encoding, re.inspect)
+      assert_equal(re, back, re.inspect)
+    end
+  end
+
+  def test_flags_survive_the_change
+    assert_equal(Regexp::IGNORECASE, Ox.parse_obj('<g>/a/i</g>').options)
+    assert_equal(Regexp::MULTILINE, Ox.parse_obj('<g>/a/m</g>').options)
+    assert_equal(Regexp::EXTENDED, Ox.parse_obj('<g>/a/x</g>').options)
+    assert_equal(//, Ox.parse_obj('<g>//</g>'))
+  end
+
+  # A pattern rb_reg_new_str() can not compile raises the same RegexpError
+  # rb_reg_new() did, rather than becoming something else.
+  def test_an_invalid_pattern_still_raises
+    assert_raise(RegexpError) { Ox.parse_obj('<g>/(/</g>') }
+    assert_raise(RegexpError) { Ox.parse_obj('<g>/[z-a]/</g>') }
+  end
+
+  def test_the_malformed_literal_check_is_unaffected
+    assert_raise(Ox::ParseError) { Ox.parse_obj('<g>abc</g>') }
+    assert_raise(Ox::ParseError) { Ox.parse_obj('<g>/</g>') }
+  end
+
+  # With no encoding anywhere the source stays ASCII-8BIT -- unchanged, and the
+  # same thing a String does in that document. Pinned so that the boundary of
+  # this change is written down rather than inferred.
+  #
+  # Ox.load rather than Ox.parse_obj because Ox.default_options = {encoding:
+  # nil} clears the reported value but not the rb_enc behind it, and parse_obj
+  # reads only the latter. So once any test in the process has set an encoding,
+  # parse_obj keeps applying it. Ox.load re-derives it from the String it is
+  # handed, which is what makes this order independent.
+  def test_without_any_encoding_a_regexp_matches_what_a_string_does
+    from_string = Ox.load(Ox.dump('あ'), mode: :object)
+    from_regexp = Ox.load(Ox.dump(/あ/), mode: :object)
+    assert_equal(Encoding::ASCII_8BIT, from_string.encoding)
+    assert_equal(Encoding::ASCII_8BIT, from_regexp.source.encoding)
+  end
+
+  # A Regexp inside a larger document takes the same encoding as the strings
+  # beside it.
+  def test_inside_a_document_with_other_values
+    Ox.default_options = BASE_OPTIONS.merge(encoding: 'UTF-8')
+    src = {a: /あ/, b: ['文字', /\p{Han}/i]}
+    assert_equal(src, Ox.parse_obj(Ox.dump(src)))
+  end
+end


### PR DESCRIPTION

`parse_regexp()` calls `rb_reg_new()`, which takes bytes and so cannot be told an encoding. A loaded Regexp's source was `ASCII-8BIT` whatever the document said:

```ruby
Ox.parse_obj('<?xml version="1.0" encoding="UTF-8"?><g>/\p{Hiragana}+/</g>')
#=> RegexpError: invalid character property name {Hiragana}

Ox.parse_obj('<?xml version="1.0" encoding="UTF-8"?><g>/あ/</g>')
#=> /\xE3\x81\x82/      a different Regexp, and == says so
```

`String` and `Symbol` have always taken `pi->options->rb_enc`; Regexp was the only value type ignoring it. Going through `rb_reg_new_str()` fixes that, and gets Ruby's own rule as well — an ASCII-only source is promoted to `US-ASCII`, the way a literal is, so this is not "associate UTF-8" (that would make `/abc/` disagree with `/abc/`).

**Nothing changes when the document carries no encoding.** The source stays `ASCII-8BIT`, which is exactly what a `String` does in that same document.

`rake test_all` is green in all five blocks. The new test file fails 4 and errors 1 of its 9 tests on `develop`.

<details>
<summary>Measurements, and one thing I found next door</summary>

### Round trips of eight Regexps, four ASCII and four not

`//`, `/abc/`, `/a.c/i`, `/a/mix`, `/あ/`, `/\p{Hiragana}+/`, `/héllo/i`, `/\A[[:alpha:]]+\z/`

| how the encoding is said | develop | this branch |
|---|---|---|
| not said at all | 5/8 | 5/8 |
| `Ox.default_options[:encoding] = 'UTF-8'` | 5/8 | **8/8** |
| `Ox.dump(re, with_xml: true, encoding: 'UTF-8')` | 5/8 | **8/8** |
| `Ox.load` of a String forced to UTF-8 | 5/8 | **8/8** |

The three rows that move are the three ways of saying UTF-8 that were being ignored.

### Why `US-ASCII` and not UTF-8

Ruby's rule, measured on 4.0.6:

| source | encoding | `fixed_encoding?` |
|---|---|---|
| ASCII only | `US-ASCII` | false |
| contains non-ASCII | the String's own | true |

The promotion happens whatever the input String was — a UTF-8, a BINARY and an EUC-JP `"abc"` all give `US-ASCII`.

### Relation to https://bugs.ruby-lang.org/issues/22178

The `US-ASCII` half is why a loaded `/abc/` stopped comparing equal to the literal on Ruby HEAD: `d663de3fc4` made `Regexp#==` compare the source fstring pointer. nobu has since fixed Ruby's side (`cdf323395e`), so that symptom goes away on its own — but the `\p{...}` and non-ASCII failures above have nothing to do with how `==` is implemented.

### Also verified

Valgrind clean; `clang-format --dry-run --Werror` clean; Ruby 2.7 syntax check passes; 12 runs under `--order=random`. `rake test` goes from 188 tests / 4014 assertions to 197 / 4060. Guards cover the flags still being parsed, an invalid pattern still raising `RegexpError`, and the malformed-literal check from #455 being unaffected.

### Found next door, not included

`Ox.default_options = {encoding: nil}` clears the reported value and the dump side, but not the `rb_enc` behind it (`ox.c:483`). So once an encoding is set in a process it can never be turned off for `Ox.parse_obj`, which reads only `rb_enc`:

```ruby
Ox.default_options = {encoding: 'UTF-8'}
Ox.default_options = {encoding: nil}

Ox.default_options[:encoding]      #=> nil
Ox.dump('a').encoding              #=> ASCII-8BIT     the char array was cleared
Ox.parse_obj(binary_xml).encoding  #=> UTF-8          rb_enc was not
```

`Ox.load` is unaffected — it re-derives `rb_enc` from the String it is given. On `develop` exactly as it is here, and an options question rather than a Regexp one, so it is not in this diff. It is why one test in the new file uses `Ox.load`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
