### PR TITLE
Fix the arity -1 entry points reading past their arguments

### DIFF
--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -997,6 +997,9 @@ static VALUE load_str(int argc, VALUE *argv, VALUE self) {
     VALUE       encoding;
     struct _err err;
 
+    if (1 > argc) {
+        rb_raise(ox_arg_error_class, "missing XML string");
+    }
     err_init(&err);
     Check_Type(*argv, T_STRING);
     /* the xml string gets modified so make a copy of it */
@@ -1059,6 +1062,9 @@ static VALUE load_file(int argc, VALUE *argv, VALUE self) {
     VALUE       obj;
     struct _err err;
 
+    if (1 > argc) {
+        rb_raise(ox_arg_error_class, "missing file path");
+    }
     err_init(&err);
     Check_Type(*argv, T_STRING);
     path = StringValuePtr(*argv);
@@ -1384,6 +1390,9 @@ static VALUE dump(int argc, VALUE *argv, VALUE self) {
     struct _options copts = ox_default_options;
     VALUE           rstr;
 
+    if (1 > argc) {
+        rb_raise(ox_arg_error_class, "missing object to dump");
+    }
     if (2 == argc) {
         parse_dump_options(argv[1], &copts);
     }
@@ -1446,6 +1455,9 @@ static VALUE to_xml(int argc, VALUE *argv, VALUE self) {
 static VALUE to_file(int argc, VALUE *argv, VALUE self) {
     struct _options copts = ox_default_options;
 
+    if (2 > argc) {
+        rb_raise(ox_arg_error_class, "missing file path or object to write");
+    }
     if (3 == argc) {
         parse_dump_options(argv[2], &copts);
     }

--- a/test/argc_test.rb
+++ b/test/argc_test.rb
@@ -1,0 +1,118 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: the arity -1 entry points in ox.c read *argv without checking
+# argc first.
+#
+# Ox.load, Ox.load_file, Ox.dump, Ox.to_xml and Ox.to_file are all defined with
+# arity -1 and went straight to *argv, so calling one with too few arguments
+# read the slot an argument would have occupied. What is in that slot is
+# whatever the caller's dispatch left there, and it is not the same thing twice:
+#
+#   Ox.load                    read a Module
+#   Ox.load from an includer   read an Object
+#   Ox.public_send(:load)      read a BasicObject
+#   Ox.method(:load).call      read a Method
+#
+# None of them crashed, since the slot is mapped, and each was rejected a step
+# later by Check_Type or by the dumper. The risk is the value that is not
+# rejected: a String there would have been parsed as if the caller had passed
+# it. Ox.sax_parse and Ox.sax_html already checked, as does every arity -1
+# method in builder.c, so this brings the rest into line.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'tmpdir'
+require 'ox'
+
+class ArgcTest < ::Test::Unit::TestCase
+  # Every call that used to reach past its arguments, with the message it should
+  # now give.
+  SHORT_CALLS = {
+    'Ox.load' => [-> { Ox.load }, 'missing XML string'],
+    'Ox.load_file' => [-> { Ox.load_file }, 'missing file path'],
+    'Ox.dump' => [-> { Ox.dump }, 'missing object to dump'],
+    'Ox.to_xml' => [-> { Ox.to_xml }, 'missing object to dump'],
+    'Ox.to_file' => [-> { Ox.to_file }, 'missing file path or object to write'],
+    'Ox.to_file(path)' => [-> { Ox.to_file('/dev/null') }, 'missing file path or object to write']
+  }.freeze
+
+  def test_a_short_call_raises_with_a_message
+    SHORT_CALLS.each do |where, (call, message)|
+      e = assert_raise(Ox::ArgError, where) { call.call }
+      assert_equal(message, e.message, where)
+    end
+  end
+
+  # The slot held something different on each of these paths before the check,
+  # so all of them have to end up at the same answer now.
+  def test_every_dispatch_path_agrees
+    [-> { Ox.load },
+     -> { Ox.send(:load) },
+     -> { Ox.public_send(:load) },
+     -> { Ox.method(:load).call },
+     -> { Ox.load(*[]) },
+     -> { [nil].map { Ox.load }.first }].each_with_index do |call, i|
+      e = assert_raise(Ox::ArgError, "path #{i}") { call.call }
+      assert_equal('missing XML string', e.message, "path #{i}")
+    end
+  end
+
+  # rb_define_module_function also defines a private instance method, so an
+  # includer reaches the same code with a different self. That changed what the
+  # unchecked read returned.
+  class Includer
+    include Ox
+
+    def short_load
+      load
+    end
+
+    def short_dump
+      dump
+    end
+  end
+
+  def test_an_includer_gets_the_same_answer
+    assert_raise(Ox::ArgError) { Includer.new.short_load }
+    assert_raise(Ox::ArgError) { Includer.new.short_dump }
+  end
+
+  # sax_parse and sax_html were already checked and keep their own class and
+  # wording, which this change deliberately leaves alone.
+  def test_the_sax_entry_points_are_unchanged
+    e = assert_raise(Ox::ParseError) { Ox.sax_parse }
+    assert_equal("Wrong number of arguments to sax_parse.\n", e.message)
+    e = assert_raise(Ox::ParseError) { Ox.sax_html }
+    assert_equal("Wrong number of arguments to sax_html.\n", e.message)
+  end
+
+  # Only the lower bound is checked, which is what sax_parse does and what every
+  # one of these has always done: an extra argument is ignored, not refused.
+  def test_extra_arguments_are_still_ignored
+    assert_equal("<s>s</s>\n", Ox.dump('s', {}, :extra))
+    assert_instance_of(Ox::Element, Ox.load('<r/>', {}, :extra))
+  end
+
+  def test_the_calls_still_work_with_the_arguments_they_want
+    assert_equal("<s>s</s>\n", Ox.dump('s'))
+    assert_equal("<s>s</s>\n", Ox.to_xml('s'))
+    assert_instance_of(Ox::Element, Ox.load('<r/>'))
+    assert_instance_of(Ox::Element, Ox.load('<r/>', mode: :generic))
+
+    Dir.mktmpdir('ox-argc') do |dir|
+      path = File.join(dir, 'doc.xml')
+      Ox.to_file(path, Ox::Element.new('r'))
+      back = Ox.load_file(path)
+      assert_instance_of(Ox::Element, back)
+      assert_equal('r', back.value)
+    end
+  end
+
+  def test_ox_arg_error_is_an_ox_error
+    assert_operator(Ox::ArgError, :<, Ox::Error)
+    assert_operator(Ox::ArgError, :<, StandardError)
+  end
+end


### PR DESCRIPTION
`Ox.load`, `Ox.load_file`, `Ox.dump`, `Ox.to_xml` and `Ox.to_file` are defined with arity `-1` and went straight to `*argv` without checking `argc`, so calling one with too few arguments read the slot an argument would have occupied. What is in that slot is whatever the caller's dispatch left there, and it is not the same thing twice:

```ruby
Ox.load                  # read a Module
Ox.public_send(:load)    # read a BasicObject
Ox.method(:load).call    # read a Method
```

None crashed — the slot is mapped, and each value was rejected a step later by `Check_Type` or by the dumper. The risk is the value that would **not** be rejected: a String there would have been parsed as if the caller had passed it. `Ox.sax_parse` and `Ox.sax_html` already checked, as does every arity `-1` method in `builder.c`, so this only brings the rest into line.

<details>
<summary>What each call read, the choices in the patch, and what is left alone</summary>

### What was read

| call | read |
|---|---|
| `Ox.load` | a Module |
| `load` from a class that includes Ox | an Object |
| `Ox.public_send(:load)` | a BasicObject |
| `Ox.method(:load).call` | a Method |

Rejected a step later as `TypeError: wrong argument type Module (expected String)` for `load`/`load_file`/`to_file`, and `NotImplementedError: Failed to dump Module Object (1a)` for `dump`/`to_xml`.

`Ox.to_file` is short by one as well as by two, since it reads `argv[1]` after `Check_Type` on `argv[0]` — so `Ox.to_file(path)` reached past its arguments too.

### Only the lower bound

Every one of these silently ignores an extra argument today, `sax_parse` included:

```ruby
Ox.dump('s', {}, :extra)   #=> "<s>s</s>\n"
Ox.load('<r/>', {}, :extra) #=> #<Ox::Element>
```

so refusing one would be a change beyond the defect. The patch checks the lower bound only, which is what `sax_parse` does.

### The error class

Raises `Ox::ArgError`, which is what `builder.c` raises for the same thing — `"missing element name"`, `"missing filename"`, `"missing IO object"`.

`sax_parse` and `sax_html` instead raise `Ox::ParseError` with `"Wrong number of arguments to sax_parse."`. I left those alone, but there are three defensible answers here and only you can pick:

* leave it as in this patch — `builder.c`'s class and wording for the five, `sax_parse`'s for the two
* make the five match `sax_parse` — `Ox::ParseError`
* make all seven raise `ArgumentError`, which is what Ruby itself raises for arity, and which `Ox::ArgError` does not inherit from

Happy to send whichever.

### Tests

`test/argc_test.rb` covers each short call and its message, the six dispatch paths that used to read six different things, an includer reaching the same code with a different `self`, the sax entry points keeping their own class and wording, extra arguments still being ignored, and the calls still working with the arguments they want. 3 of its 7 tests fail on `develop`.

Valgrind clean over 498 tests. clang-format clean, Ruby 2.7 syntax checked, five random test orders, 227 to 234 tests.

</details>
