### PR TITLE
Speed up Ox.dump by not type checking the same String twice

### DIFF
--- a/ext/ox/dump.c
+++ b/ext/ox/dump.c
@@ -1122,8 +1122,10 @@ static void dump_gen_element(VALUE obj, int depth, Out out) {
     }
     // The attribute loop runs Ruby, so both the reservation above and the name
     // pointer are spent: dump_gen_attr() calls rb_String() on each value, and
-    // growing the name String there frees the buffer name points at.
-    name = StringValuePtr(rname);
+    // growing the name String there frees the buffer name points at. The type
+    // check is not repeated: StringValuePtr() above left rname a String and a
+    // VALUE does not change type, only where its bytes live.
+    name = RSTRING_PTR(rname);
     nlen = RSTRING_LEN(rname);
     size = indent + 5 + nlen + out->opts->margin_len;
     if (out->end - out->cur <= (long)size) {
@@ -1135,7 +1137,7 @@ static void dump_gen_element(VALUE obj, int depth, Out out) {
         *out->cur++ = '>';
         do_indent   = dump_gen_nodes(nodes, depth, out);
         // The children run Ruby as well.
-        name = StringValuePtr(rname);
+        name = RSTRING_PTR(rname);
         nlen = RSTRING_LEN(rname);
         size = indent + 5 + nlen + out->opts->margin_len;
         if (out->end - out->cur <= (long)size) {
@@ -1242,20 +1244,23 @@ static int dump_gen_attr(VALUE key, VALUE value, VALUE ov) {
     case T_STRING: break;
     default: kv = rb_String(key); break;
     }
-    ks   = StringValuePtr(kv);
+    // Every arm above leaves kv a String, so no second type check is needed.
+    ks   = RSTRING_PTR(kv);
     klen = (size_t)RSTRING_LEN(kv);
     // Before the space, so a rescued raise leaves the element as it was. The
     // NUL this used to check for on its own is the low end of the same set.
     check_name_chars(ks, klen, true);
-    value = rb_String(value);
-    size  = 4 + klen + RSTRING_LEN(value);
+    if (!RB_TYPE_P(value, T_STRING)) {
+        value = rb_String(value);
+    }
+    size = 4 + klen + RSTRING_LEN(value);
     if (out->end - out->cur <= (long)size) {
         grow(out, size);
     }
     *out->cur++ = ' ';
     fill_value(out, ks, klen);
     APPEND_CHARS_SMALL(out->cur, "=\"", 2);
-    dump_str_value(out, StringValuePtr(value), RSTRING_LEN(value), xml_quote_chars);
+    dump_str_value(out, RSTRING_PTR(value), RSTRING_LEN(value), xml_quote_chars);
     *out->cur++ = '"';
 
     return ST_CONTINUE;


### PR DESCRIPTION
The generic writer asks Ruby to check a type it already established, five times per element, and dropping those makes `Ox.dump` about 12% to 14% faster on a document that is mostly markup.

```
                          develop     this
  indent 2               349.1 us   302.5 us   13.3% faster
  indent -1              325.4 us   281.8 us   13.4% faster
  no_empty               341.6 us   294.8 us   13.7% faster
  margin + indent        353.1 us   311.0 us   11.9% faster
```

A document that is mostly text does not move, which is the shape of it: the saving is one Ruby call per name and per attribute, so it tracks how much of the document is markup. Output is unchanged — a SHA-256 over 176 dumps is identical to develop. The script that produces the table is below, so the numbers can be checked in a couple of minutes.

<details>
<summary>What was redundant, and how to measure it</summary>

## The five calls

`dump_gen_element()` has to re-fetch the name after the attribute loop and again after the children, because either can run Ruby and move the String's buffer. That part is necessary and stays. But it re-fetches with `StringValuePtr()`, which also re-runs the type check — and a `VALUE` never changes type, only where its bytes live, so `RSTRING_PTR()` is the whole of what a re-read needs.

`dump_gen_attr()` does it three more times:

- it switches on `rb_type(key)`, and every arm leaves `kv` a String, then hands it to `StringValuePtr()` anyway
- it calls `rb_String(value)` unconditionally, though an attribute value is already a String in every ordinary case
- it reaches for the value's pointer through `StringValuePtr()` once more at the end

## Reproducing it

Save this as `bench_dump.rb`. It needs nothing but ox, sizes each run to a time budget rather than a fixed count, and prints the four rows above.

```ruby
require 'ox'

# One name and three attributes per element, short text, 6001 elements.
root = Ox::Element.new('catalogue')
root['xmlns'] = 'http://example.com/ns'
2_000.times do |i|
  e = Ox::Element.new("record-#{i % 97}")
  e['id']      = i.to_s
  e['kind']    = 'a' * ((i % 12) + 3)
  e['checked'] = i.even? ? 'yes' : 'no'
  title = Ox::Element.new('title')
  title << "plain title #{i}"
  desc = Ox::Element.new('desc')
  desc << 'lorem ipsum '
  e << title
  e << desc
  root << e
end

CASES = {
  'indent 2'        => {indent: 2},
  'indent -1'       => {indent: -1},
  'no_empty'        => {indent: 2, no_empty: true},
  'margin + indent' => {indent: 2, margin: '<!-- m -->'},
}.freeze

# Sizes the run to a time budget rather than a fixed count, then takes the best
# of five. A fixed count is what makes a difference this small unstable.
def best_of_five(budget = 0.3)
  yield
  n = 1
  loop do
    t = Process.clock_gettime(Process::CLOCK_MONOTONIC)
    n.times { yield }
    d = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t
    if d >= 0.05
      n = (n / d * budget).ceil
      break
    end
    n *= 8
  end
  Array.new(5) do
    GC.start
    t = Process.clock_gettime(Process::CLOCK_MONOTONIC)
    n.times { yield }
    (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t) / n
  end.min
end

puts "ox #{Ox::VERSION}  #{RUBY_DESCRIPTION}"
puts "document #{Ox.dump(root, indent: 2).bytesize} bytes"
CASES.each do |name, opts|
  printf("%-16s %8.1f us\n", name, best_of_five { Ox.dump(root, **opts) } * 1e6)
end
```

Run it against each build:

```sh
git worktree add --detach /tmp/ox-base develop
(cd /tmp/ox-base && rake compile && ruby -Ilib -Iext ~/bench_dump.rb)
rake compile && ruby -Ilib -Iext ~/bench_dump.rb
```

Run each side more than once and alternate them. Most of the noise at this scale is between processes rather than inside one, and pinning to a core (`taskset -c 2` on Linux) tightens it further. The table above is the best of three alternating runs of each.

## The profile

`perf record` over 6000 dumps of that same document at `indent: 2`. Percentages are of all samples:

| symbol | develop | this |
|---|---|---|
| `rb_string_value_ptr` | 3.72% | 1.61% |
| `rb_string_value` | 3.27% | 1.12% |
| both `@plt` stubs | 2.95% | 0.98% |
| `rb_check_convert_type_with_id` | 0.79% | — |
| **total** | **10.73%** | **3.71%** |

What is left is the one check per name and per attribute that actually does the conversion.

</details>
