### PR TITLE
Fix Ox::Builder truncating a value at an embedded NUL

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -134,7 +134,7 @@ static void append_string(Builder b, const char *str, size_t size, const char *t
         char       *bend = buf + sizeof(buf) - 1;
         const char *send = str + size;
 
-        while (str < send && '\0' != *str) {
+        while (str < send) {
             /* Copy runs of pass-through bytes a word at a time into the staging
              * buffer. A clean word has no byte below 0x20, so it can hold no
              * newline and no '\0': col and pos advance by the whole word and the
@@ -170,7 +170,7 @@ static void append_string(Builder b, const char *str, size_t size, const char *t
              * word. These are all >= 0x20 and not escape characters, so no
              * newline check is needed.
              */
-            while (str < send && '\0' != *str) {
+            while (str < send) {
                 unsigned char c = (unsigned char)*str;
 
                 if (c < 0x20 || '"' == c || '\'' == c || '&' == c || '<' == c || '>' == c) {
@@ -188,7 +188,7 @@ static void append_string(Builder b, const char *str, size_t size, const char *t
              * or a byte the table keeps unchanged ('"' and '\'' in the element
              * table, and 0x09/0x0a/0x0d in every table).
              */
-            if (str < send && '\0' != *str) {
+            if (str < send) {
                 int fcnt = table[(unsigned char)*str];
 
                 if ('1' == fcnt) {
@@ -638,9 +638,10 @@ static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
         break;
     default: rb_raise(ox_arg_error_class, "expected a Symbol or String for an element name"); break;
     }
-    // strdup() below stops at an embedded NUL but len does not.
+    // append_string() below raises on the NUL too, but only after strdup() has
+    // copied a name shorter than len says it is.
     if (NULL != memchr(name, '\0', (size_t)len)) {
-        rb_raise(ox_arg_error_class, "element name can not contain a null character");
+        rb_raise(ox_syntax_error_class, "'\\#x00' is not a valid XML character.");
     }
     if (MAX_DEPTH <= b->depth + 1) {
         rb_raise(ox_arg_error_class, "XML too deeply nested");

--- a/test/builder_name_test.rb
+++ b/test/builder_name_test.rb
@@ -29,13 +29,13 @@ class BuilderNameTest < ::Test::Unit::TestCase
 
   def test_nul_in_a_short_element_name_raises
     b = Ox::Builder.new
-    assert_raise(Ox::ArgError) { b.element("a\0bcd") }
+    assert_raise(Ox::SyntaxError) { b.element("a\0bcd") }
   end
 
   def test_nul_in_a_strdup_length_element_name_raises
     b = Ox::Builder.new
-    assert_raise(Ox::ArgError) { b.element("\0#{'x' * 200_000}") }
-    assert_raise(Ox::ArgError) { b.element("#{'a' * 70}\0#{'b' * 200_000}") }
+    assert_raise(Ox::SyntaxError) { b.element("\0#{'x' * 200_000}") }
+    assert_raise(Ox::SyntaxError) { b.element("#{'a' * 70}\0#{'b' * 200_000}") }
   end
 
   # The bug lives on the strdup side of this boundary, so pin both sides of it
@@ -65,7 +65,7 @@ class BuilderNameTest < ::Test::Unit::TestCase
 
   def test_builder_is_usable_after_a_rescued_nul_name_raise
     b = Ox::Builder.new
-    assert_raise(Ox::ArgError) { b.element("a\0b") }
+    assert_raise(Ox::SyntaxError) { b.element("a\0b") }
     b.element('x')
     b.pop
     assert_equal("<x/>\n", b.to_s)

--- a/test/builder_nul_test.rb
+++ b/test/builder_nul_test.rb
@@ -1,0 +1,164 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: Ox::Builder truncated a value at an embedded NUL instead of
+# treating it as the invalid XML character it is.
+#
+# append_string() is given a size but guarded its three loops with
+# '\0' != *str as well, the way a C string is walked. A NUL therefore ended the
+# scan before it could reach the table lookup, so the bytes after it were
+# dropped without a word. Every other character XML does not allow - 0x01 and
+# the rest of the C0 range - reached that lookup and raised Ox::SyntaxError.
+#
+# NUL is not a character XML has any way to write: the Char production is
+#
+#   Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+#
+# and a character reference has to resolve to a Char as well, so &#0; is not a
+# way out either. Ox.dump has always raised on it. Ox::Builder was the one
+# writer out of step, and out of step with itself, since it raised on 0x01.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class BuilderNulTest < ::Test::Unit::TestCase
+  # Every Builder call that runs its argument through append_string, as a block
+  # taking the byte to plant. Keyed by what part of the document it writes.
+  WRITERS = {
+    'element name' => ->(b, c) { b.element("a#{c}bcd") },
+    'void_element name' => ->(b, c) { b.void_element("a#{c}bcd") },
+    'attribute name' => ->(b, c) { b.element('ok', "a#{c}b" => 'v') },
+    'attribute value' => ->(b, c) { b.element('ok', 'k' => "a#{c}b") },
+    'text' => ->(b, c) { b.element('ok'); b.text("a#{c}b") },
+    'comment' => ->(b, c) { b.comment("a#{c}b") },
+    'doctype' => ->(b, c) { b.doctype("a#{c}b") }
+  }.freeze
+
+  def outcome(byte)
+    b = Ox::Builder.new
+    yield b
+    b.to_s
+  rescue Ox::SyntaxError => e
+    e.message
+  end
+
+  def test_every_writer_raises_on_a_nul
+    WRITERS.each do |where, writer|
+      assert_raise(Ox::SyntaxError, where) do
+        Ox::Builder.new { |b| writer.call(b, "\0") }
+      end
+    end
+  end
+
+  def test_the_message_names_the_character
+    e = assert_raise(Ox::SyntaxError) { Ox::Builder.new { |b| b.text("a\0b") } }
+    assert_equal("'\\#x00' is not a valid XML character.", e.message)
+  end
+
+  # The defect stated as the difference it made: NUL was the one invalid
+  # character that behaved differently from every other one.
+  def test_nul_now_matches_the_other_invalid_characters
+    WRITERS.each do |where, writer|
+      nul = outcome("\0") { |b| writer.call(b, "\0") }
+      soh = outcome("\x01") { |b| writer.call(b, "\x01") }
+      assert_equal(soh.sub('x01', 'x00'), nul, where)
+    end
+  end
+
+  # The word loop reads eight bytes at a time, the loop after it takes the tail
+  # shorter than a word, and the arm after that takes one flagged byte. Walking
+  # the NUL across a span longer than two words puts it in each of them.
+  def test_a_nul_is_found_at_any_offset
+    24.times do |n|
+      s = "#{'a' * n}\0#{'b' * 24}"
+      assert_raise(Ox::SyntaxError, "offset #{n}") { Ox::Builder.new { |b| b.text(s) } }
+    end
+  end
+
+  def test_a_nul_alone_and_a_nul_last
+    assert_raise(Ox::SyntaxError) { Ox::Builder.new { |b| b.text("\0") } }
+    assert_raise(Ox::SyntaxError) { Ox::Builder.new { |b| b.text("ab\0") } }
+    assert_raise(Ox::SyntaxError) { Ox::Builder.new { |b| b.text("#{'a' * 16}\0") } }
+  end
+
+  # text is the only writer that takes the option. Before the fix the NUL ended
+  # the scan whatever it was set to, so the bytes after it went missing from the
+  # stripped output as well.
+  def test_strip_invalid_chars_drops_the_nul_and_keeps_the_rest
+    xml = Ox::Builder.new(indent: -1) do |b|
+      b.element('ok') { b.text("a\0b", true) }
+    end
+    assert_equal('<ok>ab</ok>', xml)
+  end
+
+  def test_strip_invalid_chars_matches_the_other_invalid_characters
+    nul = Ox::Builder.new(indent: -1) { |b| b.element('ok') { b.text("a\0b\0c", true) } }
+    soh = Ox::Builder.new(indent: -1) { |b| b.element('ok') { b.text("a\x01b\x01c", true) } }
+    assert_equal(soh, nul)
+    assert_equal('<ok>abc</ok>', nul)
+  end
+
+  # Ox.dump has always raised. It is the behaviour Builder is being brought into
+  # line with, so a change to either side should fail here.
+  def test_ox_dump_still_raises_the_same_way
+    e = assert_raise(Ox::SyntaxError) { Ox.dump("a\0b") }
+    assert_equal("'\\#x00' is not a valid XML character.", e.message)
+  end
+
+  # raw() is documented as writing its argument with no escaping at all, so it
+  # never went through append_string and is deliberately left alone.
+  def test_raw_is_unchanged
+    assert_equal("a\0b\n", Ox::Builder.new { |b| b.raw("a\0b") })
+  end
+
+  # The escape path is shared with every other value, so pin what it produces
+  # for input that has nothing wrong with it.
+  def test_valid_output_is_unchanged
+    xml = Ox::Builder.new do |b|
+      b.instruct('xml', version: '1.0')
+      b.element('top', 'a' => %(1 & 2 < 3 "q" 'r')) do
+        b.element('mid') { b.text("hello & <world>\nsecond line") }
+        b.element('utf8') { b.text('日本語 ☃ é') }
+        b.element('long') { b.text('x' * 1000) }
+        b.comment('note')
+        b.void_element('br')
+      end
+    end
+    expected = <<~XML
+      <?xml version="1.0"?>
+      <top a="1 &amp; 2 &lt; 3 &quot;q&quot; 'r'">
+        <mid>hello &amp; &lt;world&gt;
+      second line</mid>
+        <utf8>日本語 ☃ é</utf8>
+        <long>#{'x' * 1000}</long>
+        <!--note-->
+        <br>
+      </top>
+    XML
+    # Builder writes bytes and only labels them when an encoding was asked for,
+    # so what comes back is ASCII-8BIT while the heredoc above is UTF-8.
+    assert_equal(expected.b, xml)
+  end
+
+  # append_string writes as it scans, so the bytes ahead of the character it
+  # raises on are already in the buffer. That is what a rescued 0x01 has always
+  # left behind and a rescued NUL now leaves the same thing; what matters here
+  # is that the element stack is intact and the next call still works.
+  def test_the_builder_is_usable_after_a_rescued_nul_raise
+    nul = Ox::Builder.new
+    assert_raise(Ox::SyntaxError) { nul.comment("a\0b") }
+    nul.element('x')
+    nul.pop
+
+    soh = Ox::Builder.new
+    assert_raise(Ox::SyntaxError) { soh.comment("a\x01b") }
+    soh.element('x')
+    soh.pop
+
+    assert_equal(soh.to_s, nul.to_s)
+    assert_equal("<!--a\n<x/>\n", nul.to_s)
+  end
+end


### PR DESCRIPTION

`append_string()` is handed a `size` but guarded its loops with `'\0' != *str` as well, so a NUL ended the scan before the byte could reach the table lookup and everything after it was dropped without a word:

```ruby
b.void_element("a\0bcd")        #=> <a>
b.element('ok', 'k' => "a\0b")  #=> <ok k="a"/>
b.text("a\0b")                  #=> a
b.comment("a\0b")               #=> <!--a-->
```

Every other character XML does not allow reached that lookup and raised, so `0x01` raised `Ox::SyntaxError` in all four of those places while `0x00` — the one character that cannot be written at all, not even as `&#0;` — was the one that went quiet. ox had already decided what to do with a character it cannot write: `strip_invalid_chars`, `false` by default, which raises. `Ox.dump("a\0b")` has always raised. `Ox::Builder` was the one writer out of step, and out of step with itself.

Dropping the three guards puts the NUL on the same `default:` arm as every other invalid byte, so it raises, and `strip_invalid_chars: true` drops it and keeps what follows instead of ending the value there.

`rake test_all` is green in all five blocks. The new test file fails 7 and errors 1 of its 11 tests on `develop`.

<details>
<summary>Measurements, the one error class that changed, and what is left out</summary>

### Nothing else moves

1740 cases with no NUL in them — ten writers × 58 strings × three indents, covering the escape characters, the C0 range, UTF-8, the 256-byte staging buffer boundary and the 8-byte word loop boundary — produce byte-identical output, exceptions and `line`/`column`/`pos` before and after.

### 350 cases carrying a NUL

The NUL walks across offsets 0 to 20 so it is found by the word loop, by the tail loop and by the single-byte arm.

| writer | changed | |
|---|---|---|
| `element` | 35/35 | `ArgError` → `SyntaxError`, below |
| `void_element` | 34/35 | |
| `attr_name` | 34/35 | |
| `attr_value` | 34/35 | |
| `text` | 34/35 | |
| `text` + `strip_invalid_chars` | 32/35 | |
| `comment` | 34/35 | |
| `doctype` | 34/35 | |
| `cdata` | 0/35 | not checked at all, below |
| `raw` | 0/35 | documented as unescaped |

The unchanged ones are the cases that never reached the guard: a `0x01` ahead of the NUL, which already raised, and a NUL with nothing after it to lose.

### The error class on `element`

`builder_element()` checked for the NUL itself and raised `Ox::ArgError` with its own message (#449). The check has to stay where it is — it runs before the `strdup()` that would otherwise copy a name shorter than `len` says it is — but it now raises the same `Ox::SyntaxError` with the same message as every other writer, so the two entry points to an element name no longer disagree about what a NUL is. Both classes descend from `Ox::Error`, and that `ArgError` was added after v2.14.28 and has not been in a release.

### Also verified

Valgrind clean over the whole suite; ASAN clean over both sweeps; `clang-format --dry-run --Werror` clean; Ruby 2.7 syntax check passes; 12 runs under `--order=random`. `rake test` goes from 210 tests / 4134 assertions to 221 / 4190.

### Left out

`raw()` is documented as writing its argument with no escaping, so it never went through `append_string` and is unchanged.

`cdata()` does not check its content at all, for any invalid character, not just NUL. Separate hole, separate shape, not touched here.

A Symbol name loses its length at `rb_id2name()` before `append_string` ever sees it, so `b.element(:"a\0b")` still writes `<a/>`. That is not this loop — it is how every `rb_id2name()` call site in ox converts a Symbol, `dump.c` included, where `Ox.dump(:"a\0b")` truncates the same way.

</details>
