### PR TITLE
Fix an encoding set in Ox.default_options never being cleared

### DIFF
--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -482,7 +482,10 @@ static VALUE set_def_opts(VALUE self, VALUE opts) {
 
     v = rb_hash_aref(opts, ox_encoding_sym);
     if (Qnil == v) {
+        // Ox.parse_obj and Ox.parse read rb_enc and never re-derive it from the
+        // name, so clearing only the name leaves them on the old encoding.
         *ox_default_options.encoding = '\0';
+        ox_default_options.rb_enc    = 0;
     } else {
         Check_Type(v, T_STRING);
         strncpy(ox_default_options.encoding, StringValuePtr(v), sizeof(ox_default_options.encoding) - 1);

--- a/test/default_encoding_test.rb
+++ b/test/default_encoding_test.rb
@@ -1,0 +1,115 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: an encoding set through Ox.default_options could not be
+# unset again for the rest of the process.
+#
+# The option is held twice, as the name in options.encoding and as the
+# rb_encoding * in options.rb_enc, and the two halves are read by different
+# code. set_def_opts() cleared only the name, so:
+#
+#   Ox.default_options = {encoding: 'UTF-8'}
+#   Ox.default_options = {encoding: nil}
+#
+#   Ox.default_options[:encoding]  #=> nil          says it is gone
+#   Ox.dump('a').encoding          #=> ASCII-8BIT   reads the name, agrees
+#   Ox.parse_obj(xml).encoding     #=> UTF-8        reads rb_enc, does not
+#
+# Ox.load was never affected: it re-derives rb_enc from the String it is handed
+# whenever the name is empty. Ox.parse_obj and Ox.parse take the struct as it
+# stands, so they kept applying an encoding that had been asked to go away.
+#
+# This is also what the save-and-restore idiom the test suite uses depends on -
+# @opts = Ox.default_options in setup, Ox.default_options = @opts in teardown -
+# since a saved Hash carries the cleared encoding back as nil.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class DefaultEncodingTest < ::Test::Unit::TestCase
+  BINARY_XML = '<?xml version="1.0"?><s>abc</s>'.b
+
+  def setup
+    @opts = Ox.default_options
+    Ox.default_options = {mode: :object, encoding: nil}
+  end
+
+  def teardown
+    Ox.default_options = @opts
+  end
+
+  # The four ways an encoding reaches a result. dump and load read the name,
+  # parse_obj and parse read rb_enc, so a disagreement shows up as a split.
+  def encodings
+    {
+      parse_obj: Ox.parse_obj(BINARY_XML).encoding,
+      parse: Ox.parse('<r>abc</r>'.b).text.encoding,
+      load: Ox.load(BINARY_XML).encoding,
+      dump: Ox.dump('a').encoding
+    }
+  end
+
+  def test_clearing_the_encoding_clears_it_everywhere
+    Ox.default_options = {mode: :object, encoding: 'UTF-8'}
+    assert_equal({parse_obj: Encoding::UTF_8, parse: Encoding::UTF_8,
+                  load: Encoding::UTF_8, dump: Encoding::UTF_8},
+                 encodings)
+
+    Ox.default_options = {mode: :object, encoding: nil}
+    assert_nil(Ox.default_options[:encoding])
+    assert_equal({parse_obj: Encoding::ASCII_8BIT, parse: Encoding::ASCII_8BIT,
+                  load: Encoding::ASCII_8BIT, dump: Encoding::ASCII_8BIT},
+                 encodings)
+  end
+
+  # Ox.default_options= replaces the set, so a hash that does not mention
+  # :encoding clears it as surely as one that says nil.
+  def test_an_option_hash_without_encoding_clears_it_too
+    Ox.default_options = {mode: :object, encoding: 'UTF-8'}
+    Ox.default_options = {mode: :object}
+    assert_nil(Ox.default_options[:encoding])
+    assert_equal([Encoding::ASCII_8BIT] * 4, encodings.values)
+  end
+
+  # What Ox.default_options reports and what a parse actually does have to be
+  # the same answer, whichever half of the option each one is reading.
+  def test_what_is_reported_matches_what_is_applied
+    ['UTF-8', nil, 'UTF-8', 'US-ASCII', nil].each do |enc|
+      Ox.default_options = {mode: :object, encoding: enc}
+      expected = enc ? Encoding.find(enc) : Encoding::ASCII_8BIT
+      assert_equal(enc, Ox.default_options[:encoding], "reported for #{enc.inspect}")
+      encodings.each do |where, actual|
+        assert_equal(expected, actual, "#{where} for #{enc.inspect}")
+      end
+    end
+  end
+
+  # A second encoding has to replace the first rather than be shadowed by it.
+  def test_switching_between_encodings
+    Ox.default_options = {mode: :object, encoding: 'UTF-8'}
+    Ox.default_options = {mode: :object, encoding: 'US-ASCII'}
+    assert_equal([Encoding::US_ASCII] * 4, encodings.values)
+  end
+
+  # The idiom every test file in this suite uses. On the unfixed code the
+  # restore left rb_enc holding whatever the body had set, which is how this
+  # defect was found - a test that passed alone and failed in company.
+  def test_save_and_restore_round_trips
+    saved = Ox.default_options
+    Ox.default_options = {mode: :object, encoding: 'UTF-8'}
+    Ox.default_options = saved
+    assert_equal([Encoding::ASCII_8BIT] * 4, encodings.values)
+  end
+
+  # An encoding in the document is read per parse and has nothing to do with
+  # the default, so clearing the default must not reach it.
+  def test_a_document_encoding_still_wins
+    Ox.default_options = {mode: :object, encoding: 'UTF-8'}
+    Ox.default_options = {mode: :object, encoding: nil}
+    doc = '<?xml version="1.0" encoding="UTF-8"?><s>abc</s>'.b
+    assert_equal(Encoding::UTF_8, Ox.parse_obj(doc).encoding)
+  end
+end

--- a/test/regexp_encoding_test.rb
+++ b/test/regexp_encoding_test.rb
@@ -108,15 +108,9 @@ class RegexpEncodingTest < ::Test::Unit::TestCase
   # With no encoding anywhere the source stays ASCII-8BIT -- unchanged, and the
   # same thing a String does in that document. Pinned so that the boundary of
   # this change is written down rather than inferred.
-  #
-  # Ox.load rather than Ox.parse_obj because Ox.default_options = {encoding:
-  # nil} clears the reported value but not the rb_enc behind it, and parse_obj
-  # reads only the latter. So once any test in the process has set an encoding,
-  # parse_obj keeps applying it. Ox.load re-derives it from the String it is
-  # handed, which is what makes this order independent.
   def test_without_any_encoding_a_regexp_matches_what_a_string_does
-    from_string = Ox.load(Ox.dump('あ'), mode: :object)
-    from_regexp = Ox.load(Ox.dump(/あ/), mode: :object)
+    from_string = Ox.parse_obj(Ox.dump('あ'))
+    from_regexp = Ox.parse_obj(Ox.dump(/あ/))
     assert_equal(Encoding::ASCII_8BIT, from_string.encoding)
     assert_equal(Encoding::ASCII_8BIT, from_regexp.source.encoding)
   end


### PR DESCRIPTION

The option is held twice — as the name in `options.encoding` and as the `rb_encoding *` in `options.rb_enc` — and the two halves are read by different code. `set_def_opts()` cleared only the name:

```ruby
Ox.default_options = {encoding: 'UTF-8'}
Ox.default_options = {encoding: nil}

Ox.default_options[:encoding]   #=> nil          says it is gone
Ox.dump('a').encoding           #=> ASCII-8BIT   reads the name, agrees
Ox.parse_obj(xml).encoding      #=> UTF-8        reads rb_enc, does not
Ox.parse(xml).text.encoding     #=> UTF-8        same
```

So once any code in a process had set an encoding, `Ox.parse_obj` and `Ox.parse` went on applying it for the life of the process, whatever `Ox.default_options` was set to afterwards and whatever it reported. `Ox.load` was never affected — it re-derives `rb_enc` from the String it is handed whenever the name is empty (`ox.c:907`) — and neither were `Ox.dump` or the SAX parser, which read the name.

This is also what the save-and-restore idiom depends on: `@opts = Ox.default_options` in `setup` and `Ox.default_options = @opts` in `teardown`, which nine test files here use. The saved Hash carries a cleared encoding back as `nil`, so the restore did not restore.

`rake test_all` is green in all five blocks. The new test file fails 4 of its 6 tests on `develop`.

<details>
<summary>Measurements, and the test this was found through</summary>

### 150 assignment sequences

Every ordered pair and triple drawn from `nil`, `UTF-8`, `US-ASCII`, `EUC-JP` and `ASCII-8BIT`, each starting from a cleared state, comparing what `Ox.default_options` reports and what `parse_obj`, `parse`, `load` and `dump` produce.

**21 differ.** Every one of them ends in `encoding: nil`, and the 21 are exactly the sequences where clearing had something to clear and the result is visible:

```
  51  sequences ending in nil
  -2  nothing set before the nil        (nil,nil and nil,nil,nil)
 -28  ...whose last non-nil was ASCII-8BIT, which is what a cleared
      rb_enc gives anyway, so nothing observable moves
 ---
  21
```

The other 129 are byte-identical, including the whole reported option Hash, so no other option moved.

### The test this was found through

`test/regexp_encoding_test.rb` had a test written around this defect: it used `Ox.load` where `Ox.parse_obj` was the natural call, because a preceding test setting an encoding made `parse_obj` fail there. That test now uses `Ox.parse_obj` and the note explaining the detour is gone. On `develop` the file fails in roughly one random order out of three; on this branch 15 of 15 pass.

### Also verified

Valgrind clean; `clang-format --dry-run --Werror` clean; Ruby 2.7 syntax check passes; 15 random-order runs of both affected files. `rake test` goes from 210 tests / 4134 assertions to 216 / 4169.

The two new tests that pass on `develop` as well are the guards: a document's own `<?xml encoding?>` still winning over the default, and one encoding replacing another.

</details>
