### PR TITLE
Fix Ox::Builder counting more than it writes, and to_s writing to the buffer

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -247,8 +247,8 @@ append_string(Builder b, const char *str, size_t size, const char *table, size_t
                     b->pos++;
                     *bp++ = *str++;
                 } else {
-                    b->pos += fcnt - '0';
-                    b->col += fcnt - '0';
+                    size_t written = (size_t)(fcnt - '0');
+
                     if (buf < bp) {
                         buf_append_string(&b->buf, buf, bp - buf);
                         bp = buf;
@@ -260,12 +260,17 @@ append_string(Builder b, const char *str, size_t size, const char *table, size_t
                     case '<': buf_append_string(&b->buf, "&lt;", 4); break;
                     case '>': buf_append_string(&b->buf, "&gt;", 4); break;
                     default:
-                        // Must be one of the invalid characters.
+                        // Must be one of the invalid characters. The table holds
+                        // 10 for those, the longest escape, but nothing is
+                        // written for them here.
                         if (!strip_invalid_chars) {
                             rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *str);
                         }
+                        written = 0;
                         break;
                     }
+                    b->pos += written;
+                    b->col += written;
                     str++;
                 }
             }
@@ -381,8 +386,10 @@ static void pop(Builder b) {
                       xml_str_len((const unsigned char *)e->name, e->len, xml_element_chars),
                       false);
         buf_append(&b->buf, '>');
-        b->col += e->len + 3;
-        b->pos += e->len + 3;
+        // append_string() already counted the name, so this is only the "</"
+        // and the ">".
+        b->col += 3;
+        b->pos += 3;
         if (e->buf != e->name) {
             free(e->name);
             e->name = 0;
@@ -776,12 +783,12 @@ static VALUE builder_comment(VALUE self, VALUE text) {
     i_am_a_child(b, false);
     append_indent(b);
     buf_append_string(&b->buf, "<!--", 4);
-    b->col += 5;
-    b->pos += 5;
+    b->col += 4;
+    b->pos += 4;
     append_string(b, StringValuePtr(text), size, xml_element_chars, xsize, false);
     buf_append_string(&b->buf, "-->", 3);
-    b->col += 5;
-    b->pos += 5;
+    b->col += 3;
+    b->pos += 3;
 
     return Qnil;
 }

--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -412,18 +412,21 @@ static void bclose(Builder b) {
 
 static VALUE to_s(Builder b) {
     volatile VALUE rstr;
+    size_t         len;
 
     if (0 != b->buf.fd) {
         rb_raise(ox_arg_error_class, "can not create a String with a stream or file builder.");
     }
-    if (0 <= b->indent && '\n' != *(b->buf.tail - 1)) {
-        buf_append(&b->buf, '\n');
-        b->line++;
-        b->col = 1;
-        b->pos++;
-    }
+    len          = buf_len(&b->buf);
     *b->buf.tail = '\0';  // for debugging
-    rstr         = rb_str_new(b->buf.head, buf_len(&b->buf));
+    rstr         = rb_str_new(b->buf.head, len);
+    // The closing newline goes on the String and not the buffer. Appended to the
+    // buffer it stays there, so a to_s taken before the document is finished
+    // leaves a newline in the middle of it, and in the middle of a value if that
+    // is where the builder was.
+    if (0 <= b->indent && (0 == len || '\n' != b->buf.head[len - 1])) {
+        rb_str_cat(rstr, "\n", 1);
+    }
 
     if ('\0' != *b->encoding) {
         rb_enc_associate(rstr, rb_enc_find(b->encoding));

--- a/test/builder_counters_test.rb
+++ b/test/builder_counters_test.rb
@@ -1,0 +1,174 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: Ox::Builder counted more than it wrote.
+#
+# pos, column and line are maintained by hand alongside every write, so they only
+# agree with the buffer if each write is accounted for exactly once. Three did
+# not:
+#
+#   pop()      counted the element name twice - append_string() had already
+#              advanced by e->len, then pop added e->len + 3 again
+#   comment()  wrote "<!--" (4) and "-->" (3) and counted 5 for each
+#   the strip_invalid_chars arm counted the table entry for a dropped byte,
+#              which is 10, the longest escape, for something never written
+#
+#   <a>t</a>                 8 bytes, pos said  9
+#   <abcde>t</abcde>        16 bytes, pos said 21
+#   <!--hi-->                9 bytes, pos said 12
+#   text("a\x01b", true)     9 bytes, pos said 20
+#
+# None of it is a memory safety problem - the counters are only readable as
+# Ox::Builder#pos / #column / #line and are used for neither sizing nor writing -
+# but they are what a caller is told about where they are in the output.
+#
+# What was written is measured with to_s, which had to stop writing to the buffer
+# first for that to be a fair measurement; see builder_to_s_test.rb.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class BuilderCountersTest < ::Test::Unit::TestCase
+  # Every writer, as a block over a builder. With indent: -1 the whole document
+  # is one line and to_s adds nothing, so to_s.bytesize is exactly what was
+  # written and pos has to equal it.
+  WRITERS = {
+    'element 1 char name' => ->(b) { b.element('a') { b.text('t') } },
+    'element 2 char name' => ->(b) { b.element('ab') { b.text('t') } },
+    'element 5 char name' => ->(b) { b.element('abcde') { b.text('t') } },
+    'element 20 char name' => ->(b) { b.element('a' * 20) { b.text('t') } },
+    'element symbol name' => ->(b) { b.element(:abcde) { b.text('t') } },
+    'element no child' => ->(b) { b.element('a'); b.pop },
+    'element empty text' => ->(b) { b.element('a') { b.text('') } },
+    'void_element' => ->(b) { b.void_element('br') },
+    'nested elements' => ->(b) { b.element('a') { b.element('b') { b.text('t') } } },
+    'deeply nested' => ->(b) { 5.times { |i| b.element("e#{i}") }; 5.times { b.pop } },
+    'attributes' => ->(b) { b.element('r', 'k' => 'v', 'k2' => 'v2') { b.text('t') } },
+    'attribute escaped' => ->(b) { b.element('r', 'k' => 'a<b&c"d') },
+    'text plain' => ->(b) { b.element('r') { b.text('hello') } },
+    'text escaped' => ->(b) { b.element('r') { b.text('a<b&c>d') } },
+    'text long' => ->(b) { b.element('r') { b.text('x' * 300) } },
+    'text utf8' => ->(b) { b.element('r') { b.text('日本語 ☃') } },
+    'comment' => ->(b) { b.comment('hi') },
+    'comment long' => ->(b) { b.comment('hello world') },
+    'comment empty' => ->(b) { b.comment('') },
+    'comment escaped' => ->(b) { b.comment('a<b&c') },
+    'doctype' => ->(b) { b.doctype('html') },
+    'cdata' => ->(b) { b.element('r') { b.cdata('data') } },
+    'raw' => ->(b) { b.element('r') { b.raw('<x/>') } },
+    'instruct' => ->(b) { b.instruct('xml') },
+    'instruct attrs' => ->(b) { b.instruct('xml', version: '1.0') },
+    'strip 1 invalid' => ->(b) { b.element('r') { b.text("a\x01b", true) } },
+    'strip 2 invalid' => ->(b) { b.element('r') { b.text("a\x01\x01b", true) } },
+    'strip only invalid' => ->(b) { b.element('r') { b.text("\x01", true) } },
+    'strip invalid in long' => ->(b) { b.element('r') { b.text("#{'x' * 20}\x01#{'y' * 20}", true) } }
+  }.freeze
+
+  def built(indent = -1)
+    b = Ox::Builder.new(indent: indent)
+    yield b
+    b
+  end
+
+  # The whole of Z32 in one assertion, over every writer.
+  def test_pos_equals_the_bytes_written
+    WRITERS.each do |where, writer|
+      b = built { |x| writer.call(x) }
+      assert_equal(b.to_s.bytesize, b.pos, where)
+    end
+  end
+
+  # One line, so column is pos + 1 and line never moves.
+  def test_column_and_line_agree_on_one_line
+    WRITERS.each do |where, writer|
+      next if where.start_with?('text utf8') # multibyte: column counts bytes
+
+      b = built { |x| writer.call(x) }
+      assert_equal([1, b.pos + 1], [b.line, b.column], where)
+    end
+  end
+
+  # The name was counted twice, so the error grew with its length.
+  def test_a_closing_tag_counts_the_name_once
+    (1..12).each do |n|
+      b = built { |x| x.element('a' * n) { x.text('t') } }
+      assert_equal(b.to_s.bytesize, b.pos, "name of #{n}")
+    end
+  end
+
+  def test_a_comment_counts_its_own_delimiters
+    ['', 'hi', 'hello world', 'x' * 100].each do |text|
+      b = built { |x| x.comment(text) }
+      assert_equal(b.to_s.bytesize, b.pos, text.length.to_s)
+    end
+  end
+
+  # A dropped byte is written nowhere, so it takes up no room. The table holds
+  # 10 for it, which is what was being added.
+  def test_a_dropped_invalid_character_takes_no_room
+    (0..5).each do |n|
+      b = built { |x| x.element('r') { x.text("a#{"\x01" * n}b", true) } }
+      assert_equal(b.to_s.bytesize, b.pos, "#{n} dropped")
+      assert_equal('<r>ab</r>', b.to_s, "#{n} dropped")
+    end
+  end
+
+  # An escape is written, so it is still counted by what it takes.
+  def test_an_escape_is_still_counted_by_its_length
+    b = built { |x| x.element('r') { x.text('&<>') } }
+    assert_equal('<r>&amp;&lt;&gt;</r>', b.to_s)
+    assert_equal(b.to_s.bytesize, b.pos)
+  end
+
+  def test_line_moves_with_the_newlines_in_a_value
+    b = built { |x| x.element('r') { x.text("a\nb\nc") } }
+    assert_equal(3, b.line)
+    assert_equal(b.to_s.bytesize, b.pos)
+  end
+
+  def test_the_indented_form_agrees_too
+    WRITERS.each do |where, writer|
+      b = built(2) { |x| writer.call(x) }
+      # to_s adds the closing newline to the String it returns and not to the
+      # buffer, so it is one longer than what pos counts.
+      s = b.to_s
+      expected = s.end_with?("\n") ? s.bytesize - 1 : s.bytesize
+      assert_equal(expected, b.pos, where)
+    end
+  end
+
+  # The counters have to agree with the buffer at every step, not only once the
+  # document is finished. Reading the buffer part way through is what
+  # builder_to_s_test.rb covers; here it is the measuring instrument.
+  def test_the_counters_agree_at_every_step
+    b = Ox::Builder.new(indent: -1)
+    steps = []
+    check = lambda do |label|
+      steps << [label, b.pos, b.to_s.bytesize, b.column]
+    end
+
+    b.element('r')
+    check.call('open element')
+    b.text('ab')
+    check.call('text')
+    b.comment('c')
+    check.call('comment')
+    b.element('in')
+    check.call('open nested')
+    b.text("x\x01y", true)
+    check.call('stripped text')
+    b.pop
+    check.call('close nested')
+    b.pop
+    check.call('close element')
+
+    steps.each do |label, pos, bytes, column|
+      assert_equal(bytes, pos, label)
+      assert_equal(pos + 1, column, label)
+    end
+    assert_equal('<r>ab<!--c--><in>xy</in></r>', b.to_s)
+  end
+end

--- a/test/builder_to_s_test.rb
+++ b/test/builder_to_s_test.rb
@@ -1,0 +1,173 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: Ox::Builder#to_s wrote to the document it was asked to read.
+#
+# The closing newline was appended to the buffer rather than to the String that
+# to_s returns, and line/column/pos were moved along with it. On a finished
+# document that looks idempotent, since the buffer already ends in a newline and
+# the second call adds nothing. Called before the document is finished, the
+# newline stays where the builder was:
+#
+#   b.element('r'); b.text('a')
+#   b.to_s                        # <- just a read
+#   b.text('b'); b.pop
+#   b.to_s                        #=> "<r>a\nb</r>\n"   and not "<r>ab</r>\n"
+#
+# Inside a start tag it lands between the name and the '>', which XML survives.
+# Inside a value it is a changed value, which is the part that matters.
+#
+# The newline now goes on the returned String, so to_s answers the same thing
+# whether or not it was called before, and leaves the builder alone.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class BuilderToSTest < ::Test::Unit::TestCase
+  # Where a to_s can fall, as a pair of blocks run either side of it.
+  MIDPOINTS = {
+    'between two texts' => [->(b) { b.element('r'); b.text('a') }, ->(b) { b.text('b'); b.pop }],
+    'after a start tag' => [->(b) { b.element('r') }, ->(b) { b.text('t'); b.pop }],
+    'before a child' => [->(b) { b.element('r'); b.element('c') }, ->(b) { b.text('t'); b.pop; b.pop }],
+    'after a comment' => [->(b) { b.element('r'); b.comment('c') }, ->(b) { b.text('t'); b.pop }],
+    'after an attribute' => [->(b) { b.element('r', 'k' => 'v') }, ->(b) { b.text('t'); b.pop }],
+    'at the very start' => [->(_b) {}, ->(b) { b.element('r') { b.text('t') } }]
+  }.freeze
+
+  def test_a_to_s_in_the_middle_does_not_change_the_document
+    MIDPOINTS.each do |where, (before, after)|
+      [-1, 2].each do |indent|
+        clean = Ox::Builder.new(indent: indent)
+        before.call(clean)
+        after.call(clean)
+
+        dirty = Ox::Builder.new(indent: indent)
+        before.call(dirty)
+        dirty.to_s
+        after.call(dirty)
+
+        assert_equal(clean.to_s, dirty.to_s, "#{where} indent #{indent}")
+      end
+    end
+  end
+
+  # The value is what a stray newline would corrupt without XML noticing.
+  def test_a_value_is_not_split
+    b = Ox::Builder.new(indent: 2)
+    b.element('r')
+    b.text('a')
+    b.to_s
+    b.text('b')
+    b.pop
+    assert_equal("<r>ab</r>\n".b, b.to_s)
+    assert_equal('ab', Ox.parse(b.to_s).text)
+  end
+
+  def test_many_to_s_calls_change_nothing
+    b = Ox::Builder.new(indent: 2)
+    b.element('r')
+    10.times do
+      b.to_s
+      b.text('x')
+    end
+    b.pop
+    assert_equal("<r>#{'x' * 10}</r>\n".b, b.to_s)
+  end
+
+  def test_to_s_does_not_move_the_counters
+    MIDPOINTS.each do |where, (before, _)|
+      [-1, 2].each do |indent|
+        b = Ox::Builder.new(indent: indent)
+        before.call(b)
+        state = [b.pos, b.line, b.column]
+        3.times { b.to_s }
+        assert_equal(state, [b.pos, b.line, b.column], "#{where} indent #{indent}")
+      end
+    end
+  end
+
+  def test_to_s_is_idempotent
+    b = Ox::Builder.new(indent: 2)
+    b.element('r') { b.text('t') }
+    first = b.to_s
+    3.times { assert_equal(first, b.to_s) }
+  end
+
+  # What to_s returns for a finished document is unchanged, which is the whole
+  # point: only the buffer behind it stops being written to.
+  def test_the_closing_newline_is_still_there
+    assert_equal("<r>t</r>\n".b, Ox::Builder.new(indent: 2) { |b| b.element('r') { b.text('t') } })
+    assert_equal('<r>t</r>'.b, Ox::Builder.new(indent: -1) { |b| b.element('r') { b.text('t') } })
+
+    b = Ox::Builder.new(indent: 2)
+    b.element('r') { b.text('t') }
+    assert_equal("<r>t</r>\n".b, b.to_s)
+
+    tight = Ox::Builder.new(indent: -1)
+    tight.element('r') { tight.text('t') }
+    assert_equal('<r>t</r>'.b, tight.to_s)
+  end
+
+  # ...and it still does not add a second newline to a document that has one.
+  def test_no_second_newline
+    b = Ox::Builder.new(indent: 2)
+    b.element('r') { b.text("a\n") }
+    assert_equal("<r>a\n</r>\n".b, b.to_s)
+  end
+
+  def test_an_empty_builder
+    assert_equal("\n".b, Ox::Builder.new(indent: 2).to_s)
+    assert_equal(''.b, Ox::Builder.new(indent: -1).to_s)
+    assert_equal(0, Ox::Builder.new(indent: 2).pos)
+  end
+
+  def test_the_block_form_is_unchanged
+    xml = Ox::Builder.new do |b|
+      b.instruct('xml', version: '1.0')
+      b.element('top', 'a' => '1 & 2') do
+        b.element('mid') { b.text("hello\nthere") }
+        b.comment('note')
+        b.doctype('html')
+        b.void_element('br')
+        b.cdata('c]]>d')
+      end
+    end
+    expected = <<~XML
+      <?xml version="1.0"?>
+      <top a="1 &amp; 2">
+        <mid>hello
+      there</mid>
+        <!--note-->
+        <!DOCTYPE html>
+        <br>
+        <![CDATA[c]]]]><![CDATA[>d]]>
+      </top>
+    XML
+    assert_equal(expected.b, xml)
+  end
+
+  # A file builder writes as it goes and has no to_s, which is unchanged.
+  def test_a_file_builder_still_refuses_to_s
+    require 'tempfile'
+    Tempfile.create('ox_to_s') do |f|
+      Ox::Builder.file(f.path, indent: -1) do |b|
+        b.element('r') { b.text('t') }
+        assert_raise(Ox::ArgError) { b.to_s }
+      end
+      assert_equal('<r>t</r>', File.read(f.path))
+    end
+  end
+
+  # The encoding comes from the instruct, and to_s still labels what it returns
+  # with it - including the newline it now appends there.
+  def test_the_encoding_is_still_applied
+    b = Ox::Builder.new(indent: 2)
+    b.instruct('xml', encoding: 'UTF-8')
+    b.element('r') { b.text('日本語') }
+    assert_equal(Encoding::UTF_8, b.to_s.encoding)
+    assert_equal("<?xml encoding=\"UTF-8\"?>\n<r>日本語</r>\n", b.to_s)
+  end
+end


### PR DESCRIPTION
Two independent things in `builder.c`, one commit each.

**`to_s` appended the closing newline to the buffer** rather than to the String it returns, and moved `line`/`column`/`pos` with it. On a finished document that reads as idempotent, but called before the document is finished the newline stays where the builder was — including inside a value:

```ruby
b.element('r'); b.text('a')
b.to_s                        # a read
b.text('b'); b.pop
b.to_s                        #=> "<r>a\nb</r>\n"  and not "<r>ab</r>\n"
```

**The counters counted more than was written**, in three independent places, so `pos` and `column` grew apart from the buffer as the document did. They are readable as `Ox::Builder#pos` / `#column` / `#line` and are used for neither sizing nor writing, so nothing here is a memory safety problem — a caller is simply told the wrong place in the output.

<details>
<summary>The three counts, the measurements, and how it was checked</summary>

## The counters

| | wrote | counted |
| --- | --- | --- |
| `pop()` | `</` + name + `>` | name twice — `append_string()` had already advanced by `e->len`, then `pop` added `e->len + 3` |
| `comment()` | `<!--` (4) and `-->` (3) | 5 for each |
| the `strip_invalid_chars` arm | nothing | 10 — the table entry for an invalid byte, which is the longest escape |

Measured, `indent: -1` so the whole document is one line:

```
                          bytes   pos   diff
<a>t</a>                      8     9     +1     name of 1
<ab>t</ab>                   10    12     +2     name of 2
<abcde>t</abcde>             16    21     +5     name of 5
<!--hi-->                     9    12     +3
<r>ab</r>  text("a\x01b")     9    20    +11     +1 name, +10 dropped byte
<r>ab</r>  text("a\x01\x01b") 9    30    +21
```

Every difference is one of the three. After the fix `pos == to_s.bytesize` for all 29 writers the test file covers, and `column == pos + 1` on a single line.

An escape is still counted by its length, since it is written: `&amp;` counts 5.

## to_s

The newline now goes on the returned String. `to_s` answers the same whether or not it was called before, and leaves the builder alone. What it returns is unchanged in every case — including the block form, where `bclose()` puts the newline in the buffer itself, so the two never disagree.

It also stops reading `buf.tail[-1]` on an empty buffer.

This one had to land first: `pos` is measured against `to_s.bytesize`, which is not a fair measurement while `to_s` is writing.

## Tests

- `test/builder_to_s_test.rb`, 11 tests — a `to_s` at six points in a document, each with `indent: -1` and `indent: 2`, changing neither the document nor the counters; the closing newline still there; the block form, the file builder and the encoding unchanged. **4 fail on develop**; the other 7 pin behaviour that does not change.
- `test/builder_counters_test.rb`, 9 tests — `pos == to_s.bytesize` over 29 writers, names of 1 to 12 characters, comments of four lengths, 0 to 5 dropped bytes, and the counters checked at every step of one document rather than only at the end. **8 of 9 fail on develop.**

## Checked

- 313 tests / 5194 assertions, random order ×4, plus `rake test_all` — 0 failures
- `rake test:valgrind` — 577 tests, no invalid read/write, nothing lost
- clang-format clean, Ruby 2.7 syntax OK
- Each commit checked on its own: with only the `to_s` commit applied, its 11 tests pass and the counter tests still fail.

</details>
