### PR TITLE
Speed up Ox.load in hash mode by keeping the marked arrays in a table

### DIFF
--- a/ext/ox/hash_load.c
+++ b/ext/ox/hash_load.c
@@ -13,8 +13,6 @@
 #include "ox.h"
 #include "ruby.h"
 
-#define MARK_INC 256
-
 // The approach taken for the hash and has_no_attrs parsing is to push just
 // the key on to the stack and then decide what to do on the way up/out.
 
@@ -27,45 +25,26 @@ static VALUE create_top(PInfo pi) {
     return top;
 }
 
+// Only membership is ever asked of these. As a list they were walked end to
+// end on every close, which is quadratic in the number of repeated elements
+// that carry attributes, since each of those adds a mark and only one is
+// ever taken back.
 static void mark_value(PInfo pi, VALUE val) {
     if (NULL == pi->marked) {
-        pi->marked    = ALLOC_N(VALUE, MARK_INC);
-        pi->mark_size = MARK_INC;
-    } else if (pi->mark_size <= pi->mark_cnt) {
-        pi->mark_size += MARK_INC;
-        REALLOC_N(pi->marked, VALUE, pi->mark_size);
+        pi->marked = st_init_numtable();
     }
-    pi->marked[pi->mark_cnt] = val;
-    pi->mark_cnt++;
+    st_insert(pi->marked, (st_data_t)val, (st_data_t)1);
 }
 
 static bool marked(PInfo pi, VALUE val) {
-    if (NULL != pi->marked) {
-        VALUE *vp = pi->marked + pi->mark_cnt - 1;
-
-        for (; pi->marked <= vp; vp--) {
-            if (val == *vp) {
-                return true;
-            }
-        }
-    }
-    return false;
+    return NULL != pi->marked && 0 != st_lookup(pi->marked, (st_data_t)val, NULL);
 }
 
 static void unmark(PInfo pi, VALUE val) {
     if (NULL != pi->marked) {
-        VALUE *vp = pi->marked + pi->mark_cnt - 1;
-        int    i;
+        st_data_t key = (st_data_t)val;
 
-        for (i = 0; pi->marked <= vp; vp--, i++) {
-            if (val == *vp) {
-                for (; 0 < i; i--, vp++) {
-                    *vp = *(vp + 1);
-                }
-                pi->mark_cnt--;
-                break;
-            }
-        }
+        st_delete(pi->marked, &key, NULL);
     }
 }
 
@@ -239,12 +218,12 @@ static void end_element_no_attrs(PInfo pi, const char *ename) {
 }
 
 static void finish(PInfo pi) {
-    // Called once per yielded entity and once after the loop, so the pointer
-    // and the count have to go with the block.
-    xfree(pi->marked);
-    pi->marked    = NULL;
-    pi->mark_size = 0;
-    pi->mark_cnt  = 0;
+    // Called once per yielded entity and once after the loop, so the table has
+    // to go with the block.
+    if (NULL != pi->marked) {
+        st_free_table(pi->marked);
+        pi->marked = NULL;
+    }
 }
 
 static void set_encoding_from_instruct(PInfo pi, Attr attrs) {

--- a/ext/ox/ox.h
+++ b/ext/ox/ox.h
@@ -151,9 +151,7 @@ struct _pInfo {
     CircArray           circ_array;
     unsigned long       id;  // set for text types when cirs_array is set
     Options             options;
-    VALUE              *marked;
-    int                 mark_size;  // allocated size
-    int                 mark_cnt;
+    st_table           *marked;
     char                last;  // last character read, rarely set
 };
 

--- a/ext/ox/parse.c
+++ b/ext/ox/parse.c
@@ -238,11 +238,11 @@ static VALUE ox_parse_ensure(VALUE ctxv) {
         ox_circ_array_free(ctx->pi->circ_array);
         ctx->pi->circ_array = 0;
     }
-    // Same for hash mode's mark list, freed by finish() only if the loop ends.
-    xfree(ctx->pi->marked);
-    ctx->pi->marked    = NULL;
-    ctx->pi->mark_size = 0;
-    ctx->pi->mark_cnt  = 0;
+    // Same for hash mode's mark set, freed by finish() only if the loop ends.
+    if (NULL != ctx->pi->marked) {
+        st_free_table(ctx->pi->marked);
+        ctx->pi->marked = NULL;
+    }
     return Qnil;
 }
 
@@ -269,8 +269,6 @@ ox_parse(char *xml, size_t len, ParseCallbacks pcb, char **endp, Options options
     pi.circ_array = 0;
     pi.options    = options;
     pi.marked     = NULL;
-    pi.mark_size  = 0;
-    pi.mark_cnt   = 0;
 
     ctx.pi          = &pi;
     ctx.endp        = endp;


### PR DESCRIPTION
An element that carries attributes leaves its array in `pi->marked` so that a repeated key can tell that array apart from one already holding repeats. The list was searched end to end on every element close, and each such element adds a mark while only one is ever taken back, so the list grows to the number of repeated elements and the parse is quadratic in it. A 25 MB document of records with three attributes each took 1.6 s. They are now held in an `st_table` keyed by the VALUE, which is all the lookup ever needed. `pi->marked` is not marked for GC and is only freed in `ox_parse_ensure()` and `finish()`, so those two become `st_free_table()` and the size and count go away. `mode: :hash_no_attrs` never asks and was never affected, which is why it is the control column below.

Output is unchanged over a 13923 row corpus: every sequence of up to three, and of four from a reduced set, siblings that share a key, each either carrying attributes or not and each empty, with text or with a child, laid out flat, inside a repeated attributed parent and inside a repeated plain parent, over `:hash` and `:hash_no_attrs`, `symbolize_keys` both ways, `with_cdata` both ways and with an `element_key_mod` plus `attr_key_mod`. A separate 8334 row corpus of hash and SAX results is identical too.

Ruby 4.0.6, gcc 16 `-O3`, best of five per row after a warm-up.

```
   0.2 MB  hash  0.0012 -> 0.0009 s   hash_no_attrs  0.0006 -> 0.0005 s
   0.8 MB  hash  0.0050 -> 0.0040 s   hash_no_attrs  0.0019 -> 0.0019 s
   3.1 MB  hash  0.0406 -> 0.0168 s   hash_no_attrs  0.0077 -> 0.0082 s
  12.4 MB  hash  0.4327 -> 0.0711 s   hash_no_attrs  0.0330 -> 0.0322 s
  25.0 MB  hash  1.6028 -> 0.1448 s   hash_no_attrs  0.0635 -> 0.0639 s
```

<details>
<summary>Benchmark script</summary>

```ruby
require 'benchmark'
require 'ox'

def gen(nrec)
  s = +"<?xml version=\"1.0\"?>\n<root>\n"
  nrec.times do |i|
    s << "  <record id=\"#{i}\" type=\"sample\" flag=\"true\">\n"
    s << "    <name>Item number #{i}</name>\n"
    s << "    <desc>Some moderately long description text for record #{i}.</desc>\n"
    s << "    <value>#{i * 37}</value>\n"
    s << "  </record>\n"
  end
  s << "</root>\n"
end

warm = gen(2_000)
10.times { Ox.load(warm, mode: :hash) }

[1_000, 4_000, 16_000, 64_000, 128_000].each do |n|
  doc = gen(n)
  best = lambda { |&blk| 5.times.map { Benchmark.realtime(&blk) }.min }
  times = {}
  times['hash'] = best.call { Ox.load(doc, mode: :hash) }
  times['hash_no_attrs'] = best.call { Ox.load(doc, mode: :hash_no_attrs) }
  printf("%6.1f MB  %s\n", doc.bytesize / 1e6, times.map { |k, v| format('%s %8.4f s', k, v) }.join('  '))
end
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
