### PR TITLE
Fix an element or attribute name going out unchecked

### DIFF
--- a/ext/ox/builder.c
+++ b/ext/ox/builder.c
@@ -14,6 +14,7 @@
 #include "ruby.h"
 #include "ruby/encoding.h"
 #include "ruby/version.h"
+#include "xml_check.h"
 #include "xml_str.h"
 
 #define MAX_DEPTH 128
@@ -131,18 +132,6 @@ inline static size_t check_string(const char *str, size_t size, const char *tabl
         }
     }
     return xsize;
-}
-
-// The same question for a value that is copied through rather than escaped.
-// check_string() answers it too, but only as a side effect of sizing an escaped
-// form these writers have no use for, and inside a CDATA section or a comment a
-// character reference is not expanded, so escaping is not an option there.
-inline static void check_unescaped(const char *str, size_t size) {
-    const unsigned char *bad = xml_first_invalid((const unsigned char *)str, size);
-
-    if (NULL != bad) {
-        rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *bad);
-    }
 }
 
 // One of the instruct() attributes, which are written from the Hash rather than
@@ -342,7 +331,8 @@ static int append_attr(VALUE key, VALUE value, VALUE bv) {
     // Both halves before the space: an attribute is either written whole or not
     // at all, and the element it belongs to is left as it was.
     Check_Type(value, T_STRING);
-    klen  = check_name(key, &sym, &ks, &kx, "expected a Symbol or String");
+    klen = check_name(key, &sym, &ks, &kx, "expected a Symbol or String");
+    check_name_chars(ks, (size_t)klen, true);
     vsize = (size_t)RSTRING_LEN(value);
     vx    = check_string(StringValuePtr(value), vsize, xml_attr_chars);
 
@@ -726,6 +716,7 @@ static VALUE builder_element(int argc, VALUE *argv, VALUE self) {
     // leaves an element started that no later call can finish or take back. It
     // also has to run before b->depth++, or the stack slot is never filled in.
     len = check_name(*argv, &sym, &name, &xsize, "expected a Symbol or String for an element name");
+    check_name_chars(name, (size_t)len, false);
     if (MAX_DEPTH <= b->depth + 1) {
         rb_raise(ox_arg_error_class, "XML too deeply nested");
     }
@@ -779,6 +770,7 @@ static VALUE builder_void_element(int argc, VALUE *argv, VALUE self) {
         rb_raise(ox_arg_error_class, "missing element name");
     }
     len = check_name(*argv, &sym, &name, &xsize, "expected a Symbol or String for an element name");
+    check_name_chars(name, (size_t)len, false);
     i_am_a_child(b, false);
     append_indent(b);
     buf_append(&b->buf, '<');

--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -14,6 +14,7 @@
 #include "cache8.h"
 #include "ox.h"
 #include "time_conv.h"
+#include "xml_check.h"
 #include "xml_str.h"
 
 #define USE_B64 0
@@ -179,18 +180,6 @@ inline static void fill_indent(Out out, int cnt) {
             memset(out->cur, ' ', cnt);
             out->cur += cnt;
         }
-    }
-}
-
-// Raises on a character XML has no way to write, for the values fill_value()
-// copies through. dump_str_value() answers the same question for the values it
-// escapes, but inside a CDATA section, a comment or an instruction a character
-// reference is not expanded, so escaping is not an option there.
-inline static void check_unescaped(const char *str, size_t size) {
-    const unsigned char *bad = xml_first_invalid((const unsigned char *)str, size);
-
-    if (NULL != bad) {
-        rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *bad);
     }
 }
 
@@ -1104,6 +1093,7 @@ static void dump_gen_element(VALUE obj, int depth, Out out) {
     size_t         size;
     int            indent;
 
+    check_name_chars(name, (size_t)nlen, false);
     if (0 > out->indent) {
         indent = -1;
     } else if (0 == out->indent) {
@@ -1254,11 +1244,9 @@ static int dump_gen_attr(VALUE key, VALUE value, VALUE ov) {
     }
     ks   = StringValuePtr(kv);
     klen = (size_t)RSTRING_LEN(kv);
-    // The name is written raw, so a NUL would reach the buffer and rb_str_new2()
-    // would cut the whole document there. Values already raise on it.
-    if (NULL != memchr(ks, '\0', klen)) {
-        rb_raise(ox_syntax_error_class, "'\\#x00' is not a valid XML character.");
-    }
+    // Before the space, so a rescued raise leaves the element as it was. The
+    // NUL this used to check for on its own is the low end of the same set.
+    check_name_chars(ks, klen, true);
     value = rb_String(value);
     size  = 4 + klen + RSTRING_LEN(value);
     if (out->end - out->cur <= (long)size) {

--- a/ext/ox/xml_check.h
+++ b/ext/ox/xml_check.h
@@ -1,0 +1,58 @@
+/* xml_check.h
+ * Copyright (c) 2011, Peter Ohler
+ * All rights reserved.
+ */
+
+#ifndef OX_XML_CHECK_H
+#define OX_XML_CHECK_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "err.h"
+#include "xml_str.h"
+
+/* What a writer asks before it writes anything, shared by dump.c and builder.c.
+ * The scans are in xml_str.h, which stays free of Ruby so it can be reasoned
+ * about on its own; these are the wrappers that turn an answer into a raise.
+ */
+
+/* Raises on a character XML has no way to write, for a value that is copied
+ * through rather than escaped. The escape path answers the same question on its
+ * way past, but inside a CDATA section, a comment or an instruction a character
+ * reference is not expanded, so escaping is not an option for those.
+ */
+inline static void check_unescaped(const char *str, size_t size) {
+    const unsigned char *bad = xml_first_invalid((const unsigned char *)str, size);
+
+    if (NULL != bad) {
+        rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *bad);
+    }
+}
+
+/* Refuses a name only for a character that could end it where it is written,
+ * the narrow rule #469 settled on, since anything else is odd but round trips.
+ * A byte XML can not hold at all keeps the message the values raise with.
+ *
+ * Escaping is not the answer here even where a table has an escape: a name is
+ * not a place a character reference is expanded, so &lt; in a name reads back
+ * as four more characters rather than as the one that was asked for.
+ */
+inline static void check_name_chars(const char *str, size_t size, bool attr) {
+    const char           ends = attr ? XML_NAME_ATTR : XML_NAME_ELEMENT;
+    const unsigned char *bad  = xml_first_bad_name((const unsigned char *)str, size, ends);
+    const char          *kind = attr ? "an attribute" : "an element";
+
+    if (NULL == bad) {
+        return;
+    }
+    if (0x20 > *bad && '\t' != *bad && '\n' != *bad && '\r' != *bad) {
+        rb_raise(ox_syntax_error_class, "'\\#x%02x' is not a valid XML character.", *bad);
+    }
+    if (0x20 >= *bad) {
+        rb_raise(ox_syntax_error_class, "'\\#x%02x' can not be used in %s name.", *bad, kind);
+    }
+    rb_raise(ox_syntax_error_class, "'%c' can not be used in %s name.", *bad, kind);
+}
+
+#endif /* OX_XML_CHECK_H */

--- a/ext/ox/xml_str.h
+++ b/ext/ox/xml_str.h
@@ -183,6 +183,41 @@ inline static const unsigned char *xml_first_invalid(const unsigned char *str, s
     return NULL;
 }
 
+/* What a byte does to a name, in the same shape as the escape tables. '2' ends
+ * a name wherever one is written - a byte at or below a space, either white
+ * space or one XML can not hold at all, or one of the five characters a start
+ * tag is read with. '1' ends only an attribute name, the quote its value is
+ * written in. '0' is a byte a name can hold.
+ */
+#define XML_NAME_ELEMENT '2'
+#define XML_NAME_ATTR '1'
+
+static const char xml_name_chars[257] = "\
+22222222222222222222222222222222\
+20100020000000020000000000002220\
+00000000000000000000000000000000\
+00000000000000000000000000000000\
+00000000000000000000000000000000\
+00000000000000000000000000000000\
+00000000000000000000000000000000\
+00000000000000000000000000000000";
+
+/* First byte of str that ends a name written where ends says it is written, or
+ * NULL. One load and one compare a byte, since every one of these is a name and
+ * a name is short enough that a word loop would spend more on its own setup
+ * than it saves.
+ */
+inline static const unsigned char *xml_first_bad_name(const unsigned char *str, size_t len, char ends) {
+    const unsigned char *end = str + len;
+
+    for (; str < end; str++) {
+        if (ends <= xml_name_chars[*str]) {
+            return str;
+        }
+    }
+    return NULL;
+}
+
 /* A CDATA section ends at the first "]]>", so a value holding one closes its
  * own section and the rest is read as markup. Both writers split each
  * occurrence into "]]" + "]]>" + "<![CDATA[" + ">", which reads back as the

--- a/test/invalid_replace_test.rb
+++ b/test/invalid_replace_test.rb
@@ -191,13 +191,17 @@ class InvalidReplaceTest < ::Test::Unit::TestCase
                  Ox.dump({"a\x01b" => 1}, invalid_replace: '?'))
   end
 
-  # An element name is written raw rather than escaped, so it is not this
-  # option's to govern and a NUL there still costs the document. Pinned so that
-  # a change to either side shows up here. See Z34 / issue #460.
+  # A name is written raw rather than escaped, so it is not this option's to
+  # govern. It used to go out unchecked; since issue #469 it raises instead, and
+  # the option does not soften that. Pinned so a change to either side shows up.
   def test_names_are_not_covered_by_the_option
     STATES.each_key do |state|
-      assert_equal("\n<r\x01/>\n", Ox.dump(Ox::Element.new("r\x01"), mode: :generic, invalid_replace: state),
-                   state.inspect)
+      assert_raise(Ox::SyntaxError, state.inspect) do
+        Ox.dump(Ox::Element.new("r\x01"), mode: :generic, invalid_replace: state)
+      end
+      e = Ox::Element.new('r')
+      e["k\x01"] = 'v'
+      assert_raise(Ox::SyntaxError, state.inspect) { Ox.dump(e, mode: :generic, invalid_replace: state) }
     end
   end
 

--- a/test/name_chars_test.rb
+++ b/test/name_chars_test.rb
@@ -1,0 +1,246 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Regression test: an element or attribute name was written with no check that
+# it could be a name, so a name could end itself and start something else.
+#
+#   e = Ox::Element.new('r')
+#   e[%q{a="1" b}] = '2'
+#   Ox.dump(e)                       #=> "\n<r a=\"1\" b=\"2\"/>\n"
+#   Ox.parse(Ox.dump(e)).attributes  #=> {a: "1", b: "2"}    one in, two out
+#
+# Both writers did it and neither said anything. Ox::Builder ran a name through
+# xml_element_chars, which escapes '<', '>' and '&' but not '"', so it stopped
+# the element name injection and not the attribute one; the DOM dumper writes a
+# name with fill_value and escaped nothing at all.
+#
+#   name       Ox.dump elem   Builder elem   Ox.dump attr   Builder attr
+#   a<b        injects        &lt;           injects        &lt;
+#   a="1" b    -              -              INJECTS        INJECTS
+#   a b        <a b/>         <a b/>         <r a b="1"/>   <r a b="1"/>
+#   a\0b       document cut   raised         raised         raised
+#   a\x01b     written raw    raised         written raw    raised
+#
+# Escaping is not the fix even where a table has an escape: a name is not a
+# place a character reference is expanded, so &lt; in a name reads back as four
+# more characters rather than as the one that was asked for.
+#
+# Issue #469 settled on the narrow rule, so what is refused is only what could
+# end the name where it is written -- a byte at or below a space, '<', '>',
+# '&', '/', '=', and '"' in an attribute name. A name that is odd but reads
+# back whole, '1abc' or 'a-b' or an element name holding a '"', still goes out.
+
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), '../ext')
+
+require 'test/unit'
+require 'ox'
+
+class NameCharsTest < ::Test::Unit::TestCase
+  # Every way a name reaches the buffer, keyed by what it is a name of. The
+  # value takes the name and returns the document.
+  ELEMENT = {
+    'Ox.dump element'            => ->(n) { Ox.dump(Ox::Element.new(n)) },
+    'Builder#element'            => ->(n) { Ox::Builder.new(indent: -1) { |b| b.element(n) } },
+    'Builder#element symbol'     => ->(n) { Ox::Builder.new(indent: -1) { |b| b.element(n.to_sym) } },
+    'Builder#void_element'       => ->(n) { Ox::Builder.new(indent: -1) { |b| b.void_element(n) } },
+  }.freeze
+
+  ATTRIBUTE = {
+    'Ox.dump attribute'          => ->(n) { e = Ox::Element.new('r'); e[n] = '1'; Ox.dump(e) },
+    'Ox.dump attribute symbol'   => ->(n) { e = Ox::Element.new('r'); e[n.to_sym] = '1'; Ox.dump(e) },
+    'Ox.dump instruct attribute' => lambda { |n|
+      i = Ox::Instruct.new('xml')
+      i[n] = '1'
+      d = Ox::Document.new
+      d << i
+      d << Ox::Element.new('r')
+      Ox.dump(d)
+    },
+    'Builder#element attribute'  => ->(n) { Ox::Builder.new(indent: -1) { |b| b.element('r', n => '1') } },
+    'Builder attribute symbol'   => ->(n) { Ox::Builder.new(indent: -1) { |b| b.element('r', n.to_sym => '1') } },
+  }.freeze
+
+  WRITERS = ELEMENT.merge(ATTRIBUTE).freeze
+
+  # Ends the name in every position it is written in.
+  BOTH = ['<', '>', '&', '/', '=', ' ', "\t", "\n", "\r"].freeze
+
+  # An attribute value is written in double quotes, so only there.
+  ATTR_ONLY = ['"'].freeze
+
+  def refused?
+    yield
+    false
+  rescue Ox::SyntaxError
+    true
+  end
+
+  def test_every_writer_refuses_a_character_that_ends_the_name
+    BOTH.each do |c|
+      WRITERS.each do |where, w|
+        assert_raise(Ox::SyntaxError, "#{where} #{c.inspect}") { w.call("a#{c}b") }
+      end
+    end
+  end
+
+  def test_only_an_attribute_name_refuses_the_quote
+    ATTR_ONLY.each do |c|
+      ATTRIBUTE.each do |where, w|
+        assert_raise(Ox::SyntaxError, "#{where} #{c.inspect}") { w.call("a#{c}b") }
+      end
+      ELEMENT.each do |where, w|
+        assert_nothing_raised(where) { w.call("a#{c}b") }
+      end
+    end
+  end
+
+  # The two writers disagreed here and it was the attribute half that injected,
+  # so state it as the document that came back rather than as a raise.
+  def test_the_attribute_injection_is_closed_in_both_writers
+    name = %q{a="1" b}
+    assert_raise(Ox::SyntaxError) do
+      e = Ox::Element.new('r')
+      e[name] = '2'
+      Ox.dump(e)
+    end
+    assert_raise(Ox::SyntaxError) { Ox::Builder.new(indent: -1) { |b| b.element('r', name => '2') } }
+  end
+
+  def test_the_element_injection_is_closed_in_both_writers
+    name = 'a<b/><injected'
+    assert_raise(Ox::SyntaxError) { Ox.dump(Ox::Element.new(name)) }
+    assert_raise(Ox::SyntaxError) { Ox::Builder.new(indent: -1) { |b| b.element(name) } }
+  end
+
+  # A NUL used to cut the whole document short in the one writer that let it
+  # through, since rb_str_new2() stops at it.
+  def test_a_nul_no_longer_cuts_the_document
+    assert_raise(Ox::SyntaxError) { Ox.dump(Ox::Element.new("a\0b")) }
+  end
+
+  # Below a space the byte is one XML can not hold at all, which is a different
+  # complaint from a name it could hold but can not use, so the message the
+  # value writers already raise with is kept.
+  def test_the_whole_control_range_raises_everywhere
+    (0..0x1f).each do |b|
+      c = b.chr
+      WRITERS.each do |where, w|
+        e = assert_raise(Ox::SyntaxError, "#{where} #{format('%02x', b)}") { w.call("a#{c}b") }
+        want = if ["\t", "\n", "\r"].include?(c)
+                 kind = where.include?('attribute') ? 'an attribute' : 'an element'
+                 format("'\\#x%02x' can not be used in %s name.", b, kind)
+               else
+                 format("'\\#x%02x' is not a valid XML character.", b)
+               end
+        assert_equal(want, e.message, where)
+      end
+    end
+  end
+
+  # The scan reads a 256 entry table, where a wrong column would be silent. So
+  # state the rule again here, independently of the table, and hold every byte
+  # in both positions against it.
+  def test_the_rule_holds_for_every_byte
+    (0..255).each do |b|
+      name = "a#{b.chr}b".dup.force_encoding('ASCII-8BIT')
+      elem = b <= 0x20 || ['<', '>', '&', '/', '='].include?(b.chr)
+      attr = elem || b.chr == '"'
+      assert_equal(elem, refused? { Ox.dump(Ox::Element.new(name)) }, format('element %02x', b))
+      assert_equal(attr, refused? { e = Ox::Element.new('r'); e[name] = '1'; Ox.dump(e) },
+                   format('attribute %02x', b))
+    end
+  end
+
+  def test_the_message_names_the_character_and_the_kind
+    e = assert_raise(Ox::SyntaxError) { Ox.dump(Ox::Element.new('a<b')) }
+    assert_equal("'<' can not be used in an element name.", e.message)
+
+    e = assert_raise(Ox::SyntaxError) { Ox::Builder.new(indent: -1) { |b| b.element('r', 'a=b' => '1') } }
+    assert_equal("'=' can not be used in an attribute name.", e.message)
+
+    e = assert_raise(Ox::SyntaxError) { Ox::Builder.new(indent: -1) { |b| b.element('a b') } }
+    assert_equal("'\\#x20' can not be used in an element name.", e.message)
+  end
+
+  # The narrow rule stops here on purpose: these are not names XML would take,
+  # but they read back as the one name that was asked for, so refusing them
+  # would break callers for no gain.
+  def test_a_name_that_reads_back_whole_still_goes_out
+    ['1abc', 'a-b', 'a.b', 'a:b', 'a!b', "a'b", '日本語'].each do |n|
+      ELEMENT.each do |where, w|
+        assert_nothing_raised("#{where} #{n.inspect}") { w.call(n) }
+      end
+      ATTRIBUTE.each do |where, w|
+        assert_nothing_raised("#{where} #{n.inspect}") { w.call(n) }
+      end
+    end
+    e = Ox::Element.new('1abc')
+    e['a-b'] = '1'
+    assert_equal("\n<1abc a-b=\"1\"/>\n".b, Ox.dump(e))
+    assert_equal('<1abc a-b="1"/>', Ox::Builder.new(indent: -1) { |b| b.element('1abc', 'a-b' => '1') })
+  end
+
+  def test_a_valid_document_is_unchanged
+    e = Ox::Element.new('top')
+    e['name'] = 'a<b'
+    e << (c = Ox::Element.new('kid-1:ns'))
+    c << 'text & more'
+    assert_equal("\n<top name=\"a&lt;b\">\n  <kid-1:ns>text &amp; more</kid-1:ns>\n</top>\n".b, Ox.dump(e))
+    assert_equal('<top name="a&lt;b"><kid-1:ns>text &amp; more</kid-1:ns></top>',
+                 Ox::Builder.new(indent: -1) { |b|
+                   b.element('top', 'name' => 'a<b') { b.element('kid-1:ns') { b.text('text & more') } }
+                 })
+  end
+
+  # The check has to run before the '<', or a rescued raise leaves an element
+  # started that no later call can finish. Same property as issue #465.
+  def test_a_rescued_element_raise_leaves_nothing_behind
+    b = Ox::Builder.new(indent: -1)
+    b.element('r')
+    b.element('c', 'ok' => '1')
+    assert_raise(Ox::SyntaxError) { b.element('bad name') }
+    assert_raise(Ox::SyntaxError) { b.void_element('bad<name') }
+    b.text('t')
+    b.pop
+    b.pop
+    assert_equal('<r><c ok="1">t</c></r>', b.to_s)
+  end
+
+  # An attribute is written whole or not at all and the element it belongs to is
+  # left as it was, which is what the value check already promised.
+  def test_a_rescued_attribute_raise_writes_no_part_of_it
+    bad = Ox::Builder.new(indent: -1)
+    bad.element('r')
+    assert_raise(Ox::SyntaxError) { bad.element('c', 'ok' => '1', 'x=y' => '2') }
+
+    val = Ox::Builder.new(indent: -1)
+    val.element('r')
+    assert_raise(Ox::SyntaxError) { val.element('c', 'ok' => '1', 'z' => "\x01") }
+
+    assert_equal(val.to_s, bad.to_s)
+    assert_equal('<r><c ok="1"', bad.to_s)
+  end
+
+  # A processing instruction target is the Instruct's value, and issue #460
+  # settled that a value closing its own construct is the caller's business.
+  # Both writers leave it alone, so pin that they agree.
+  def test_an_instruct_target_is_left_alone
+    d = Ox::Document.new
+    d << Ox::Instruct.new('a b')
+    d << Ox::Element.new('r')
+    assert_equal("<?a b?>\n<r/>\n".b, Ox.dump(d))
+    assert_equal('<?a b?><r/>', Ox::Builder.new(indent: -1) { |b| b.instruct('a b'); b.element('r') })
+  end
+
+  # The scan walks the name a byte at a time, so put the bad byte at every
+  # offset either side of the 64 byte inline buffer Builder copies a name into.
+  def test_the_byte_is_found_at_any_offset
+    [1, 7, 8, 9, 62, 63, 64, 65, 200].each do |n|
+      name = "#{'a' * n}<b"
+      WRITERS.each do |where, w|
+        assert_raise(Ox::SyntaxError, "#{where} #{n}") { w.call(name) }
+      end
+    end
+  end
+end

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -700,12 +700,13 @@ class Func < Test::Unit::TestCase
     end
   end
 
-  def test_escape_open_close_tag_names
+  # Was escaped to </&gt;&lt;script&gt;&lt;/script&gt;>, which is not an
+  # injection but is not a name either. Since issue #469 the name is refused.
+  def test_open_close_tag_names_are_refused
     Ox.default_options = $ox_object_options
     b = Ox::Builder.new
-    b.element(%(/><script></script>)) { b.text('xss') }
-    s = b.to_s
-    assert_equal(%(</&gt;&lt;script&gt;&lt;/script&gt;>xss<//&gt;&lt;script&gt;&lt;/script&gt;>\n), s)
+    e = assert_raise(Ox::SyntaxError) { b.element(%(/><script></script>)) { b.text('xss') } }
+    assert_equal("'/' can not be used in an element name.", e.message)
   end
 
   def test_attr_as_string


### PR DESCRIPTION
Closes #469.

A name is written raw rather than escaped and neither writer looked at it first, so a name could end itself and start something else with nothing raised. `Ox::Builder` produced the same string as `Ox.dump` here:

```ruby
e = Ox::Element.new('r')
e[%q{a="1" b}] = '2'
Ox.parse(Ox.dump(e)).attributes  #=> {a: "1", b: "2"}    one attribute in, two out
```

You picked **narrow**, so what is refused is only what could end the name where it is written — a byte at or below a space, `<`, `>`, `&`, `/`, `=`, and `"` in an attribute name. A name that is odd but reads back whole, `1abc` or `a-b` or an element name holding a `"`, still goes out exactly as it did. A processing instruction target is an `Ox::Instruct`'s value, and #460 settled that a value closing its own construct is the caller's business, so both writers still leave it alone.

<details>
<summary>What changed, and how it was checked</summary>

## The two writers disagreed

`Ox::Builder` runs a name through `xml_element_chars`, which escapes `<`, `>` and `&` but not `"`. That stopped the element name injection and not the attribute one. `Ox.dump` writes a name with `fill_value` and escaped nothing at all, so both injected there.

| name | `Ox.dump` element | Builder element | `Ox.dump` attribute | Builder attribute |
|---|---|---|---|---|
| `a<b` | injects | `&lt;` | injects | `&lt;` |
| `a="1" b` | — | — | **injects** | **injects** |
| `a b` | `<a b/>` | `<a b/>` | `<r a b="1"/>` | `<r a b="1"/>` |
| `a\0b` | document cut short | raised | raised | raised |
| `a\x01b` | written raw | raised | written raw | raised |

The NUL row is the one that loses data: `Ox.dump` returns its buffer with `rb_str_new2`, which stops at the first NUL, so `Ox.dump(Ox::Element.new("a\0b"))` was `"\n<a"` and the rest of the document was gone. That is the same shape #468 fixed for value nodes; the name was the half it did not reach.

## Escaping is not the answer

Even where a table has an escape for the character, a name is not a place a character reference is expanded. `&lt;` in a name reads back as four more characters rather than as the one that was asked for, which is why the Builder's current output for an XSS shaped name is `</&gt;&lt;script&gt;&lt;/script&gt;>` — not an injection, but not a name either. Refusing is the only answer that is right in both writers.

## The change

`xml_str.h` gains `xml_name_chars` and `xml_first_bad_name()`, a byte at a time where the value scans are a word at a time since a name is short enough that a word loop would spend more on its own setup than it saves.

The wrapper that turns that answer into a raise wants Ruby, which `xml_str.h` deliberately does not, so it goes in a new `xml_check.h` — self-contained, in the shape of `helper.h`. That is also where `check_unescaped()` moves to: #468 left a copy of it in each writer, and a second one of these would have made three. Both writers now hold only the call.

Call sites, all before the first byte of the construct is written so a rescued raise leaves nothing behind:

- `dump.c` — `dump_gen_element()` before the indent, `dump_gen_attr()` before the space. The latter replaces the NUL-only `memchr` check, which is the low end of the same set.
- `builder.c` — `builder_element()` and `builder_void_element()` after `check_name()`, `append_attr()` before the space.

A byte XML can not hold at all keeps the message the value writers already raise with, so `'\#x00' is not a valid XML character.` is unchanged. A name-only complaint reads `'=' can not be used in an attribute name.`

## What it costs

The check is one more pass over every name, so the cost tracks how much of a document is names. Against develop on the same machine, compiler and Ruby, pinned to one core, best of 45 samples each:

| generic `Ox.dump` | develop | this branch | |
|---|---|---|---|
| markup heavy — 3 attributes, short text | 0.271 ms | 0.288 ms | −6.2% |
| balanced — 1 attribute, a paragraph each | 0.284 ms | 0.295 ms | −3.8% |
| text heavy — no attributes, long text | 0.299 ms | 0.295 ms | none measurable |
| `Ox::Builder`, markup heavy | 1.073 ms | 1.084 ms | −1.0% |

`Ox.parse`, the SAX parser and object mode do not go through either writer and do not move.

I wrote the scan as a comparison chain first and it measured the same as the table, so what it costs is the pass rather than the test in it. If the element name half is not worth that to you, it can be dropped and only attribute names checked — that is where the silent injection is — but then the DOM dumper keeps writing `<a<b/><injected/>` for an element name.

## Two existing tests changed

- `test_escape_open_close_tag_names` pinned the Builder escaping `/><script></script>` into a name. It now pins the refusal, and is renamed since it no longer describes escaping.
- `test_names_are_not_covered_by_the_option` pinned `:invalid_replace` having no say over a name and the name going out anyway. It still pins that the option has no say, and now that the name raises whatever the option is set to.

## Checked

- `rake test_all` 0 failures on 4.0.6; `rake test` 336 tests / 6986 assertions, and in random order three times
- `rake test:valgrind` 600 tests, no error summary, no lost blocks, no invalid read or write
- clang-format clean, Ruby 2.7 parses the touched test files, and `xml_check.h` compiles on its own as the only include of a translation unit
- `test/name_chars_test.rb` is new: 14 tests / 1346 assertions, including one that states the rule again in Ruby and holds all 256 bytes in both positions against it, since a wrong column in the table would otherwise be silent. Built against a develop worktree first, where **11 of the 14 fail**. The three that pass there are the ones pinning behaviour this does not change — the odd-but-round-tripping names, a valid document byte for byte, and the instruct target.

</details>
