### PR TITLE
Fix :invalid_replace having no effect unless :effort is moved

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -420,13 +420,18 @@ inline static void dump_str_value(Out out, const char *value, size_t size, const
                 case '>': APPEND_CHARS_SMALL(out->cur, "&gt;", 4); break;
                 default:
                     // Must be one of the invalid characters.
-                    if (StrictEffort == out->opts->effort) {
+                    if (NotSet == out->opts->allow_invalid) {
                         rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", c);
                     }
                     if (Yes == out->opts->allow_invalid) {
-                        APPEND_CHARS_SMALL(out->cur, "&#x00", 5);
-                        dump_hex(c, out);
-                        *out->cur++ = ';';
+                        // A character reference has to resolve to a Char, which #x0 is not.
+                        // Reading &#x0000; back ends the text at the NUL and drops the rest
+                        // without an error, so the byte is left out instead.
+                        if ('\0' != c) {
+                            APPEND_CHARS_SMALL(out->cur, "&#x00", 5);
+                            dump_hex(c, out);
+                            *out->cur++ = ';';
+                        }
                     } else if ('\0' != *out->opts->inv_repl) {
                         // If the empty string then ignore. The first character of
                         // the replacement is the length.

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -176,7 +176,7 @@ struct _options ox_default_options = {
     SpcSkip,       // skip
     No,            // smart
     true,          // convert_special
-    No,            // allow_invalid
+    NotSet,        // allow_invalid
     false,         // no_empty
     false,         // with_cdata
     {'\0'},        // inv_repl
@@ -290,8 +290,9 @@ static VALUE hints_to_overlay(Hints hints) {
  * - _:skip_ [:skip_none|:skip_return|:skip_white|:skip_off] determines how to handle white space in text
  * - _:smart_ [true|false|nil] flag indicating the SAX parser uses hints if available (use with html)
  * - _:convert_special_ [true|false|nil] flag indicating special characters like &lt; are converted with the SAX parser
- * - _:invalid_replace_ [nil|String] replacement string for invalid XML characters on dump. nil indicates include anyway
- * as hex. A string, limited to 10 characters will replace the invalid character with the replace.
+ * - _:invalid_replace_ [nil|false|String] what to do with a character XML can not hold on dump. false, the default,
+ * raises an Ox::SyntaxError. nil writes it as a hex character reference, other than a NUL which is dropped since
+ * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it.
  * - _:no_empty_ [true|false|nil] flag indicating there should be no empty elements in a dump
  * - _:with_cdata_ [true|false] includes cdata in hash_load results
  * - _:strip_namespace_ [String|true|false] false or "" results in no namespace stripping. A string of "*" or true will
@@ -367,12 +368,14 @@ static VALUE get_def_opts(VALUE self) {
     case SpcSkip: rb_hash_aset(opts, skip_sym, skip_white_sym); break;
     default: rb_hash_aset(opts, skip_sym, Qnil); break;
     }
-    if (Yes == ox_default_options.allow_invalid) {
-        rb_hash_aset(opts, invalid_replace_sym, Qnil);
-    } else {
+    switch (ox_default_options.allow_invalid) {
+    case Yes: rb_hash_aset(opts, invalid_replace_sym, Qnil); break;
+    case No:
         rb_hash_aset(opts,
                      invalid_replace_sym,
                      rb_str_new(ox_default_options.inv_repl + 1, (int)*ox_default_options.inv_repl));
+        break;
+    default: rb_hash_aset(opts, invalid_replace_sym, Qfalse); break;
     }
     if ('\0' == *ox_default_options.strip_ns) {
         rb_hash_aset(opts, strip_namespace_sym, Qfalse);
@@ -451,8 +454,9 @@ static VALUE sax_html_overlay(VALUE self) {
  *   - _:attr_key_mod_ [Proc|nil] converts attribute keys on parse if not nil
  *   - _:skip_ [:skip_none|:skip_return|:skip_white|:skip_off] determines how to handle white space in text
  *   - _:smart_ [true|false|nil] flag indicating the SAX parser uses hints if available (use with html)
- *   - _:invalid_replace_ [nil|String] replacement string for invalid XML characters on dump. nil indicates include
- * anyway as hex. A string, limited to 10 characters will replace the invalid character with the replace.
+ *   - _:invalid_replace_ [nil|false|String] what to do with a character XML can not hold on dump. false, the default,
+ * raises an Ox::SyntaxError. nil writes it as a hex character reference, other than a NUL which is dropped since
+ * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it.
  *   - _:strip_namespace_ [nil|String|true|false] "" or false result in no namespace stripping. A string of "*" or true
  * will strip all namespaces. Any other non-empty string indicates that matching namespaces will be stripped.
  * - _:with_cdata_ [true|false] includes cdata in hash_load results
@@ -582,9 +586,19 @@ static VALUE set_def_opts(VALUE self, VALUE opts) {
         rb_raise(ox_parse_error_class, ":no_empty must be true or false.\n");
     }
 
-    v = rb_hash_aref(opts, invalid_replace_sym);
+    v = rb_hash_lookup(opts, invalid_replace_sym);
     if (Qnil == v) {
-        ox_default_options.allow_invalid = Yes;
+        // A key that is not there asks for the default, an explicit nil asks for
+        // the character to be written out, so the two cannot share a branch.
+        if (Qtrue == rb_funcall(opts, has_key_id, 1, invalid_replace_sym)) {
+            ox_default_options.allow_invalid = Yes;
+        } else {
+            ox_default_options.allow_invalid = NotSet;
+            *ox_default_options.inv_repl     = '\0';
+        }
+    } else if (Qfalse == v) {
+        ox_default_options.allow_invalid = NotSet;
+        *ox_default_options.inv_repl     = '\0';
     } else {
         long slen;
 
@@ -847,6 +861,9 @@ static int load_options_cb(VALUE k, VALUE v, VALUE opts) {
     } else if (invalid_replace_sym == k) {
         if (Qnil == v) {
             copts->allow_invalid = Yes;
+        } else if (Qfalse == v) {
+            copts->allow_invalid = NotSet;
+            *copts->inv_repl     = '\0';
         } else {
             long slen;
 
@@ -984,8 +1001,9 @@ static VALUE load(char *xml, size_t len, int argc, VALUE *argv, VALUE self, VALU
  *     - _:auto_define_ - auto define missing classes and modules
  *   - *:trace* [Fixnum] trace level as a Fixnum, default: 0 (silent)
  *   - *:symbolize_keys* [true|false|nil] symbolize element attribute keys or leave as Strings
- *   - *:invalid_replace* [nil|String] replacement string for invalid XML characters on dump. nil indicates include
- * anyway as hex. A string, limited to 10 characters will replace the invalid character with the replace.
+ *   - *:invalid_replace* [nil|false|String] what to do with a character XML can not hold on dump. false, the default,
+ * raises an Ox::SyntaxError. nil writes it as a hex character reference, other than a NUL which is dropped since
+ * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it.
  *   - *:strip_namespace* [String|true|false] "" or false result in no namespace stripping. A string of "*" or true will
  * strip all namespaces. Any other non-empty string indicates that matching namespaces will be stripped.
  *   - *:with_cdata* [true|false] if true cdata is included in hash_load output otherwise it is not.
@@ -1048,8 +1066,9 @@ static VALUE load_str(int argc, VALUE *argv, VALUE self) {
  *     - _:auto_define_ - auto define missing classes and modules
  *   - *:trace* [Fixnum] trace level as a Fixnum, default: 0 (silent)
  *   - *:symbolize_keys* [true|false|nil] symbolize element attribute keys or leave as Strings
- *   - *:invalid_replace* [nil|String] replacement string for invalid XML characters on dump. nil indicates include
- * anyway as hex. A string, limited to 10 characters will replace the invalid character with the replace.
+ *   - *:invalid_replace* [nil|false|String] what to do with a character XML can not hold on dump. false, the default,
+ * raises an Ox::SyntaxError. nil writes it as a hex character reference, other than a NUL which is dropped since
+ * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it.
  *   - *:strip_namespace* [String|true|false] "" or false result in no namespace stripping. A string of "*" or true will
  * strip all namespaces. Any other non-empty string indicates that matching namespaces will be stripped.
  */
@@ -1318,6 +1337,9 @@ static void parse_dump_options(VALUE ropts, Options copts) {
             if (Qtrue == rb_funcall(ropts, has_key_id, 1, invalid_replace_sym)) {
                 copts->allow_invalid = Yes;
             }
+        } else if (Qfalse == v) {
+            copts->allow_invalid = NotSet;
+            *copts->inv_repl     = '\0';
         } else {
             long slen;
 

--- a/test/invalid_replace_test.rb
+++ b/test/invalid_replace_test.rb
@@ -1,0 +1,301 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: :invalid_replace did nothing unless :effort was moved off its
+# default, and what :effort left behind could not be read back.
+#
+# dump_str_value() decided the invalid character case like this:
+#
+#   if (StrictEffort == out->opts->effort) { rb_raise(...); }   <- decided here
+#   if (Yes == out->opts->allow_invalid) { ... }                <- :invalid_replace
+#
+# The raise was settled before :invalid_replace was looked at, and :effort starts
+# as :strict, so on a fresh process the documented dump option did nothing at
+# all. Reaching it meant setting :effort, which is documented as a load option -
+# "effort to use when an undefined class is encountered". The coupling ran both
+# ways: anyone who set effort: :tolerant so that object mode would accept an
+# undefined class also, silently, turned off the character check on dump.
+#
+# :invalid_replace now governs that path on its own and :effort no longer reaches
+# it. That needs a third state, since "no replacement was asked for" and "the
+# empty string was asked for" have to differ - raise, and drop the byte:
+#
+#   false   raise Ox::SyntaxError            <- the default
+#   nil     write it as a hex reference
+#   ""      drop it
+#   "..."   write the replacement instead
+#
+# The nil case had its own problem. A character reference has to resolve to a
+# Char and #x0 is not one, so &#x0000; is not XML - and worse, reading it back
+# ends the text at the NUL and loses the rest without an error:
+#
+#   Ox.dump("a\0b")               #=> "<s>a&#x0000;b</s>\n"
+#   Ox.parse_obj(Ox.dump("a\0b")) #=> "a"          the rest is gone, no error
+#
+# so a NUL is now dropped rather than written. Every other C0 byte round trips
+# within ox and is still written as a reference.
+#
+# See https://github.com/ohler55/ox/issues/464 for the decision.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class InvalidReplaceTest < ::Test::Unit::TestCase
+  # The four states, keyed by the value :invalid_replace is given.
+  STATES = {false => :raise, nil => :hex, '' => :drop, '?' => :replace}.freeze
+
+  EFFORTS = %i[strict tolerant auto_define].freeze
+
+  def setup
+    # default_options returns every key it accepts, so this restores exactly.
+    @saved = Ox.default_options
+    # No :invalid_replace here on purpose - a freshly built options Hash does not
+    # carry the key, and the default it falls back to is what most of this file
+    # is about.
+    Ox.default_options = {mode: :object, effort: :strict, skip: :skip_white}
+  end
+
+  def teardown
+    Ox.default_options = @saved
+  end
+
+  def dump(str, **opts)
+    Ox.dump(str, **opts)
+  rescue Ox::SyntaxError => e
+    e
+  end
+
+  # The default has to keep raising, or every caller who never set the option
+  # would silently start writing documents with the byte dropped. An assignment
+  # that leaves the key out used to turn allow_invalid on instead, so any
+  # unrelated default_options= quietly started writing &#xNNNN;.
+  def test_the_default_raises
+    assert_equal(false, Ox.default_options[:invalid_replace])
+    assert_raise(Ox::SyntaxError) { Ox.dump("a\x01b") }
+    assert_raise(Ox::SyntaxError) { Ox.dump("a\0b") }
+  end
+
+  def test_each_state_does_what_it_says
+    assert_instance_of(Ox::SyntaxError, dump("a\x01b", invalid_replace: false))
+    assert_equal("<s>a&#x0001;b</s>\n", dump("a\x01b", invalid_replace: nil))
+    assert_equal("<s>ab</s>\n", dump("a\x01b", invalid_replace: ''))
+    assert_equal("<s>a?b</s>\n", dump("a\x01b", invalid_replace: '?'))
+    assert_equal("<s>a[bad]b</s>\n", dump("a\x01b", invalid_replace: '[bad]'))
+  end
+
+  # The point of the change: the option works on a process that never touched
+  # :effort, which is the state every process starts in.
+  def test_the_option_works_without_touching_effort
+    assert_equal(:strict, Ox.default_options[:effort])
+    assert_equal("<s>a?b</s>\n", dump("a\x01b", invalid_replace: '?'))
+  end
+
+  # ...and :effort cannot reach the character check from any of its values.
+  def test_effort_does_not_reach_the_character_check
+    EFFORTS.each do |effort|
+      STATES.each_key do |state|
+        with = dump("a\x01b", effort: effort, invalid_replace: state)
+        without = dump("a\x01b", invalid_replace: state)
+        if with.is_a?(Ox::SyntaxError)
+          assert_instance_of(Ox::SyntaxError, without, "#{effort} #{state.inspect}")
+        else
+          assert_equal(without, with, "#{effort} #{state.inspect}")
+        end
+      end
+    end
+  end
+
+  # An :effort on its own no longer decides anything about characters, so it
+  # falls through to the default, which raises.
+  def test_effort_alone_raises_whatever_it_is_set_to
+    EFFORTS.each do |effort|
+      assert_raise(Ox::SyntaxError, effort.to_s) { Ox.dump("a\x01b", effort: effort) }
+    end
+  end
+
+  def test_a_nul_is_dropped_rather_than_written
+    assert_equal("<s>ab</s>\n", dump("a\0b", invalid_replace: nil))
+    assert_equal("<s>ab</s>\n", dump("a\0b", invalid_replace: ''))
+    assert_equal("<s>a?b</s>\n", dump("a\0b", invalid_replace: '?'))
+    assert_instance_of(Ox::SyntaxError, dump("a\0b", invalid_replace: false))
+  end
+
+  # A NUL is the only byte allow_invalid refuses to write, because it is the
+  # only one that costs the rest of the document on the way back.
+  def test_every_other_c0_byte_is_still_written_as_a_reference
+    (1..0x1f).each do |b|
+      next if [0x09, 0x0a, 0x0d].include?(b)
+
+      assert_equal(format('<s>a&#x%04x;b</s>%s', b, "\n"),
+                   dump("a#{b.chr}b", invalid_replace: nil),
+                   format('0x%02x', b))
+    end
+  end
+
+  def test_the_tabs_and_newlines_xml_allows_are_untouched
+    ["\t", "\n", "\r"].each do |c|
+      STATES.each_key do |state|
+        assert_equal("<s>a#{c}b</s>\n", dump("a#{c}b", invalid_replace: state), c.inspect)
+      end
+    end
+  end
+
+  # What allow_invalid writes now survives a round trip through ox, which is
+  # what &#x0000; did not.
+  def test_what_is_written_reads_back
+    Ox.default_options = {mode: :object, skip: :skip_none, invalid_replace: nil}
+    assert_equal('ab', Ox.parse_obj(Ox.dump("a\0b")))
+    assert_equal("a\x01b", Ox.parse_obj(Ox.dump("a\x01b")))
+    assert_equal("a\x1fb", Ox.parse_obj(Ox.dump("a\x1fb")))
+  end
+
+  def test_the_message_still_names_the_character
+    e = dump("a\x01b", invalid_replace: false)
+    assert_equal("'\\#x01' is not a valid XML character.", e.message)
+    e = dump("a\0b", invalid_replace: false)
+    assert_equal("'\\#x00' is not a valid XML character.", e.message)
+  end
+
+  # The byte is found wherever it sits: the escape scan reads a word at a time,
+  # then a tail shorter than a word, then one flagged byte.
+  def test_the_byte_is_found_at_any_offset
+    24.times do |n|
+      s = "#{'a' * n}\x01#{'b' * 24}"
+      assert_raise(Ox::SyntaxError, "offset #{n} raise") { Ox.dump(s, invalid_replace: false) }
+      assert_equal("<s>#{'a' * n}#{'b' * 24}</s>\n", dump(s, invalid_replace: ''), "offset #{n} drop")
+    end
+  end
+
+  def test_more_than_one_bad_byte
+    assert_equal("<s>a-b-c</s>\n", dump("a\x01b\x02c", invalid_replace: '-'))
+    assert_equal("<s>abc</s>\n", dump("a\0b\0c", invalid_replace: nil))
+    assert_equal("<s>--</s>\n", dump("\x01\x02", invalid_replace: '-'))
+  end
+
+  # An attribute value goes through the same escape path with a different table.
+  def test_an_attribute_value_takes_the_option_too
+    e = Ox::Element.new('r')
+    e[:k] = "a\x01b"
+    assert_raise(Ox::SyntaxError) { Ox.dump(e, mode: :generic, invalid_replace: false) }
+    assert_equal(%(\n<r k="a?b"/>\n), Ox.dump(e, mode: :generic, invalid_replace: '?'))
+    assert_equal(%(\n<r k="ab"/>\n), Ox.dump(e, mode: :generic, invalid_replace: ''))
+    assert_equal(%(\n<r k="a&#x0001;b"/>\n), Ox.dump(e, mode: :generic, invalid_replace: nil))
+  end
+
+  def test_object_mode_values_take_the_option_too
+    assert_equal("<m>a?b</m>\n", dump(:"a\x01b", invalid_replace: '?'))
+    assert_equal("<h>\n  <s>a?b</s>\n  <i>1</i>\n</h>\n",
+                 Ox.dump({"a\x01b" => 1}, invalid_replace: '?'))
+  end
+
+  # An element name is written raw rather than escaped, so it is not this
+  # option's to govern and a NUL there still costs the document. Pinned so that
+  # a change to either side shows up here. See Z34 / issue #460.
+  def test_names_are_not_covered_by_the_option
+    STATES.each_key do |state|
+      assert_equal("\n<r\x01/>\n", Ox.dump(Ox::Element.new("r\x01"), mode: :generic, invalid_replace: state),
+                   state.inspect)
+    end
+  end
+
+  def test_a_call_option_beats_the_default
+    Ox.default_options = {mode: :object, invalid_replace: '?'}
+    assert_equal("<s>a?b</s>\n", Ox.dump("a\x01b"))
+    assert_raise(Ox::SyntaxError) { Ox.dump("a\x01b", invalid_replace: false) }
+    assert_equal("<s>ab</s>\n", Ox.dump("a\x01b", invalid_replace: ''))
+  end
+
+  def test_the_default_survives_a_call_that_does_not_mention_it
+    Ox.default_options = {mode: :object, invalid_replace: '?'}
+    Ox.dump("ok", effort: :tolerant)
+    assert_equal("<s>a?b</s>\n", Ox.dump("a\x01b"))
+    assert_equal('?', Ox.default_options[:invalid_replace])
+  end
+
+  # Every state has to come back as it went in, or a caller who saves and
+  # restores default_options changes the behaviour by doing so.
+  def test_default_options_round_trips_every_state
+    STATES.each_key do |state|
+      Ox.default_options = {mode: :object, invalid_replace: state}
+      assert_equal(state, Ox.default_options[:invalid_replace], state.inspect)
+
+      saved = Ox.default_options
+      Ox.default_options = saved
+      assert_equal(saved, Ox.default_options, state.inspect)
+      assert_equal(state, Ox.default_options[:invalid_replace], state.inspect)
+    end
+  end
+
+  # A key that is not there is the default, whatever else the assignment sets...
+  def test_an_assignment_without_the_key_leaves_the_default
+    Ox.default_options = {mode: :object, invalid_replace: '?'}
+    Ox.default_options = {mode: :object}
+    assert_equal(false, Ox.default_options[:invalid_replace])
+    assert_raise(Ox::SyntaxError) { Ox.dump("a\x01b") }
+  end
+
+  # ...but an explicit nil still asks for the character to be written, and the
+  # two have to stay distinguishable.
+  def test_an_explicit_nil_is_not_a_missing_key
+    Ox.default_options = {mode: :object, invalid_replace: nil}
+    assert_nil(Ox.default_options[:invalid_replace])
+    assert_equal("<s>a&#x0001;b</s>\n", Ox.dump("a\x01b"))
+  end
+
+  # The escape table reserves ten bytes for an invalid character, which is what
+  # the longest replacement takes, so a value that is nothing but bad bytes is
+  # where the reservation runs out first.
+  def test_the_longest_replacement_on_every_byte
+    s = "\x01" * 100
+    assert_equal("<s>#{'x' * 10 * 100}</s>\n", dump(s, invalid_replace: 'x' * 10))
+    assert_equal("<s>#{'&#x0001;' * 100}</s>\n", dump(s, invalid_replace: nil))
+    assert_equal("<s></s>\n", dump(s, invalid_replace: ''))
+    assert_equal("<s></s>\n", dump("\0" * 100, invalid_replace: nil))
+  end
+
+  def test_the_replacement_length_limit_is_unchanged
+    assert_equal("<s>a#{'x' * 10}b</s>\n", dump("a\x01b", invalid_replace: 'x' * 10))
+    assert_raise(Ox::ParseError) { Ox.dump("a\x01b", invalid_replace: 'x' * 11) }
+    assert_raise(Ox::ParseError) { Ox.default_options = {invalid_replace: 'x' * 11} }
+  end
+
+  def test_a_value_that_is_neither_a_string_nor_false_still_raises
+    assert_raise(TypeError) { Ox.dump("a\x01b", invalid_replace: 123) }
+    assert_raise(TypeError) { Ox.default_options = {invalid_replace: 123} }
+    assert_raise(TypeError) { Ox.default_options = {invalid_replace: :nope} }
+  end
+
+  # true is not one of the three, and reading it as "replace with nothing"
+  # would be a guess, so it is refused like any other non-String.
+  def test_true_is_not_a_state
+    assert_raise(TypeError) { Ox.dump("a\x01b", invalid_replace: true) }
+  end
+
+  # Ox::Builder has its own check and has never taken this option. Pinned so
+  # that bringing the two together is a deliberate change rather than a
+  # side effect.
+  def test_builder_is_unaffected
+    STATES.each_key do |state|
+      Ox.default_options = {mode: :object, invalid_replace: state}
+      assert_raise(Ox::SyntaxError, state.inspect) do
+        Ox::Builder.new(indent: -1) { |b| b.element('r') { b.text("a\x01b") } }
+      end
+    end
+  end
+
+  # Nothing above may change what a document with nothing wrong in it looks
+  # like, whatever the option is set to.
+  def test_valid_output_is_unchanged
+    STATES.each_key do |state|
+      xml = Ox.dump({'k' => 'hello & <world>', 'utf8' => '日本語 ☃ é'},
+                    mode: :object, invalid_replace: state)
+      # No :encoding was asked for, so what comes back is bytes.
+      assert_equal("<h>\n  <s>k</s>\n  <s>hello &amp; &lt;world&gt;</s>\n" \
+                   "  <s>utf8</s>\n  <s>日本語 ☃ é</s>\n</h>\n".b,
+                   xml, state.inspect)
+    end
+  end
+end

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -329,7 +329,7 @@ class Func < Test::Unit::TestCase
   end
 
   def test_dump_invalid_character
-    assert_raise(Ox::SyntaxError) { Ox.dump("foo\x19bar") }
+    assert_raise(Ox::SyntaxError) { Ox.dump("foo\x19bar", invalid_replace: false) }
   end
 
   def test_unsupported_ox_version
@@ -537,16 +537,19 @@ class Func < Test::Unit::TestCase
     assert_equal('π', doc.attributes[:name].force_encoding('UTF-8'))
   end
 
+  # :effort no longer reaches the character check, so these two pass what they
+  # are actually asking for: the empty string drops the character and false is
+  # the state that raises.
   def test_escape_dump_tolerant
     Ox.default_options = $ox_object_options
-    dumped_xml = Ox.dump("tab\tamp&backspace\b.", effort: :tolerant)
+    dumped_xml = Ox.dump("tab\tamp&backspace\b.", invalid_replace: '')
     assert_equal("<s>tab\tamp&amp;backspace.</s>\n", dumped_xml)
   end
 
   def test_escape_dump_strict
     Ox.default_options = $ox_object_options
     begin
-      Ox.dump("tab\tamp&backspace\b.", effort: :strict)
+      Ox.dump("tab\tamp&backspace\b.", invalid_replace: false)
     rescue Exception => e
       assert_equal("'\\#x08' is not a valid XML character.", e.message)
       return


### PR DESCRIPTION

`:effort` decided the invalid character case before `:invalid_replace` was looked at, and it starts as `:strict`, so on a fresh process the documented dump option did nothing at all. Reaching it meant setting `:effort` — a load option — which also turned the character check off for anyone who set `effort: :tolerant` so that object mode would accept an undefined class.

`:invalid_replace` now governs that path on its own, with a third state so that an absent option still raises: `false` raises (the default), `nil` writes a hex character reference, `""` drops the byte, and a string replaces it. A NUL is no longer written as `&#x0000;` — a character reference has to resolve to a `Char`, and reading that one back ends the text there and loses the rest without an error.

Closes #464 — both changes were approved there, along with the documentation update, which is in here too.

<details>
<summary>Measurements, what changes, and how it was checked</summary>

## What it did

```c
default:
    // Must be one of the invalid characters.
    if (StrictEffort == out->opts->effort) {          // <- decided here
        rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", c);
    }
    if (Yes == out->opts->allow_invalid) {            // <- :invalid_replace only reaches here
```

On a process that never touched `:effort`:

```ruby
Ox.default_options[:effort]                 #=> :strict
Ox.dump("a\0b", invalid_replace: '?')       #=> Ox::SyntaxError
Ox.dump("a\0b", invalid_replace: '')        #=> Ox::SyntaxError
Ox.dump("a\0b", invalid_replace: nil)       #=> Ox::SyntaxError
```

## The third state

There was no state that told "no replacement was asked for" from "the empty string was asked for" — both were `allow_invalid == No` with `inv_repl` empty — yet they have to do different things. `allow_invalid` now holds `NotSet` for the first, which is what it starts as.

| `:invalid_replace` | |
| --- | --- |
| `false` | raise `Ox::SyntaxError` — the default |
| `nil` | write a hex character reference |
| `""` | drop the character |
| `"..."` | write the replacement, up to 10 characters |

`false` rather than a symbol keeps the three states in three types, the way `:strip_namespace` already takes `false`/`true`/String.

`set_def_opts()` now tells a missing key from an explicit `nil` with `rb_hash_lookup` + `has_key?`, the way `parse_dump_options()` already did. Without that, **any** assignment that left the key out turned `allow_invalid` on:

```ruby
Ox.default_options = {mode: :object}    # no :invalid_replace anywhere
Ox.dump("a\0b")                         #=> "<s>a&#x0000;b</s>\n"   before
                                        #=> Ox::SyntaxError         after
```

## The NUL

```ruby
Ox.dump("a\0b")                    #=> "<s>a&#x0000;b</s>\n"   before
Ox.parse_obj(Ox.dump("a\0b"))      #=> "a"        the rest is gone, no error
```

Every other C0 byte round trips within ox and is still written as a reference; only the NUL is dropped. `&#x0001;` through `&#x001f;` are unchanged.

## What changes for a caller

| | before | after |
| --- | --- | --- |
| `dump(s, invalid_replace: "?")`, fresh process | `Ox::SyntaxError` | `a?b` |
| `dump(s, effort: :tolerant)`, no `:invalid_replace` | byte dropped | `Ox::SyntaxError` |
| `dump("a\0b", invalid_replace: nil)` | `a&#x0000;b` | `ab` |
| `Ox.default_options[:invalid_replace]`, fresh process | `""` | `false` |
| `Ox.default_options = {…}` without the key | turns `allow_invalid` on | leaves the default |

The second row is the one that trades a silent drop for a raise. It is the same trade as the first row in the other direction: the byte is only dropped now when something asked for it to be.

## Tests

`test/invalid_replace_test.rb`, 26 tests: the four states, `:effort` reaching none of them from any of its three values, the NUL dropped while every other C0 byte is still written, `default_options` round tripping each state, a missing key told from an explicit `nil`, and the longest replacement on a value that is nothing but bad bytes — which is where the ten bytes the escape table reserves per invalid character run out first. **21 of the 26 fail on develop.**

Three existing tests in `test/tests.rb` now pass what they are actually asking for rather than an `:effort`:

- `test_escape_dump_strict` — `invalid_replace: false`, the state that raises
- `test_escape_dump_tolerant` — `invalid_replace: ''`, which drops
- `test_dump_invalid_character` — `invalid_replace: false`; it set no options at all and was reading whatever the test before it left behind

## Checked

- 293 tests / 5018 assertions, random order ×3, plus `rake test_all` — 0 failures
- `rake test:valgrind` — 557 tests, no invalid read/write, nothing lost
- clang-format clean, Ruby 2.7 syntax OK

## Not in this PR

Names, comments, CDATA and instructions do not go through `dump_str_value()`, so this option does not reach them and a NUL in one still truncates the document. That is a separate path and I have left it alone here; happy to open an issue if you want it looked at.

</details>
