### PR TITLE
Fix a Symbol name being truncated at an embedded NUL

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -236,8 +236,9 @@ static void append_string(Builder b, const char *str, size_t size, const char *t
 }
 
 static void append_sym_str(Builder b, VALUE v) {
-    const char *s;
-    long        len;
+    volatile VALUE sym = Qnil;
+    const char    *s;
+    long           len;
 
     switch (rb_type(v)) {
     case T_STRING:
@@ -245,8 +246,9 @@ static void append_sym_str(Builder b, VALUE v) {
         len = RSTRING_LEN(v);
         break;
     case T_SYMBOL:
-        s   = rb_id2name(SYM2ID(v));
-        len = strlen(s);
+        sym = rb_sym2str(v);
+        s   = StringValuePtr(sym);
+        len = RSTRING_LEN(sym);
         break;
     default: rb_raise(ox_arg_error_class, "expected a Symbol or String"); break;
     }
@@ -613,10 +615,11 @@ static VALUE builder_instruct(int argc, VALUE *argv, VALUE self) {
  * - +attributes+ - (Hash) of the element
  */
 static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
-    Builder     b;
-    Element     e;
-    const char *name;
-    long        len;
+    Builder        b;
+    Element        e;
+    volatile VALUE sym = Qnil;
+    const char    *name;
+    long           len;
 
     TypedData_Get_Struct(self, struct _builder, &ox_builder_type, b);
 
@@ -633,8 +636,9 @@ static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
         len  = RSTRING_LEN(*argv);
         break;
     case T_SYMBOL:
-        name = rb_id2name(SYM2ID(*argv));
-        len  = strlen(name);
+        sym  = rb_sym2str(*argv);
+        name = StringValuePtr(sym);
+        len  = RSTRING_LEN(sym);
         break;
     default: rb_raise(ox_arg_error_class, "expected a Symbol or String for an element name"); break;
     }
@@ -682,9 +686,10 @@ static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
  * - +attributes+ - (Hash) of the element
  */
 static VALUE builder_void_element(int argc, VALUE *argv, VALUE self) {
-    Builder     b;
-    const char *name;
-    long        len;
+    Builder        b;
+    volatile VALUE sym = Qnil;
+    const char    *name;
+    long           len;
 
     TypedData_Get_Struct(self, struct _builder, &ox_builder_type, b);
 
@@ -699,8 +704,9 @@ static VALUE builder_void_element(int argc, VALUE *argv, VALUE self) {
         len  = RSTRING_LEN(*argv);
         break;
     case T_SYMBOL:
-        name = rb_id2name(SYM2ID(*argv));
-        len  = strlen(name);
+        sym  = rb_sym2str(*argv);
+        name = StringValuePtr(sym);
+        len  = RSTRING_LEN(sym);
         break;
     default: rb_raise(ox_arg_error_class, "expected a Symbol or String for an element name"); break;
     }

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -151,9 +151,10 @@ static Type obj_class_code(VALUE obj) {
         return (is_xml_friendly((uchar *)StringValuePtr(obj), (int)RSTRING_LEN(obj), xml_element_chars)) ? StringCode
                                                                                                          : String64Code;
     case T_SYMBOL: {
-        const char *sym = rb_id2name(SYM2ID(obj));
+        volatile VALUE sym = rb_sym2str(obj);
 
-        return (is_xml_friendly((uchar *)sym, (int)strlen(sym), xml_element_chars)) ? SymbolCode : Symbol64Code;
+        return (is_xml_friendly((uchar *)RSTRING_PTR(sym), (int)RSTRING_LEN(sym), xml_element_chars)) ? SymbolCode
+                                                                                                      : Symbol64Code;
     }
     case T_DATA: return (rb_cTime == clas) ? TimeCode : ((ox_date_class == clas) ? DateCode : 0);
     case T_STRUCT: return (rb_cRange == clas) ? RangeCode : StructCode;
@@ -786,9 +787,10 @@ static void dump_obj(ID aid, VALUE obj, int depth, Out out) {
         break;
     }
     case T_SYMBOL: {
-        const char *sym = rb_id2name(SYM2ID(obj));
+        volatile VALUE rsym = rb_sym2str(obj);
+        const char    *sym  = RSTRING_PTR(rsym);
 
-        cnt = (int)strlen(sym);
+        cnt = (int)RSTRING_LEN(rsym);
 #if USE_B64
         if (is_xml_friendly((uchar *)sym, cnt)) {
             e.type = SymbolCode;
@@ -1220,21 +1222,24 @@ static int dump_gen_nodes(VALUE obj, int depth, Out out) {
 }
 
 static int dump_gen_attr(VALUE key, VALUE value, VALUE ov) {
-    Out out = (Out)ov;
-
-    const char *ks;
-    size_t      klen;
-    size_t      size;
+    Out            out = (Out)ov;
+    volatile VALUE kv  = key;
+    const char    *ks;
+    size_t         klen;
+    size_t         size;
 
     switch (rb_type(key)) {
-    case T_SYMBOL: ks = rb_id2name(SYM2ID(key)); break;
-    case T_STRING: ks = StringValuePtr(key); break;
-    default:
-        key = rb_String(key);
-        ks  = StringValuePtr(key);
-        break;
+    case T_SYMBOL: kv = rb_sym2str(key); break;
+    case T_STRING: break;
+    default: kv = rb_String(key); break;
     }
-    klen  = strlen(ks);
+    ks   = StringValuePtr(kv);
+    klen = (size_t)RSTRING_LEN(kv);
+    // The name is written raw, so a NUL would reach the buffer and rb_str_new2()
+    // would cut the whole document there. Values already raise on it.
+    if (NULL != memchr(ks, '\0', klen)) {
+        rb_raise(ox_syntax_error_class, "'\\#x00' is not a valid XML character.");
+    }
     value = rb_String(value);
     size  = 4 + klen + RSTRING_LEN(value);
     if (out->end - out->cur <= (long)size) {

--- a/test/symbol_nul_test.rb
+++ b/test/symbol_nul_test.rb
@@ -1,0 +1,191 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: a Symbol used as a name or value lost its length on the way
+# out, so an embedded NUL truncated it silently.
+#
+# rb_id2name() hands back a C string, so every call site took the length with
+# strlen(). A Symbol may hold a NUL, and there the length stopped short. The
+# truncation happened before any validation could see the byte, so the checks
+# added for the String paths never fired and the shorter name was written as if
+# the caller had asked for it:
+#
+#   Ox::Builder#element(:"a\0b")   wrote <a/>, where "a\0b" raises
+#   Ox.dump(:"a\0b")              wrote <m>a</m>, which loads back as :a
+#
+# The object mode round trip is the part that bites: a Hash keyed by :"a\0b"
+# came back keyed by :a, a different Symbol, with nothing raised anywhere.
+#
+# The fix is rb_sym2str() plus RSTRING_LEN, which keeps the length. Nothing here
+# asks for new validation - once the length survives, the checks that were
+# already there do the work, and a Symbol lands on the same answer as the String
+# it prints as.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class SymbolNulTest < ::Test::Unit::TestCase
+  MSG = "'\\#x00' is not a valid XML character."
+
+  # tests.rb leaves its own defaults behind and three of them change what the
+  # assertions below see, so establish all three rather than inherit them.
+  #
+  # :invalid_replace matters most. Ox.dump only raises on an invalid character
+  # while allow_invalid is No, and that is the startup state alone: assigning
+  # default_options without the key turns allow_invalid on, and no value turns
+  # it back off. Asking for '' instead pins the arm this file wants - the byte
+  # is dropped and the rest of the value is kept - whatever ran before it.
+  BASE_OPTIONS = {mode: :object, skip: :skip_white, invalid_replace: ''}.freeze
+
+  def setup
+    @opts = Ox.default_options
+    Ox.default_options = BASE_OPTIONS
+  end
+
+  def teardown
+    Ox.default_options = @opts
+  end
+
+  # Every writer that takes a name, as a pair of blocks: the Symbol form and the
+  # String form of the same name. The point of the fix is that the two agree.
+  PAIRS = {
+    'Builder#element' => [
+      ->(n) { Ox::Builder.new { |b| b.element(n.to_sym) } },
+      ->(n) { Ox::Builder.new { |b| b.element(n) } }
+    ],
+    'Builder#void_element' => [
+      ->(n) { Ox::Builder.new { |b| b.void_element(n.to_sym) } },
+      ->(n) { Ox::Builder.new { |b| b.void_element(n) } }
+    ],
+    'Builder attribute name' => [
+      ->(n) { Ox::Builder.new { |b| b.element('ok', n.to_sym => 'v') } },
+      ->(n) { Ox::Builder.new { |b| b.element('ok', n => 'v') } }
+    ],
+    'Element attribute name' => [
+      ->(n) { e = Ox::Element.new('r'); e[n.to_sym] = 'v'; Ox.dump(e) },
+      ->(n) { e = Ox::Element.new('r'); e[n] = 'v'; Ox.dump(e) }
+    ]
+  }.freeze
+
+  def outcome
+    yield
+  rescue Ox::SyntaxError => e
+    e.message
+  end
+
+  def test_a_symbol_name_agrees_with_the_string_it_prints_as
+    PAIRS.each do |where, (sym, str)|
+      %W[a\0b \0 a\0 ab\0 a\0b\0c #{'a' * 20}\0b].each do |n|
+        assert_equal(outcome { str.call(n) }, outcome { sym.call(n) }, "#{where} #{n.inspect}")
+      end
+    end
+  end
+
+  def test_every_name_writer_raises_on_a_symbol_with_a_nul
+    PAIRS.each do |where, (sym, _)|
+      e = assert_raise(Ox::SyntaxError, where) { sym.call("a\0b") }
+      assert_equal(MSG, e.message, where)
+    end
+  end
+
+  # The word loop reads eight bytes at a time and the tail loop takes what is
+  # left, so walk the NUL across more than two words.
+  def test_a_nul_is_found_at_any_offset_in_a_symbol
+    24.times do |n|
+      name = "#{'a' * n}\0#{'b' * 24}"
+      assert_raise(Ox::SyntaxError, "offset #{n}") do
+        Ox::Builder.new { |b| b.element(name.to_sym) }
+      end
+    end
+  end
+
+  # A name at or past struct _element's 64 byte inline buffer is strdup'd, which
+  # is the path #449 and #458 were about. Reaching it with a Symbol needs the
+  # length to be right first.
+  def test_a_long_symbol_name_raises_too
+    assert_raise(Ox::SyntaxError) { Ox::Builder.new { |b| b.element("#{'a' * 70}\0b".to_sym) } }
+    assert_raise(Ox::SyntaxError) { Ox::Builder.new { |b| b.element("\0#{'x' * 200}".to_sym) } }
+  end
+
+  # What the defect cost in practice, in one line. Everything after the NUL was
+  # dropped along with it, so the value came back as a different Symbol and
+  # nothing said so. A String in the same place has always kept its tail.
+  def test_ox_dump_keeps_what_follows_the_nul_in_a_symbol
+    assert_equal("<m>ab</m>\n", Ox.dump(:"a\0b"))
+    assert_equal("<s>ab</s>\n", Ox.dump("a\0b"))
+    assert_equal("<h>\n  <m>ab</m>\n  <i>1</i>\n</h>\n", Ox.dump({:"a\0b" => 1}))
+    assert_equal("<a>\n  <m>ab</m>\n</a>\n", Ox.dump([:"a\0b"]))
+  end
+
+  # An ivar holding such a Symbol reaches the same place by another route.
+  class Holder
+    def initialize(v)
+      @v = v
+    end
+  end
+
+  def test_a_symbol_held_in_an_object_keeps_its_tail
+    assert_equal("<o c=\"SymbolNulTest::Holder\">\n  <m a=\"@v\">ab</m>\n</o>\n",
+                 Ox.dump(Holder.new(:"a\0b")))
+  end
+
+  def test_an_instruct_attribute_name_raises
+    i = Ox::Instruct.new('xml')
+    i[:"a\0b"] = 'v'
+    doc = Ox::Document.new
+    doc << i
+    assert_raise(Ox::SyntaxError) { Ox.dump(doc) }
+  end
+
+  # Struct members are written by index, not by name, so a NUL in a member name
+  # never reaches the output. Pinned so the fix is not read as covering it.
+  NulMember = Struct.new(:"a\0b", :ok)
+
+  def test_a_struct_member_name_is_not_affected
+    assert_equal("<u c=\"SymbolNulTest::NulMember\">\n  <i a=\"0\">1</i>\n  <i a=\"1\">2</i>\n</u>\n",
+                 Ox.dump(NulMember.new(1, 2)))
+  end
+
+  # Symbols with no NUL have to be untouched, including the ones that take the
+  # base64 arm in object mode and the ones long enough to leave the fast path.
+  def test_symbols_without_a_nul_are_unchanged
+    [:a, :abc, :CamelCase, :_x, :'a<b', :'a&b', :'a b', :日本語, :é,
+     ('x' * 20).to_sym, ('y' * 100).to_sym].each do |sym|
+      assert_equal(sym, Ox.parse_obj(Ox.dump(sym)), sym.inspect)
+    end
+  end
+
+  # A tab, newline or carriage return in a Symbol reaches the output intact.
+  # What happens on the way back in is the :skip option's business, not this
+  # change's: the default :skip_white turns it into a space, so the round trip
+  # is lossy there and exact under the other two. Both arms are set explicitly
+  # because leaving it to whatever ran first is what made Z27's test flaky.
+  def test_whitespace_in_a_symbol_reaches_the_output
+    assert_equal("<m>a\nb</m>\n", Ox.dump(:"a\nb"))
+    assert_equal("<m>a\tb</m>\n", Ox.dump(:"a\tb"))
+    assert_equal("<s>a\nb</s>\n", Ox.dump("a\nb"))
+
+    Ox.default_options = {mode: :object, skip: :skip_white}
+    assert_equal(:"a b", Ox.parse_obj(Ox.dump(:"a\nb")))
+    Ox.default_options = {mode: :object, skip: :skip_none}
+    assert_equal(:"a\nb", Ox.parse_obj(Ox.dump(:"a\nb")))
+  end
+
+  def test_a_symbol_name_still_writes_the_same_document
+    xml = Ox::Builder.new do |b|
+      b.element(:top, :a => '1') do
+        b.element(:mid) { b.text('hello') }
+        b.void_element(:br)
+      end
+    end
+    assert_equal(%(<top a="1">\n  <mid>hello</mid>\n  <br>\n</top>\n).b, xml)
+  end
+
+  def test_a_symbol_keyed_hash_still_round_trips
+    h = {a: 1, b: 'two', 'c' => :three}
+    assert_equal(h, Ox.parse_obj(Ox.dump(h)))
+  end
+end


### PR DESCRIPTION
`rb_id2name()` hands back a C string, so every call site took the length back with `strlen()`. A Symbol may hold a NUL, and there the length stopped short — before any validation could see the byte, so the shorter name was written as if the caller had asked for it. The String in the same position has raised since #458.

```ruby
Ox::Builder.new { |b| b.element(:"a\0b") }  #=> "<a/>\n"      "a\0b" raises
Ox.dump(:"a\0b")                            #=> "<m>a</m>\n"
Ox.parse_obj(Ox.dump({:"a\0b" => 1}))       #=> {a: 1}        a different Symbol
```

Replaced with `rb_sym2str()` plus `RSTRING_LEN` at the six sites that reach the output, each holding the name String in a `volatile VALUE` for as long as the char pointer is used. Measured 904 cases against `develop`: **the 432 with no NUL are unchanged**, and all 313 changes are NUL cases, 307 of which were silently wrong output before.

<details>
<summary>Sites, the deliberate extra check, evidence, and what is left out</summary>

### Sites

Changed, the six that reach the output: `builder.c` `append_sym_str`, `builder_element`, `builder_void_element`; `dump.c` `obj_class_code`, the `T_SYMBOL` arm of `dump_obj`, and `dump_gen_attr`.

Left alone, none of them able to hold a NUL: `ox.c:649/1355` format an option name into an error message, `obj_load.c:699` only tests the result against `NULL` and `:940` is a debug `printf`, and `dump.c:665` takes an ivar name, which Ruby will not let contain a NUL.

### The one check that is not just a length

`dump_gen_attr` also took `strlen()` on String and converted keys, so those lost their length the same way; it now takes `RSTRING_LEN` for every kind of key. That is why it gained a NUL check: the name is written with `fill_value()` rather than `dump_str_value()`, so once the length is right the byte reaches the buffer, and `rb_str_new2()` in `ox.c:1393` would cut the whole document there. Values already raise on it. Happy to drop this if you would rather it stayed a pure length change.

### Evidence

904 dump and build cases, over names that are plain, unfriendly, multibyte, longer than the fast path, and carrying a NUL at every offset from 0 to 20, each written as both a Symbol and the String it prints as:

| | rows | changed |
|---|---|---|
| no NUL | 432 | **0** |
| with a NUL | 468 | 312, all to the same `Ox::SyntaxError`; 156 unchanged (the String arms, already raising) |
| held in an ivar or a Struct | 4 | 1, a Symbol in an ivar |

313 changed in all. 307 were silently wrong output before; the other 6 raised on the way back in instead, as `Ox::ParseError "Invalid element for object mode"` from `obj_load.c`, reporting the damage a document later. One further row differs only by an anonymous class's address and is not a change.

`test/symbol_nul_test.rb` covers the six paths, a Symbol agreeing with the String it prints as, the NUL at every offset across more than two words, names past `struct _element`'s 64 byte inline buffer, an ivar and an Instruct attribute, and Struct members staying unaffected since they are written by index. It fixes `:mode`, `:skip` and `:invalid_replace` rather than inheriting them, because all three change what the assertions see. 7 of its 12 tests fail on `develop`; the 5 that pass are the deliberate guards.

Valgrind clean over 503 tests. `GC.stress` across 300 dynamic symbols through seven paths each, which is what the `volatile VALUE` holds are for. clang-format clean, Ruby 2.7 syntax checked, six random test orders. The ASAN `dynamic-stack-buffer-overflow` the suite reports is Ruby's own `invoke_iseq_block_from_c` and reproduces identically on `develop`.

### Found while doing this, and left out

Each of these is a separate root cause, so none is folded in. Say the word on any of them and I will send a patch or open an issue.

* **`Ox.dump` does not validate or escape a DOM element or attribute name at all.** `Ox::Element.new("a<b/><injected")` reads back as element `injected`, and `e[%q{a="1" b}] = "2"` reads back as two attributes. Picking what a name may hold is a judgement call of the same kind as issue #460.
* **`Ox.default_options=` without `:invalid_replace` turns `allow_invalid` on, and no value turns it back off**, so `Ox.dump` can never raise on an invalid character again in that process. Same shape as #459, but with no way back.
* **`allow_invalid` writes `&#x0000;`**, which is not a valid character reference, so ox cannot read back what it wrote.
* **The object mode round trip collapses `\t`, `\n` and `\r` to a space** under the default `skip: :skip_white`, for Strings as well as Symbols.

</details>
