### PR TITLE
Fix a rescued raise leaving part of the value in the buffer

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -112,9 +112,51 @@ static void append_indent(Builder b) {
     }
 }
 
-static void append_string(Builder b, const char *str, size_t size, const char *table, bool strip_invalid_chars) {
+// Returns the escaped size append_string() needs, and raises first if the value
+// holds a character XML has no way to write. append_string() raises on the same
+// byte, but only once the delimiters around the value are already in the buffer
+// and, for an element, once the element is on the stack, and nothing takes those
+// back. So the writers ask here before they write anything.
+//
+// Only a value whose escaped form is longer can hold one, since an invalid byte
+// counts 10, so the common case is the one walk append_string() always did.
+inline static size_t check_string(const char *str, size_t size, const char *table) {
     size_t xsize = xml_str_len((const unsigned char *)str, size, table);
 
+    if (xsize != size) {
+        const unsigned char *bad = xml_first_invalid((const unsigned char *)str, size);
+
+        if (NULL != bad) {
+            rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *bad);
+        }
+    }
+    return xsize;
+}
+
+// Resolves a Symbol or String name to bytes and checks it, for the writers that
+// take either. sym holds the Symbol's name String for as long as *strp is used.
+inline static long check_name(VALUE v, volatile VALUE *sym, const char **strp, size_t *xsizep, const char *msg) {
+    long len;
+
+    switch (rb_type(v)) {
+    case T_STRING:
+        *strp = StringValuePtr(v);
+        len   = RSTRING_LEN(v);
+        break;
+    case T_SYMBOL:
+        *sym  = rb_sym2str(v);
+        *strp = RSTRING_PTR(*sym);
+        len   = RSTRING_LEN(*sym);
+        break;
+    default: rb_raise(ox_arg_error_class, "%s", msg); break;
+    }
+    *xsizep = check_string(*strp, (size_t)len, xml_element_chars);
+
+    return len;
+}
+
+static void
+append_string(Builder b, const char *str, size_t size, const char *table, size_t xsize, bool strip_invalid_chars) {
     if (size == xsize) {
         const char *s   = str;
         const char *end = str + size;
@@ -238,21 +280,10 @@ static void append_string(Builder b, const char *str, size_t size, const char *t
 static void append_sym_str(Builder b, VALUE v) {
     volatile VALUE sym = Qnil;
     const char    *s;
-    long           len;
+    size_t         xsize = 0;
+    long           len   = check_name(v, &sym, &s, &xsize, "expected a Symbol or String");
 
-    switch (rb_type(v)) {
-    case T_STRING:
-        s   = StringValuePtr(v);
-        len = RSTRING_LEN(v);
-        break;
-    case T_SYMBOL:
-        sym = rb_sym2str(v);
-        s   = StringValuePtr(sym);
-        len = RSTRING_LEN(sym);
-        break;
-    default: rb_raise(ox_arg_error_class, "expected a Symbol or String"); break;
-    }
-    append_string(b, s, len, xml_element_chars, false);
+    append_string(b, s, len, xml_element_chars, xsize, false);
 }
 
 static void i_am_a_child(Builder b, bool is_text) {
@@ -272,17 +303,29 @@ static void i_am_a_child(Builder b, bool is_text) {
 }
 
 static int append_attr(VALUE key, VALUE value, VALUE bv) {
-    Builder b = (Builder)bv;
+    Builder        b   = (Builder)bv;
+    volatile VALUE sym = Qnil;
+    const char    *ks;
+    long           klen;
+    size_t         kx;
+    size_t         vsize;
+    size_t         vx;
+
+    // Both halves before the space: an attribute is either written whole or not
+    // at all, and the element it belongs to is left as it was.
+    Check_Type(value, T_STRING);
+    klen  = check_name(key, &sym, &ks, &kx, "expected a Symbol or String");
+    vsize = (size_t)RSTRING_LEN(value);
+    vx    = check_string(StringValuePtr(value), vsize, xml_attr_chars);
 
     buf_append(&b->buf, ' ');
     b->col++;
     b->pos++;
-    append_sym_str(b, key);
+    append_string(b, ks, klen, xml_element_chars, kx, false);
     buf_append_string(&b->buf, "=\"", 2);
     b->col += 2;
     b->pos += 2;
-    Check_Type(value, T_STRING);
-    append_string(b, StringValuePtr(value), (int)RSTRING_LEN(value), xml_attr_chars, false);
+    append_string(b, StringValuePtr(value), vsize, xml_attr_chars, vx, false);
     buf_append(&b->buf, '"');
     b->col++;
     b->pos++;
@@ -331,7 +374,12 @@ static void pop(Builder b) {
             append_indent(b);
         }
         buf_append_string(&b->buf, "</", 2);
-        append_string(b, e->name, e->len, xml_element_chars, false);
+        append_string(b,
+                      e->name,
+                      e->len,
+                      xml_element_chars,
+                      xml_str_len((const unsigned char *)e->name, e->len, xml_element_chars),
+                      false);
         buf_append(&b->buf, '>');
         b->col += e->len + 3;
         b->pos += e->len + 3;
@@ -547,6 +595,13 @@ static VALUE builder_instruct(int argc, VALUE *argv, VALUE self) {
     Builder b;
 
     TypedData_Get_Struct(self, struct _builder, &ox_builder_type, b);
+    if (0 < argc) {
+        volatile VALUE nsym = Qnil;
+        const char    *nstr;
+        size_t         nx;
+
+        check_name(*argv, &nsym, &nstr, &nx, "expected a Symbol or String");
+    }
     i_am_a_child(b, false);
     append_indent(b);
     if (0 == argc) {
@@ -617,7 +672,8 @@ static VALUE builder_instruct(int argc, VALUE *argv, VALUE self) {
 static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
     Builder        b;
     Element        e;
-    volatile VALUE sym = Qnil;
+    volatile VALUE sym   = Qnil;
+    size_t         xsize = 0;
     const char    *name;
     long           len;
 
@@ -626,30 +682,15 @@ static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
     if (1 > argc) {
         rb_raise(ox_arg_error_class, "missing element name");
     }
-    i_am_a_child(b, false);
-    append_indent(b);
-    // Everything that can raise has to run before b->depth++ or the raise
-    // leaves a stack slot that was never filled in.
-    switch (rb_type(*argv)) {
-    case T_STRING:
-        name = StringValuePtr(*argv);
-        len  = RSTRING_LEN(*argv);
-        break;
-    case T_SYMBOL:
-        sym  = rb_sym2str(*argv);
-        name = StringValuePtr(sym);
-        len  = RSTRING_LEN(sym);
-        break;
-    default: rb_raise(ox_arg_error_class, "expected a Symbol or String for an element name"); break;
-    }
-    // append_string() below raises on the NUL too, but only after strdup() has
-    // copied a name shorter than len says it is.
-    if (NULL != memchr(name, '\0', (size_t)len)) {
-        rb_raise(ox_syntax_error_class, "'\\#x00' is not a valid XML character.");
-    }
+    // Everything that can raise has to run before the first write, or the raise
+    // leaves an element started that no later call can finish or take back. It
+    // also has to run before b->depth++, or the stack slot is never filled in.
+    len = check_name(*argv, &sym, &name, &xsize, "expected a Symbol or String for an element name");
     if (MAX_DEPTH <= b->depth + 1) {
         rb_raise(ox_arg_error_class, "XML too deeply nested");
     }
+    i_am_a_child(b, false);
+    append_indent(b);
     b->depth++;
     e = &b->stack[b->depth];
     if (sizeof(e->buf) <= (size_t)len) {
@@ -666,7 +707,7 @@ static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
     buf_append(&b->buf, '<');
     b->col++;
     b->pos++;
-    append_string(b, e->name, len, xml_element_chars, false);
+    append_string(b, e->name, len, xml_element_chars, xsize, false);
     if (1 < argc && T_HASH == rb_type(argv[1])) {
         rb_hash_foreach(argv[1], append_attr, (VALUE)b);
     }
@@ -687,7 +728,8 @@ static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
  */
 static VALUE builder_void_element(int argc, VALUE *argv, VALUE self) {
     Builder        b;
-    volatile VALUE sym = Qnil;
+    volatile VALUE sym   = Qnil;
+    size_t         xsize = 0;
     const char    *name;
     long           len;
 
@@ -696,24 +738,13 @@ static VALUE builder_void_element(int argc, VALUE *argv, VALUE self) {
     if (1 > argc) {
         rb_raise(ox_arg_error_class, "missing element name");
     }
+    len = check_name(*argv, &sym, &name, &xsize, "expected a Symbol or String for an element name");
     i_am_a_child(b, false);
     append_indent(b);
-    switch (rb_type(*argv)) {
-    case T_STRING:
-        name = StringValuePtr(*argv);
-        len  = RSTRING_LEN(*argv);
-        break;
-    case T_SYMBOL:
-        sym  = rb_sym2str(*argv);
-        name = StringValuePtr(sym);
-        len  = RSTRING_LEN(sym);
-        break;
-    default: rb_raise(ox_arg_error_class, "expected a Symbol or String for an element name"); break;
-    }
     buf_append(&b->buf, '<');
     b->col++;
     b->pos++;
-    append_string(b, name, len, xml_element_chars, false);
+    append_string(b, name, len, xml_element_chars, xsize, false);
     if (1 < argc && T_HASH == rb_type(argv[1])) {
         rb_hash_foreach(argv[1], append_attr, (VALUE)b);
     }
@@ -732,15 +763,19 @@ static VALUE builder_void_element(int argc, VALUE *argv, VALUE self) {
  */
 static VALUE builder_comment(VALUE self, VALUE text) {
     Builder b;
+    size_t  size;
+    size_t  xsize;
 
     TypedData_Get_Struct(self, struct _builder, &ox_builder_type, b);
     rb_check_type(text, T_STRING);
+    size  = (size_t)RSTRING_LEN(text);
+    xsize = check_string(StringValuePtr(text), size, xml_element_chars);
     i_am_a_child(b, false);
     append_indent(b);
     buf_append_string(&b->buf, "<!--", 4);
     b->col += 5;
     b->pos += 5;
-    append_string(b, StringValuePtr(text), RSTRING_LEN(text), xml_element_chars, false);
+    append_string(b, StringValuePtr(text), size, xml_element_chars, xsize, false);
     buf_append_string(&b->buf, "-->", 3);
     b->col += 5;
     b->pos += 5;
@@ -755,15 +790,19 @@ static VALUE builder_comment(VALUE self, VALUE text) {
  */
 static VALUE builder_doctype(VALUE self, VALUE text) {
     Builder b;
+    size_t  size;
+    size_t  xsize;
 
     TypedData_Get_Struct(self, struct _builder, &ox_builder_type, b);
     rb_check_type(text, T_STRING);
+    size  = (size_t)RSTRING_LEN(text);
+    xsize = check_string(StringValuePtr(text), size, xml_element_chars);
     i_am_a_child(b, false);
     append_indent(b);
     buf_append_string(&b->buf, "<!DOCTYPE ", 10);
     b->col += 10;
     b->pos += 10;
-    append_string(b, StringValuePtr(text), RSTRING_LEN(text), xml_element_chars, false);
+    append_string(b, StringValuePtr(text), size, xml_element_chars, xsize, false);
     buf_append(&b->buf, '>');
     b->col++;
     b->pos++;
@@ -781,6 +820,8 @@ static VALUE builder_text(int argc, VALUE *argv, VALUE self) {
     Builder        b;
     volatile VALUE v;
     volatile VALUE strip_invalid_chars;
+    size_t         size;
+    size_t         xsize;
 
     TypedData_Get_Struct(self, struct _builder, &ox_builder_type, b);
 
@@ -794,9 +835,14 @@ static VALUE builder_text(int argc, VALUE *argv, VALUE self) {
         strip_invalid_chars = Qfalse;
     }
 
-    v = rb_String(v);
+    v    = rb_String(v);
+    size = (size_t)RSTRING_LEN(v);
+    // Stripping is allowed to drop the byte, so it is the one writer that does
+    // not have to refuse the value up front.
+    xsize = RTEST(strip_invalid_chars) ? xml_str_len((const unsigned char *)StringValuePtr(v), size, xml_element_chars)
+                                       : check_string(StringValuePtr(v), size, xml_element_chars);
     i_am_a_child(b, true);
-    append_string(b, StringValuePtr(v), RSTRING_LEN(v), xml_element_chars, RTEST(strip_invalid_chars));
+    append_string(b, StringValuePtr(v), size, xml_element_chars, xsize, RTEST(strip_invalid_chars));
 
     return Qnil;
 }

--- a/ext/ox/xml_str.h
+++ b/ext/ox/xml_str.h
@@ -144,6 +144,45 @@ inline static size_t xml_str_len(const unsigned char *str, size_t len, const cha
     return size - len * (size_t)'0';
 }
 
+/* First byte of str that no XML table lets through, or NULL.
+ *
+ * Every table marks the same set - the bytes under 0x20 other than 0x09, 0x0a
+ * and 0x0d - so this takes no table and answers for all of them. They are all
+ * under 0x20, which is the first term of xml_bytes_of_interest(), so a word
+ * that term does not flag holds none of them and is skipped whole.
+ *
+ * A caller that has to write a delimiter before the value it is escaping uses
+ * this to find out first, since the escape loop only reaches the byte after
+ * the delimiter is already out.
+ */
+inline static const unsigned char *xml_first_invalid(const unsigned char *str, size_t len) {
+    const unsigned char *end = str + len;
+
+    while (str + 8 <= end) {
+        uint64_t v;
+
+        memcpy(&v, str, 8);
+        if (0 != (((v - XSTR_ONES * 0x20) & ~v) & XSTR_HIGH)) {
+            int i;
+
+            for (i = 0; i < 8; i++) {
+                unsigned char c = str[i];
+
+                if (c < 0x20 && '\t' != c && '\n' != c && '\r' != c) {
+                    return str + i;
+                }
+            }
+        }
+        str += 8;
+    }
+    for (; str < end; str++) {
+        if (*str < 0x20 && '\t' != *str && '\n' != *str && '\r' != *str) {
+            return str;
+        }
+    }
+    return NULL;
+}
+
 /* A CDATA section ends at the first "]]>", so a value holding one closes its
  * own section and the rest is read as markup. Both writers split each
  * occurrence into "]]" + "]]>" + "<![CDATA[" + ">", which reads back as the

--- a/test/builder_nul_test.rb
+++ b/test/builder_nul_test.rb
@@ -143,10 +143,10 @@ class BuilderNulTest < ::Test::Unit::TestCase
     assert_equal(expected.b, xml)
   end
 
-  # append_string writes as it scans, so the bytes ahead of the character it
-  # raises on are already in the buffer. That is what a rescued 0x01 has always
-  # left behind and a rescued NUL now leaves the same thing; what matters here
-  # is that the element stack is intact and the next call still works.
+  # A rescued call writes nothing at all, so the document reads as though it had
+  # never been made. This assertion used to pin the opposite - the "<!--a" the
+  # scan had already emitted before it reached the NUL - which is the behaviour
+  # builder_resume_test.rb now covers for every writer.
   def test_the_builder_is_usable_after_a_rescued_nul_raise
     nul = Ox::Builder.new
     assert_raise(Ox::SyntaxError) { nul.comment("a\0b") }
@@ -159,6 +159,6 @@ class BuilderNulTest < ::Test::Unit::TestCase
     soh.pop
 
     assert_equal(soh.to_s, nul.to_s)
-    assert_equal("<!--a\n<x/>\n", nul.to_s)
+    assert_equal("<x/>\n".b, nul.to_s)
   end
 end

--- a/test/builder_resume_test.rb
+++ b/test/builder_resume_test.rb
@@ -1,0 +1,196 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: a rescued Ox::SyntaxError left part of the value in the
+# buffer, and nothing could take it back.
+#
+# append_string() writes as it scans, so by the time it reached a character XML
+# has no way to write, the delimiters around the value and the bytes ahead of
+# that character were already out. A caller skipping a bad value - rescue and
+# carry on - was left holding a document that could not be parsed:
+#
+#   b.comment("a\1b") rescue nil    left "<!--" open over the rest of the file
+#   b.element("a\1b") rescue nil    left "<a", and put the element on the stack
+#   b.element('r', 'k' => "a\1b")   left the attribute quote open
+#
+# The element case had no way out at all. The name was on the stack, so pop()
+# went to write "</a\1b>", raised on the same byte with "</a" already out, and
+# decremented the depth on the way, so a second pop could not finish it either.
+#
+# The writers now check the value before they write anything, so a rescued call
+# leaves the builder exactly as it was. An element that was validly opened stays
+# open, since that call did succeed, and one bad attribute does not take the
+# element or the attributes before it with it.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class BuilderResumeTest < ::Test::Unit::TestCase
+  # Every writer that takes a value through append_string, with what it should
+  # have written by the time the value is refused.
+  WRITERS = {
+    'comment' => [->(b, v) { b.comment(v) }, ''],
+    'doctype' => [->(b, v) { b.doctype(v) }, ''],
+    'element name' => [->(b, v) { b.element(v) }, ''],
+    'element name sym' => [->(b, v) { b.element(v.to_sym) }, ''],
+    'void_element' => [->(b, v) { b.void_element(v) }, ''],
+    'void_element sym' => [->(b, v) { b.void_element(v.to_sym) }, ''],
+    'instruct' => [->(b, v) { b.instruct(v) }, ''],
+    'attr name' => [->(b, v) { b.element('r', v => 'x') }, '<r'],
+    'attr value' => [->(b, v) { b.element('r', 'k' => v) }, '<r'],
+    'attr name sym' => [->(b, v) { b.element('r', v.to_sym => 'x') }, '<r'],
+    'text' => [->(b, v) { b.element('r'); b.text(v) }, '<r']
+  }.freeze
+
+  # A byte in each of the ranges the tables refuse, at offsets inside the word
+  # loop, on its own, and past it.
+  BAD = ["a\x01b", "\x01", "a\0b", "a\x1fb", "a\x0bb", "#{'x' * 9}\x01",
+         "\x01#{'x' * 20}", "#{'x' * 20}\x01"].freeze
+
+  def rescued(writer, value)
+    b = Ox::Builder.new(indent: -1)
+    assert_raise(Ox::SyntaxError) { writer.call(b, value) }
+    b
+  end
+
+  def test_a_rescued_call_writes_nothing
+    WRITERS.each do |where, (writer, expected)|
+      BAD.each do |v|
+        b = rescued(writer, v)
+        assert_equal(expected.b, b.to_s, "#{where} #{v.inspect}")
+      end
+    end
+  end
+
+  # The counters are maintained by hand alongside the writes, so they have to
+  # agree with a buffer that only holds what the calls before the refused one
+  # put there. indent: -1 keeps it to one line, so column is pos + 1.
+  def test_the_counters_agree_with_the_buffer
+    WRITERS.each do |where, (writer, expected)|
+      b = rescued(writer, "a\x01b")
+      assert_equal([1, expected.length + 1, expected.length], [b.line, b.column, b.pos], where)
+    end
+  end
+
+  # The point of the change: rescue a bad value, keep going, get a document.
+  def test_the_document_parses_after_a_rescued_call
+    WRITERS.each do |where, (writer, _)|
+      BAD.each do |v|
+        b = rescued(writer, v)
+        b.element('z')
+        b.pop
+        begin
+          b.pop
+        rescue Ox::ArgError
+          nil
+        end
+        assert_nothing_raised("#{where} #{v.inspect}") { Ox.parse(b.to_s) }
+      end
+    end
+  end
+
+  # pop() writes the name it kept on the stack. An element that was refused is
+  # not on the stack at all, so there is nothing left for pop to trip over.
+  def test_pop_after_a_rescued_element_name
+    b = Ox::Builder.new
+    assert_raise(Ox::SyntaxError) { b.element("a\x01b") }
+    b.element('z')
+    b.pop
+    assert_raise(Ox::ArgError) { b.pop }
+    assert_equal("<z/>\n".b, b.to_s)
+  end
+
+  # An attribute is written whole or not at all, so the ones before it stay and
+  # the element is still the caller's to finish.
+  def test_a_bad_attribute_keeps_the_element_and_the_good_attributes
+    b = Ox::Builder.new(indent: -1)
+    assert_raise(Ox::SyntaxError) { b.element('r', 'ok' => '1', 'bad' => "a\x01b") }
+    b.text('t')
+    b.pop
+    assert_equal('<r ok="1">t</r>'.b, b.to_s)
+  end
+
+  # A depth the element never reached would leave a stack slot uninitialised,
+  # which is the shape of the crash #449 fixed from the other direction.
+  def test_many_rescued_calls_then_a_document
+    b = Ox::Builder.new(indent: -1)
+    200.times do
+      begin
+        b.element("a\x01b")
+      rescue Ox::SyntaxError
+        nil
+      end
+      begin
+        b.comment("a\x01b")
+      rescue Ox::SyntaxError
+        nil
+      end
+    end
+    b.element('r') { b.text('t') }
+    assert_equal('<r>t</r>'.b, b.to_s)
+    assert_nothing_raised { GC.start }
+  end
+
+  # strip_invalid_chars is the one writer that is allowed to take the value: it
+  # drops the byte rather than refusing, so it still writes.
+  def test_text_with_strip_invalid_chars_still_writes
+    xml = Ox::Builder.new(indent: -1) do |b|
+      b.element('r') { b.text("a\x01b", true) }
+    end
+    assert_equal('<r>ab</r>'.b, xml)
+  end
+
+  # raw() is documented as writing its argument untouched and never went through
+  # append_string, so it is deliberately not checked.
+  def test_raw_is_unchanged
+    assert_equal("a\x01b".b, Ox::Builder.new(indent: -1) { |b| b.raw("a\x01b") })
+  end
+
+  # Nothing above may change what a good document looks like, including the
+  # escapes, the newline bookkeeping and the argument type errors.
+  def test_valid_output_is_unchanged
+    xml = Ox::Builder.new do |b|
+      b.instruct('xml', version: '1.0')
+      b.element('top', 'a' => %(1 & 2 < 3 "q")) do
+        b.element('mid') { b.text("hello & <world>\nsecond line") }
+        b.element('utf8') { b.text('日本語 ☃') }
+        b.comment('note')
+        b.doctype('html')
+        b.void_element('br')
+        b.cdata('c]]>d')
+      end
+    end
+    expected = <<~XML
+      <?xml version="1.0"?>
+      <top a="1 &amp; 2 &lt; 3 &quot;q&quot;">
+        <mid>hello &amp; &lt;world&gt;
+      second line</mid>
+        <utf8>日本語 ☃</utf8>
+        <!--note-->
+        <!DOCTYPE html>
+        <br>
+        <![CDATA[c]]]]><![CDATA[>d]]>
+      </top>
+    XML
+    assert_equal(expected.b, xml)
+  end
+
+  def test_argument_type_errors_are_unchanged
+    assert_raise(Ox::ArgError) { Ox::Builder.new { |b| b.element(123) } }
+    assert_raise(Ox::ArgError) { Ox::Builder.new { |b| b.void_element(123) } }
+    assert_raise(Ox::ArgError) { Ox::Builder.new { |b| b.element('r', 123 => 'v') } }
+    assert_raise(TypeError) { Ox::Builder.new { |b| b.element('r', 'k' => 123) } }
+    assert_raise(TypeError) { Ox::Builder.new { |b| b.comment(123) } }
+    assert_raise(Ox::ArgError) { Ox::Builder.new(&:element) }
+  end
+
+  def test_the_message_still_names_the_character
+    e = assert_raise(Ox::SyntaxError) { Ox::Builder.new { |b| b.comment("a\x01b") } }
+    assert_equal("'\\#x01' is not a valid XML character.", e.message)
+    e = assert_raise(Ox::SyntaxError) { Ox::Builder.new { |b| b.element("a\0b") } }
+    assert_equal("'\\#x00' is not a valid XML character.", e.message)
+  end
+end


### PR DESCRIPTION
`append_string()` writes as it scans, so by the time it reached a byte XML has no way to write, the delimiters around the value and everything ahead of that byte were already out. A caller skipping a bad value — rescue and carry on — was left holding a document that could not be read back. Over 66 rescue-and-continue cases, 7 writers against 6 bad values, **48 came back `Ox::ParseError`**.

The element case had no way out at all: the name was on the stack, so `pop()` raised on the same byte with `</a` already written, and decremented the depth on the way, so a second `pop` could not finish it either.

```ruby
b.element("a\1b") rescue nil
b.element('z'); b.pop
b.pop   #=> Ox::SyntaxError, close tag cut at "</a"
b.pop   #=> Ox::ArgError "closed too many elements"
b.to_s  #=> "<a>\n  <z/>\n</a\n"      no call can fix this
```

The writers now check the value before they write anything, so a rescued call leaves the builder as it was — **66 of 66 parse**. It costs no extra scanning on the common path, measured with a counter and with perf.

<details>
<summary>What each writer left, the check, the cost, and what is left out</summary>

### What a rescued call used to leave

| writer | left in the buffer | |
|---|---|---|
| `comment` | `<!--a` | swallowed the rest of the file |
| `doctype` | `<!DOCTYPE a` | never closed |
| `element` name | `<a` | and the element went on the stack |
| `void_element` | `<a` | never closed |
| attribute name | `<r a` | a name with no value |
| attribute value | `<r k="a` | an open quote |
| `text` | `<r>a` | truncated, the one well formed case |

An element that was validly opened still stays open, since that call did succeed, and one bad attribute no longer takes the element or the attributes before it with it.

### The check

`xml_first_invalid()` in `xml_str.h`. Every table marks the same bytes invalid — those under `0x20` other than `0x09`, `0x0a` and `0x0d` — so it needs no table. That was checked against all three tables over **691,200 cases**: every byte value, at every offset, at lengths 1 to 24, with three fillers. All of them are under `0x20`, the first term of `xml_bytes_of_interest()`, so a word without one is skipped whole.

The predicate over-reports in two ways and never under-reports: a tab, newline or return flags its word, and a match borrows into the byte above it. The byte loop that follows settles it, which is also why this needs no endianness case the way `xml_first_of_interest()` does. No byte in `0x80..0xff` is ever reported, so UTF-8 is untouched.

### The cost

`xml_str_len()` moved out of `append_string()` into the check, which passes `xsize` down. Only a value whose escaped form is longer can hold an invalid byte, so the second walk runs solely where something has to be escaped anyway. Counted on a builder workload:

| | | `xml_str_len` | `xml_first_invalid` |
|---|---|---|---|
| no escapes | base | 14200 / 56,800 B | 0 |
| | this | 14200 / 56,800 B | 0 |
| escaped | base | 14200 / 326,800 B | 0 |
| | this | 14200 / 326,800 B | 2000 / 280,000 B |

perf puts the whole change at **+1.1 to 1.5% instructions** and **+2.6 to 3.6% cycles**. The escaped case scans 86% more bytes for 1.26% more instructions, because `xml_first_invalid()` only tests for bytes under `0x20` and `<`, `&`, `>` and `"` are all above it, so their words are skipped.

If you would rather not pay that at all, say so and I will close this — the behaviour it buys is a guarantee `Ox::Builder` has never documented, so it is your call whether it is one you want.

### Also in here, and left out

`Check_Type` on an attribute value moved ahead of the name — the same defect in the argument checks, since it used to raise with the name and the opening quote already written.

Left alone: `text` with `strip_invalid_chars`, which is allowed to drop the byte and so does not refuse the value, and `raw()`, which is documented as writing its argument untouched and never went through `append_string()`.

One assertion in `builder_nul_test.rb` pinned the old behaviour — the `<!--a` the scan had already emitted — and now reads `""`. That test came in with #458, which is where this was first noticed.

### Tests

`test/builder_resume_test.rb` covers the 11 writer and value combinations for what a rescued call leaves, that the counters agree with the buffer, that the document parses afterwards, `pop` after a refused element name, a bad attribute keeping the good ones, 200 rescued calls then a document, and that valid output, the escapes and the argument type errors are unchanged. 6 of its 11 tests fail on `develop`.

Valgrind clean over 531 tests. clang-format clean, Ruby 2.7 syntax checked, four random test orders, 256 to 267 tests.

### Found while doing this, not folded in

`Ox::Builder#to_s` appends its trailing newline **to the buffer** rather than to the String it returns, so calling it mid-document changes the document: `b.text('a'); b.to_s; b.text('b')` gives `<r>a\nb</r>` where leaving the `to_s` out gives `<r>ab</r>`. The counters move with it. It only happens with `indent >= 0`. Happy to send that separately.

</details>
