### PR TITLE
Fix a comment, CDATA, DOCTYPE or instruction value going out unchecked

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -133,6 +133,29 @@ inline static size_t check_string(const char *str, size_t size, const char *tabl
     return xsize;
 }
 
+// The same question for a value that is copied through rather than escaped.
+// check_string() answers it too, but only as a side effect of sizing an escaped
+// form these writers have no use for, and inside a CDATA section or a comment a
+// character reference is not expanded, so escaping is not an option there.
+inline static void check_unescaped(const char *str, size_t size) {
+    const unsigned char *bad = xml_first_invalid((const unsigned char *)str, size);
+
+    if (NULL != bad) {
+        rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *bad);
+    }
+}
+
+// One of the instruct() attributes, which are written from the Hash rather than
+// passed in. A value of the wrong type is left to the type check that already
+// refuses it further down.
+inline static void check_instruct_value(VALUE attrs, VALUE key) {
+    volatile VALUE v = rb_hash_lookup(attrs, key);
+
+    if (Qnil != v && rb_cString == rb_obj_class(v)) {
+        check_unescaped(StringValuePtr(v), (size_t)RSTRING_LEN(v));
+    }
+}
+
 // Resolves a Symbol or String name to bytes and checks it, for the writers that
 // take either. sym holds the Symbol's name String for as long as *strp is used.
 inline static long check_name(VALUE v, volatile VALUE *sym, const char **strp, size_t *xsizep, const char *msg) {
@@ -601,6 +624,13 @@ static VALUE builder_instruct(int argc, VALUE *argv, VALUE self) {
         size_t         nx;
 
         check_name(*argv, &nsym, &nstr, &nx, "expected a Symbol or String");
+        if (1 < argc && rb_cHash == rb_obj_class(argv[1])) {
+            // The "<?" and the target are out by the time the values are
+            // written, so a raise down there would leave them in the buffer.
+            check_instruct_value(argv[1], ox_version_sym);
+            check_instruct_value(argv[1], ox_encoding_sym);
+            check_instruct_value(argv[1], ox_standalone_sym);
+        }
     }
     i_am_a_child(b, false);
     append_indent(b);
@@ -871,6 +901,7 @@ static VALUE builder_cdata(VALUE self, VALUE data) {
     s    = str;
     end  = str + len;
     from = str;
+    check_unescaped(str, (size_t)len);
     i_am_a_child(b, false);
     append_indent(b);
     buf_append_string(&b->buf, "<![CDATA[", 9);

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -182,6 +182,18 @@ inline static void fill_indent(Out out, int cnt) {
     }
 }
 
+// Raises on a character XML has no way to write, for the values fill_value()
+// copies through. dump_str_value() answers the same question for the values it
+// escapes, but inside a CDATA section, a comment or an instruction a character
+// reference is not expanded, so escaping is not an option there.
+inline static void check_unescaped(const char *str, size_t size) {
+    const unsigned char *bad = xml_first_invalid((const unsigned char *)str, size);
+
+    if (NULL != bad) {
+        rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *bad);
+    }
+}
+
 inline static void fill_value(Out out, const char *value, size_t len) {
     if (16 < len) {
         APPEND_CHARS(out->cur, value, len);
@@ -1164,10 +1176,12 @@ static void dump_gen_instruct(VALUE obj, int depth, Out out) {
     long           clen     = 0;
     size_t         size;
 
+    check_unescaped(name, (size_t)nlen);
     if (T_STRING == rb_type(rcontent)) {
         content = StringValuePtr(rcontent);
         clen    = RSTRING_LEN(rcontent);
-        size    = 4 + nlen + clen;
+        check_unescaped(content, (size_t)clen);
+        size = 4 + nlen + clen;
     } else {
         size = 4 + nlen;
     }
@@ -1278,6 +1292,11 @@ dump_gen_val_node(VALUE obj, int depth, const char *pre, size_t plen, const char
     vlen = RSTRING_LEN(v);
     from = val;
     end  = val + vlen;
+    // Ox::Raw is documented as going out untouched, so it is the one value node
+    // that is not checked. The rest are markup ox wrote the delimiters for.
+    if (ox_raw_clas != rb_obj_class(obj)) {
+        check_unescaped(val, vlen);
+    }
     if (0 > out->indent) {
         indent = -1;
     } else if (0 == out->indent) {

--- a/ext/ox/ox.c
+++ b/ext/ox/ox.c
@@ -292,7 +292,9 @@ static VALUE hints_to_overlay(Hints hints) {
  * - _:convert_special_ [true|false|nil] flag indicating special characters like &lt; are converted with the SAX parser
  * - _:invalid_replace_ [nil|false|String] what to do with a character XML can not hold on dump. false, the default,
  * raises an Ox::SyntaxError. nil writes it as a hex character reference, other than a NUL which is dropped since
- * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it.
+ * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it. This
+ * covers text and attribute values. A comment, CDATA section, DOCTYPE or processing instruction expands no character
+ * reference, so a character XML can not hold always raises there.
  * - _:no_empty_ [true|false|nil] flag indicating there should be no empty elements in a dump
  * - _:with_cdata_ [true|false] includes cdata in hash_load results
  * - _:strip_namespace_ [String|true|false] false or "" results in no namespace stripping. A string of "*" or true will
@@ -456,7 +458,9 @@ static VALUE sax_html_overlay(VALUE self) {
  *   - _:smart_ [true|false|nil] flag indicating the SAX parser uses hints if available (use with html)
  *   - _:invalid_replace_ [nil|false|String] what to do with a character XML can not hold on dump. false, the default,
  * raises an Ox::SyntaxError. nil writes it as a hex character reference, other than a NUL which is dropped since
- * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it.
+ * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it. This
+ * covers text and attribute values. A comment, CDATA section, DOCTYPE or processing instruction expands no character
+ * reference, so a character XML can not hold always raises there.
  *   - _:strip_namespace_ [nil|String|true|false] "" or false result in no namespace stripping. A string of "*" or true
  * will strip all namespaces. Any other non-empty string indicates that matching namespaces will be stripped.
  * - _:with_cdata_ [true|false] includes cdata in hash_load results
@@ -1003,7 +1007,9 @@ static VALUE load(char *xml, size_t len, int argc, VALUE *argv, VALUE self, VALU
  *   - *:symbolize_keys* [true|false|nil] symbolize element attribute keys or leave as Strings
  *   - *:invalid_replace* [nil|false|String] what to do with a character XML can not hold on dump. false, the default,
  * raises an Ox::SyntaxError. nil writes it as a hex character reference, other than a NUL which is dropped since
- * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it.
+ * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it. This
+ * covers text and attribute values. A comment, CDATA section, DOCTYPE or processing instruction expands no character
+ * reference, so a character XML can not hold always raises there.
  *   - *:strip_namespace* [String|true|false] "" or false result in no namespace stripping. A string of "*" or true will
  * strip all namespaces. Any other non-empty string indicates that matching namespaces will be stripped.
  *   - *:with_cdata* [true|false] if true cdata is included in hash_load output otherwise it is not.
@@ -1068,7 +1074,9 @@ static VALUE load_str(int argc, VALUE *argv, VALUE self) {
  *   - *:symbolize_keys* [true|false|nil] symbolize element attribute keys or leave as Strings
  *   - *:invalid_replace* [nil|false|String] what to do with a character XML can not hold on dump. false, the default,
  * raises an Ox::SyntaxError. nil writes it as a hex character reference, other than a NUL which is dropped since
- * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it.
+ * &#x0000; can not be read back. A string, limited to 10 characters, replaces it and the empty string drops it. This
+ * covers text and attribute values. A comment, CDATA section, DOCTYPE or processing instruction expands no character
+ * reference, so a character XML can not hold always raises there.
  *   - *:strip_namespace* [String|true|false] "" or false result in no namespace stripping. A string of "*" or true will
  * strip all namespaces. Any other non-empty string indicates that matching namespaces will be stripped.
  */

--- a/test/val_node_chars_test.rb
+++ b/test/val_node_chars_test.rb
@@ -1,0 +1,172 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: the value nodes were written without checking what was in
+# them.
+#
+# A comment, a CDATA section, a DOCTYPE and a processing instruction all copy
+# their value through instead of escaping it, and none of those writers looked
+# at it first. Text and names have always raised on a character XML has no way
+# to write, so the two halves of the same class disagreed:
+#
+#   input "a\0b" / "a\x01b"    Ox::Builder      Ox.dump
+#   text                       raise            raise
+#   element / attribute name   raise            raise
+#   comment                    raise            wrote it
+#   doctype                    raise            wrote it
+#   cdata                      wrote it         wrote it
+#   instruct target            raise            wrote it
+#   instruct content / attrs   wrote it         wrote it
+#
+# A NUL is the case that loses data. Ox.dump returns its buffer with
+# rb_str_new2, which stops at the first NUL, so the byte does not merely go out
+# invalid - everything after it, including the rest of the document, is gone and
+# nothing is raised:
+#
+#   Ox.dump(Ox::Element.new('r') << Ox::Comment.new("a\0b"))  #=> "\n<r>\n  <!--a"
+#
+# Escaping is not the answer for these nodes: a character reference is not
+# expanded inside a comment, a CDATA section or an instruction, so &#x1; there
+# is five more wrong characters rather than one right one. The only thing the
+# value can be is a run of Char, so they now refuse anything else, which is what
+# every other writer already did.
+#
+# Ox::Raw is documented as going out untouched and still does.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class ValNodeCharsTest < ::Test::Unit::TestCase
+  # Every writer that copies a value through, as a block taking the byte to
+  # plant. Both halves are here because the point is that they now agree.
+  WRITERS = {
+    'Builder cdata' => ->(c) { Ox::Builder.new(indent: -1) { |b| b.element('r') { b.cdata("a#{c}b") } } },
+    'Builder comment' => ->(c) { Ox::Builder.new(indent: -1) { |b| b.comment("a#{c}b") } },
+    'Builder doctype' => ->(c) { Ox::Builder.new(indent: -1) { |b| b.doctype("a#{c}b") } },
+    'Builder instruct target' => ->(c) { Ox::Builder.new(indent: -1) { |b| b.instruct("a#{c}b") } },
+    'Builder instruct version' => ->(c) { Ox::Builder.new(indent: -1) { |b| b.instruct('xml', version: "1#{c}0") } },
+    'Builder instruct encoding' => ->(c) { Ox::Builder.new(indent: -1) { |b| b.instruct('xml', encoding: "U#{c}F") } },
+    'Builder instruct standalone' => lambda { |c|
+      Ox::Builder.new(indent: -1) { |b| b.instruct('xml', standalone: "y#{c}s") }
+    },
+    'dump CData' => ->(c) { Ox.dump(Ox::Element.new('r') << Ox::CData.new("a#{c}b")) },
+    'dump Comment' => ->(c) { Ox.dump(Ox::Element.new('r') << Ox::Comment.new("a#{c}b")) },
+    'dump DocType' => ->(c) { Ox.dump(document(Ox::DocType.new("a#{c}b"))) },
+    'dump Instruct target' => ->(c) { Ox.dump(document(Ox::Instruct.new("a#{c}b"))) },
+    'dump Instruct content' => lambda { |c|
+      i = Ox::Instruct.new('xml')
+      i.content = "a#{c}b"
+      Ox.dump(document(i))
+    }
+  }.freeze
+
+  # A DocType or an Instruct is only written as part of a Document.
+  def self.document(node)
+    d = Ox::Document.new
+    d << node
+    d << Ox::Element.new('r')
+    d
+  end
+
+  def written(writer, byte)
+    writer.call(byte)
+  rescue Ox::SyntaxError => e
+    e.message
+  end
+
+  def test_every_writer_refuses_a_character_xml_can_not_hold
+    ["\x00", "\x01", "\x1f"].each do |c|
+      WRITERS.each do |where, writer|
+        assert_raise(Ox::SyntaxError, "#{where} #{c.inspect}") { writer.call(c) }
+      end
+    end
+  end
+
+  # The whole of the C0 range, so the three XML does allow are not swept up with
+  # the rest.
+  def test_the_c0_range_and_its_three_exceptions
+    (0..0x1f).each do |n|
+      c = n.chr
+      allowed = ["\t", "\n", "\r"].include?(c)
+      WRITERS.each do |where, writer|
+        label = format('%s 0x%02x', where, n)
+        if allowed
+          assert_nothing_raised(label) { writer.call(c) }
+        else
+          assert_raise(Ox::SyntaxError, label) { writer.call(c) }
+        end
+      end
+    end
+  end
+
+  def test_the_message_names_the_byte
+    assert_match(/#x01/, written(WRITERS['dump Comment'], "\x01"))
+    assert_match(/#x00/, written(WRITERS['Builder cdata'], "\x00"))
+  end
+
+  # This is the one that lost data rather than merely writing something invalid.
+  def test_a_nul_no_longer_truncates_the_document
+    assert_raise(Ox::SyntaxError) { Ox.dump(Ox::Element.new('r') << Ox::Comment.new("a\0b")) }
+    assert_raise(Ox::SyntaxError) { Ox.dump(Ox::Element.new('r') << Ox::CData.new("a\0b")) }
+    assert_raise(Ox::SyntaxError) { Ox.dump(self.class.document(Ox::DocType.new("a\0b"))) }
+    assert_raise(Ox::SyntaxError) { Ox.dump(self.class.document(Ox::Instruct.new("a\0b"))) }
+  end
+
+  # Ox::Raw says it adds what it is given without modification, so it is the one
+  # value node that is left alone.
+  def test_raw_is_still_untouched
+    assert_equal("<r>a\x01b</r>".b, Ox::Builder.new(indent: -1) { |b| b.element('r') { b.raw("a\x01b") } })
+    assert_equal("\n<r>\n  a\x01b\n</r>\n".b, Ox.dump(Ox::Element.new('r') << Ox::Raw.new("a\x01b")))
+  end
+
+  def test_what_xml_does_allow_still_goes_through
+    assert_equal("<r><![CDATA[a\tb\nc\rd]]></r>".b,
+                 Ox::Builder.new(indent: -1) { |b| b.element('r') { b.cdata("a\tb\nc\rd") } })
+    assert_equal('<r><![CDATA[日本語 ☃]]></r>'.b,
+                 Ox::Builder.new(indent: -1) { |b| b.element('r') { b.cdata('日本語 ☃') } })
+    assert_equal("\n<r>\n  <!--日本語\tx-->\n</r>\n".b,
+                 Ox.dump(Ox::Element.new('r') << Ox::Comment.new("日本語\tx")))
+    assert_equal('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'.b,
+                 Ox::Builder.new(indent: -1) do |b|
+                   b.instruct('xml', version: '1.0', encoding: 'UTF-8', standalone: 'yes')
+                 end)
+  end
+
+  # CDATA passes markup through unescaped, which is the whole point of it, and
+  # that has not changed - only the characters XML has no way to write at all.
+  def test_cdata_still_passes_markup_through
+    assert_equal('<r><![CDATA[a<b&c>d]]></r>'.b,
+                 Ox::Builder.new(indent: -1) { |b| b.element('r') { b.cdata('a<b&c>d') } })
+    assert_equal('<r><![CDATA[c]]]]><![CDATA[>d]]></r>'.b,
+                 Ox::Builder.new(indent: -1) { |b| b.element('r') { b.cdata('c]]>d') } })
+    assert_equal("\n<r>\n  <![CDATA[c]]]]><![CDATA[>d]]>\n</r>\n".b,
+                 Ox.dump(Ox::Element.new('r') << Ox::CData.new('c]]>d')))
+    # The split makes two sections that read back as the three characters, which
+    # is what #450 settled on.
+    xml = Ox::Builder.new(indent: -1) { |b| b.element('r') { b.cdata('c]]>d') } }
+    assert_equal('c]]>d', Ox.parse(xml).nodes.map(&:value).join)
+  end
+
+  # The check is made before anything is written, so a caller that rescues and
+  # carries on is left with the document it had.
+  def test_a_rescued_raise_leaves_nothing_behind
+    b = Ox::Builder.new(indent: -1)
+    b.element('r')
+    b.text('ok')
+    assert_raise(Ox::SyntaxError) { b.cdata("a\x01b") }
+    assert_raise(Ox::SyntaxError) { b.comment("a\x01b") }
+    assert_raise(Ox::SyntaxError) { b.instruct('xml', version: "1\x010") }
+    b.pop
+    assert_equal('<r>ok</r>'.b, b.to_s)
+    assert_equal('ok', Ox.parse(b.to_s).text)
+  end
+
+  # An argument that is not a String is still refused by the type check rather
+  # than by this one.
+  def test_a_non_string_instruct_value_is_unchanged
+    assert_raise(Ox::ParseError) { Ox::Builder.new(indent: -1) { |b| b.instruct('xml', version: 1.0) } }
+  end
+end


### PR DESCRIPTION
A value node copies its value through instead of escaping it, and none of those writers looked at it first. Text and names have always raised on a character XML has no way to write, so the two halves of the same class disagreed:

| input `"a\0b"` / `"a\x01b"` | `Ox::Builder` | `Ox.dump` |
| --- | --- | --- |
| text, element / attribute name | raise | raise |
| comment, doctype | raise | **wrote it** |
| cdata | **wrote it** | **wrote it** |
| instruct target | raise | **wrote it** |
| instruct content / attributes | **wrote it** | **wrote it** |

A NUL is the case that loses data. `Ox.dump` returns its buffer with `rb_str_new2`, which stops at the first NUL, so the byte does not merely go out invalid — everything after it, including the rest of the document, is gone and nothing is raised:

```ruby
Ox.dump(el << Ox::Comment.new("a\0b"))  #=> "\n<r>\n  <!--a"
```

They now refuse anything that is not a `Char`, which is what every other writer already did. `Ox::Raw` is documented as going out untouched and still does.

<details>
<summary>Why not escape, what changes for a caller, and how it was checked</summary>

## Why not escape

A character reference is not expanded inside a comment, a CDATA section or an instruction, so `&#x1;` written there is five more wrong characters rather than one right one. The only thing these values can hold is a run of `Char`, so refusing is the only correct answer — which is why this is a check and not a new escape table.

The check runs before the delimiters are written, so a rescued raise leaves nothing behind, the way `#465` settled for the other writers:

```ruby
b = Ox::Builder.new(indent: -1)
b.element('r'); b.text('ok')
begin; b.cdata("a\x01b"); rescue Ox::SyntaxError; end
b.pop
b.to_s        #=> "<r>ok</r>"
```

`Ox::Builder#instruct` checks its three attribute values next to the target rather than where they are written, since `<?` and the target are already in the buffer by then.

## This is not what #460 settled

#460 asked about a value that closes its own construct — `Ox::Comment.new('a--><b/>')` — and the answer was that building a well-formed document is the caller's job. That is a different axis and nothing here touches it: `-->` is a run of perfectly valid `Char`, so it still goes out exactly as it did, in both writers.

What this changes is a value XML has no way to hold at all, where there is no well-formed document for a caller to aim at. #460 also asked whether `Ox::Builder` and the DOM dumper should agree; on this axis they now do.

## What changes for a caller

A document that used to come out invalid, or truncated, now raises `Ox::SyntaxError`. Nothing that was valid XML changes: `\t`, `\n`, `\r`, UTF-8 and the markup a CDATA section is there to carry all still go through, and the `]]>` split from #450 is untouched.

`:invalid_replace` does not reach these nodes and did not before either — it is a choice between writing a character reference and replacing the byte, and the first of those is not available here. The four option doc blocks now say so. **If you would rather the replacement string applied to them as well, say so and I will add it** — it is a larger change than this one, so I have not assumed it.

## Rows this closes

Three, all measured on `develop`:

- CDATA contents unchecked in both writers
- NUL in a `Comment`, `CData`, `DocType` or `Instruct` truncating the whole document
- `Ox::Builder#instruct` not checking `version` / `encoding` / `standalone`, so `version: %q{1.0" x="2}` could add an attribute

## Tests

`test/val_node_chars_test.rb`, 9 tests. Twelve writers × the whole C0 range, so the three characters XML does allow are not swept up with the rest; the message naming the byte; `Ox::Raw` untouched; valid input unchanged; the `]]>` split still round-tripping; and a rescued raise leaving the document alone. **5 of the 9 fail on develop**; the other 4 pin behaviour that does not change.

## Checked

- 302 tests / 5460 assertions, random order ×3, plus `rake test_all` — 0 failures
- `rake test:valgrind` — 566 tests, no invalid read/write, nothing lost
- clang-format clean, Ruby 2.7 syntax OK

</details>
