### PR TITLE
Fix a slash in a Regexp pattern coming back escaped

### DIFF
--- a/ext/ox/obj_load.c
+++ b/ext/ox/obj_load.c
@@ -330,6 +330,8 @@ static VALUE circ_array_get(CircArray ca, unsigned long id) {
 
 static VALUE parse_regexp(const char *text, PInfo pi) {
     const char *te;
+    const char *s;
+    char       *b;
     VALUE       src;
     size_t      len     = strlen(text);
     int         options = 0;
@@ -363,7 +365,26 @@ static VALUE parse_regexp(const char *text, PInfo pi) {
     // and leaves the source ASCII-8BIT. Going through the String also gets
     // Ruby's own rule, which promotes an ASCII only source to US-ASCII the way
     // a literal is.
-    src = rb_str_new(text + 1, te - text - 1);
+    src = rb_str_new(0, te - text - 1);
+    b   = RSTRING_PTR(src);
+    // The dumper writes Regexp#inspect, which escapes a / in the source as \/,
+    // so take that back off. A backslash pair is stepped over whole or the /
+    // in "\\/" would be read as the escaped one.
+    s = text + 1;
+    while (s < te) {
+        if ('\\' == *s && s + 1 < te) {
+            if ('/' == s[1]) {
+                *b++ = '/';
+            } else {
+                *b++ = *s;
+                *b++ = s[1];
+            }
+            s += 2;
+        } else {
+            *b++ = *s++;
+        }
+    }
+    rb_str_set_len(src, b - RSTRING_PTR(src));
     if (0 != pi->options->rb_enc) {
         rb_enc_associate(src, pi->options->rb_enc);
     }

--- a/test/regexp_literal_test.rb
+++ b/test/regexp_literal_test.rb
@@ -98,11 +98,13 @@ class RegexpLiteralTest < ::Test::Unit::TestCase
   end
 
   # Regexp#inspect escapes a '/' in the pattern, so scanning back from the end
-  # still lands on the delimiter and the length covers the whole pattern.
+  # still lands on the delimiter and the length covers the whole pattern. The
+  # source used to keep the backslash inspect had added, which is what
+  # regexp_slash_test.rb is about; what this one pins is the delimiter scan.
   def test_an_escaped_slash_in_the_pattern
     re = load_obj('/a\\/b/')
     assert_instance_of(Regexp, re)
-    assert_equal('a\\/b', re.source)
+    assert_equal('a/b', re.source)
     assert_match(re, 'a/b')
   end
 

--- a/test/regexp_slash_test.rb
+++ b/test/regexp_slash_test.rb
@@ -1,0 +1,139 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: a '/' in a Regexp pattern came back with a backslash in front
+# of it, so the loaded Regexp was not == the one that was dumped.
+#
+# The dumper writes Regexp#inspect, which escapes a '/' in the source as '\/'.
+# The loader took the bytes between the delimiters verbatim, so the backslash
+# inspect had added stayed in the source:
+#
+#   Ox.dump(%r{a/b})           => "<g>/a\\/b/</g>"
+#   Ox.parse_obj(that).source  => "a\\/b"     where the original was "a/b"
+#
+# Matching was never affected, since '\/' and '/' mean the same thing to a
+# regexp engine. What changed was the source, and Regexp#== compares sources.
+#
+# The dumped form is ambiguous and cannot be made to round trip everything:
+# Regexp.new('/') and Regexp.new('\/') hold different sources, are not ==, and
+# both write "/\//". One of the two has to lose. This picks the one that Ruby
+# itself cannot produce from a literal - /a\/b/.source is already "a/b", so a
+# source holding '\/' only comes from Regexp.new with a redundant backslash, and
+# that Regexp matches exactly what the unescaped one matches.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class RegexpSlashTest < ::Test::Unit::TestCase
+  # tests.rb leaves mode: :object behind and :encoding changes what a source
+  # comes back as, so establish both rather than inherit them.
+  BASE_OPTIONS = {mode: :object, encoding: nil}.freeze
+
+  def setup
+    @opts = Ox.default_options
+    Ox.default_options = BASE_OPTIONS
+  end
+
+  def teardown
+    Ox.default_options = @opts
+  end
+
+  def round_trip(re)
+    Ox.parse_obj(Ox.dump(re))
+  end
+
+  # The gate. Every one of these has a bare '/' somewhere and none of them
+  # round tripped before.
+  SLASHED = ['a/b', '/', '//', '/a', 'a/', 'a//b', '///',
+             '[a/b]', '(?<n>/)', 'a{1,2}/', '\\A/\\z'].freeze
+
+  def test_a_slash_in_the_pattern_survives
+    SLASHED.each do |src|
+      re = Regexp.new(src)
+      back = round_trip(re)
+      assert_instance_of(Regexp, back, src)
+      assert_equal(re.source, back.source, src)
+      assert_equal(re, back, src)
+    end
+  end
+
+  # A '/' after a real backslash is the case a naive unescape would get wrong,
+  # since the backslash pair has to be stepped over whole.
+  def test_a_slash_after_an_escaped_backslash_survives
+    ['a\\\\/b', 'a\\\\\\\\/b', '\\\\/', '/\\\\/'].each do |src|
+      re = Regexp.new(src)
+      assert_equal(re.source, round_trip(re).source, src)
+      assert_equal(re, round_trip(re), src)
+    end
+  end
+
+  # Sources with no '/' at all were never affected and must stay that way.
+  def test_patterns_without_a_slash_are_unchanged
+    ['abc', 'a.c', '\\d+', 'a|b', '\\\\', 'a\\.b', 'a\\nb', "a\nb",
+     'a"b', "a'b", 'a<b', 'a&b', 'a\\\\', ''].each do |src|
+      re = Regexp.new(src)
+      assert_equal(re.source, round_trip(re).source, src)
+      assert_equal(re, round_trip(re), src)
+    end
+  end
+
+  # Every Regexp that can be written as a literal round trips, because Ruby
+  # normalises the redundant backslash away when it reads the literal.
+  def test_literals_round_trip
+    [%r{a/b}, /a\/b/, %r{/}, %r{//}, /\A\/\z/, %r{[a/b]}, %r{a/b}i, %r{/}mx,
+     //, /abc/, /a.c/i, /\d+/m, /a|b/x].each do |re|
+      assert_equal(re, round_trip(re), re.inspect)
+    end
+  end
+
+  def test_flags_survive_alongside_a_slash
+    assert_equal(Regexp::IGNORECASE, round_trip(%r{a/b}i).options)
+    assert_equal(Regexp::MULTILINE | Regexp::EXTENDED, round_trip(%r{/}mx).options)
+    assert_equal(0, round_trip(%r{a/b}).options)
+  end
+
+  # The two spellings the dumped form cannot tell apart. Whichever way the
+  # loader reads it, one of them comes back as the other, so pin which.
+  def test_the_ambiguous_pair
+    bare = Regexp.new('/')
+    escaped = Regexp.new('\\/')
+    assert_not_equal(bare.source, escaped.source)
+    assert_not_equal(bare, escaped)
+    assert_equal(bare.inspect, escaped.inspect, 'the dumped form is the same for both')
+
+    assert_equal(bare, round_trip(bare))
+    assert_equal(bare, round_trip(escaped))
+  end
+
+  # Neither spelling changes what the Regexp matches, which is why trading one
+  # for the other is not a behaviour change.
+  def test_the_redundant_escape_matches_the_same_things
+    a = Regexp.new('a\\/b')
+    b = Regexp.new('a/b')
+    ['a/b', 'a\\/b', 'x', ''].each do |s|
+      assert_equal(a.match?(s), b.match?(s), s)
+      assert_equal(a.match?(s), round_trip(a).match?(s), s)
+    end
+  end
+
+  def test_a_regexp_with_a_slash_inside_a_larger_document
+    src = {a: %r{x/y}i, b: [%r{/}, 'z/w']}
+    assert_equal(src, Ox.parse_obj(Ox.dump(src)))
+  end
+
+  # A pattern the loader cannot make sense of still raises rather than being
+  # read past the end.
+  def test_malformed_input_still_raises
+    assert_raise(Ox::ParseError) { Ox.parse_obj('<g>abc</g>') }
+    assert_raise(Ox::ParseError) { Ox.parse_obj('<g>/</g>') }
+    assert_raise(Ox::ParseError) { Ox.parse_obj('<g></g>') }
+  end
+
+  # A trailing backslash has no byte after it to pair with.
+  def test_a_trailing_backslash_is_not_read_past
+    assert_raise(RegexpError) { Ox.parse_obj('<g>/a\\/</g>') }
+  end
+end


### PR DESCRIPTION
The dumper writes `Regexp#inspect`, which escapes a `/` in the source as `\/`. The loader took the bytes between the delimiters verbatim, so the backslash `inspect` had added stayed in the source and the Regexp that came back was not `==` the one that went out:

```ruby
Ox.dump(%r{a/b})                    #=> "<g>/a\\/b/</g>"
Ox.parse_obj(Ox.dump(%r{a/b})).source  #=> "a\\/b"    the original was "a/b"
```

Matching was never affected — `\/` and `/` mean the same thing to the engine. What changed was the source, and `Regexp#==` compares sources. `parse_regexp()` now takes that backslash back off, stepping over a backslash pair whole so the `/` in `"\\/"` is not read as the escaped one. **Round trip goes from 16/31 sources to 28/31**, and nothing is written differently, so documents stay compatible in both directions.

<details>
<summary>Why 28 and not 31, the measurements, and what moved in the tests</summary>

### The dumped form is ambiguous

`Regexp.new('/')` and `Regexp.new('\/')` hold different sources, are **not** `==`, and both write `"/\//"`. One of the two has to lose — no reading of that text can give back both.

This picks the one Ruby itself cannot produce from a literal:

```ruby
/a\/b/.source   #=> "a/b"     Ruby normalises the redundant backslash away
%r{a/b}.source  #=> "a/b"
Regexp.new('a\/b').source  #=> "a\\/b"   only this way keeps it
```

So after this change **every Regexp that can be written as a literal round trips**, and the three that do not are redundant escapes built through `Regexp.new`, each of which matches exactly what its unescaped form matches.

If you would rather not make that trade, the alternative is to stop writing `inspect` and write the source and flags separately — unambiguous, but a change to what goes on the wire, which is why I did not reach for it. Say the word either way.

### Measurements

31 hand built sources: bare slashes, slashes after real backslashes, runs of backslashes, slashes at either end, and sources with no slash at all.

| | |
|---|---|
| round trip before | 16 / 31 |
| round trip after | **28 / 31** |
| fixed | 15 |
| traded | 3 — `'\/'`, `'a\/b'`, `'\\\/'` |

Over the same 31 sources against 17 subject strings, **what each Regexp matches is unchanged**, before and after.

### Tests

`test/regexp_slash_test.rb` covers the slashed sources, a slash after an escaped backslash, sources with no slash staying untouched, every Regexp that can be written as a literal round tripping, flags surviving alongside a slash, the ambiguous pair and which way it now falls, that the redundant escape matches the same things, a Regexp with a slash inside a larger document, and malformed input still raising. 5 of its 10 tests fail on `develop`.

One assertion in `regexp_literal_test.rb` pinned the old source and now reads `"a/b"`. That file is about the delimiter scan from #455, which this does not change, so only the source assertion moved.

Valgrind clean over 501 tests. clang-format clean, Ruby 2.7 syntax checked, five random test orders, 227 to 237 tests.

</details>
