### PR TITLE
Speed up hash_no_attrs by interning element names directly

### DIFF
--- a/ext/ox/hash_load.c
+++ b/ext/ox/hash_load.c
@@ -127,14 +127,17 @@ static void add_element(PInfo pi, const char *ename, Attr attrs, int hasChildren
 }
 
 static void add_element_no_attrs(PInfo pi, const char *ename, Attr attrs, int hasChildren) {
-    VALUE s = rb_str_new2(ename);
-    if (0 != pi->options->rb_enc) {
-        rb_enc_associate(s, pi->options->rb_enc);
-    }
+    rb_encoding *enc = pi->options->rb_enc;
+
     if (helper_stack_empty(&pi->helpers)) {
         create_top(pi);
     }
-    helper_stack_push(&pi->helpers, rb_intern_str(s), Qnil, NoCode);
+    // Intern the name without a temporary String, preserving rb_str_new2's
+    // binary encoding when the parser has no encoding set.
+    helper_stack_push(&pi->helpers,
+                      rb_intern3(ename, strlen(ename), NULL == enc ? rb_ascii8bit_encoding() : enc),
+                      Qnil,
+                      NoCode);
 }
 
 static int umark_hash_cb(VALUE key, VALUE value, VALUE x) {

--- a/test/hash_load_test.rb
+++ b/test/hash_load_test.rb
@@ -24,13 +24,15 @@ $: << File.join(File.dirname(__FILE__), '../lib')
 $: << File.join(File.dirname(__FILE__), '../ext')
 
 require 'test/unit'
+require 'tmpdir'
 require 'ox'
 
 class HashLoadTest < ::Test::Unit::TestCase
   def setup
-    # The memcheck lane runs every file in one process, so do not inherit
-    # whatever options ran before this.
+    # The memcheck lane runs every file in one process. Let the input or XML
+    # declaration choose the encoding instead of inheriting a default.
     @opts = Ox.default_options
+    Ox.default_options = {encoding: nil, symbolize_keys: true}
   end
 
   def teardown
@@ -117,7 +119,7 @@ class HashLoadTest < ::Test::Unit::TestCase
 
       [true, false].each do |symbolize|
         key = symbolize ? name.to_sym : name
-        result = Ox.load(xml, mode: :hash_no_attrs, symbolize_keys: symbolize, encoding: nil)
+        result = Ox.load(xml, mode: :hash_no_attrs, symbolize_keys: symbolize)
         assert_equal({key => %w[one two]}, result)
         assert_equal(name.encoding, result.keys.first.encoding)
       end
@@ -126,9 +128,27 @@ class HashLoadTest < ::Test::Unit::TestCase
 
   def test_hash_no_attrs_declared_name_encoding
     xml = '<?xml version="1.0" encoding="UTF-8"?><項目/>'.b
-    result = Ox.load(xml, mode: :hash_no_attrs, symbolize_keys: false, encoding: nil)
+    result = Ox.load(xml, mode: :hash_no_attrs, symbolize_keys: false)
     assert_equal({'項目' => nil}, result)
     assert_equal(Encoding::UTF_8, result.keys.first.encoding)
+  end
+
+  def test_hash_no_attrs_file_name_defaults_to_binary
+    # Unlike load(String), load_file has no input encoding. Without a default
+    # or XML declaration, the interned name must retain the binary fallback.
+    Dir.mktmpdir('ox-hash-no-attrs') do |dir|
+      path = File.join(dir, 'names.xml')
+      File.binwrite(path, '<root><項目>1</項目></root>')
+
+      [true, false].each do |symbolize|
+        name = '項目'.b
+        root_key = symbolize ? :root : 'root'
+        name_key = symbolize ? name.to_sym : name
+        result = Ox.load_file(path, mode: :hash_no_attrs, symbolize_keys: symbolize)
+        assert_equal({root_key => {name_key => '1'}}, result)
+        assert_equal(Encoding::ASCII_8BIT, result[root_key].keys.first.encoding)
+      end
+    end
   end
 
   def test_hash_no_attrs_name_modifier_receives_encoded_string
@@ -138,7 +158,7 @@ class HashLoadTest < ::Test::Unit::TestCase
       name.upcase
     end
     result = Ox.load('<root><項目 ignored="yes">one</項目><項目>two</項目></root>',
-                     mode: :hash_no_attrs, encoding: 'UTF-8',
+                     mode: :hash_no_attrs,
                      element_key_mod: modifier, symbolize_keys: true)
     assert_equal({'ROOT' => {'項目' => %w[one two]}}, result)
     assert_equal(['項目', '項目', 'root'], names)

--- a/test/hash_load_test.rb
+++ b/test/hash_load_test.rb
@@ -109,6 +109,42 @@ class HashLoadTest < ::Test::Unit::TestCase
     assert_equal({top: 't'}, Ox.load('<top a="1"><top>t</top></top>', mode: :hash_no_attrs)[:top])
   end
 
+  def test_hash_no_attrs_name_encodings
+    %w[UTF-8 Shift_JIS ASCII-8BIT].each do |encoding|
+      name = '項目'.encode(encoding == 'ASCII-8BIT' ? 'UTF-8' : encoding).force_encoding(encoding)
+      xml = '<'.b + name.b + '>one</'.b + name.b + '><'.b + name.b + '>two</'.b + name.b + '>'
+      xml.force_encoding(encoding)
+
+      [true, false].each do |symbolize|
+        key = symbolize ? name.to_sym : name
+        result = Ox.load(xml, mode: :hash_no_attrs, symbolize_keys: symbolize, encoding: nil)
+        assert_equal({key => %w[one two]}, result)
+        assert_equal(name.encoding, result.keys.first.encoding)
+      end
+    end
+  end
+
+  def test_hash_no_attrs_declared_name_encoding
+    xml = '<?xml version="1.0" encoding="UTF-8"?><項目/>'.b
+    result = Ox.load(xml, mode: :hash_no_attrs, symbolize_keys: false, encoding: nil)
+    assert_equal({'項目' => nil}, result)
+    assert_equal(Encoding::UTF_8, result.keys.first.encoding)
+  end
+
+  def test_hash_no_attrs_name_modifier_receives_encoded_string
+    names = []
+    modifier = lambda do |name|
+      names << name
+      name.upcase
+    end
+    result = Ox.load('<root><項目 ignored="yes">one</項目><項目>two</項目></root>',
+                     mode: :hash_no_attrs, encoding: 'UTF-8',
+                     element_key_mod: modifier, symbolize_keys: true)
+    assert_equal({'ROOT' => {'項目' => %w[one two]}}, result)
+    assert_equal(['項目', '項目', 'root'], names)
+    assert_equal([Encoding::UTF_8, Encoding::UTF_8, Encoding::US_ASCII], names.map(&:encoding))
+  end
+
   def test_string_keys
     assert_equal({'top' => [{'a' => '1'}]},
                  Ox.load('<top a="1"/>', mode: :hash, symbolize_keys: false))


### PR DESCRIPTION
`Ox.load(..., mode: :hash_no_attrs)` creates a temporary Ruby String for every element name, associates its encoding, and immediately interns it. Repeated tags therefore allocate a new String even when the name is already interned.

Use `rb_intern3()` directly on the name bytes, preserving the parser's encoding and the ASCII-8BIT fallback of `rb_str_new2()`. This removes one temporary String per element. The change is limited to `hash_no_attrs`.

On Ruby 4.0.6 / arm64, parsing 40,000 records with five text fields per record:

| | Before | After | |
| --- | ---: | ---: | ---: |
| Parse time | 34.65 ms | 29.78 ms | 14% up |
| Allocated objects | 480,006 | 240,005 | 1/2 down |

This is a 14% reduction in parse time. Each process warmed up twice, then measured seven parses with `GC.start` before each measurement. Results above are the medians of four process-level medians, alternating the before/after execution order. All result digests matched.

The input was generated with:

```ruby
xml = '<rows>' + '<row id="1"><name>Alice</name><city>Tokyo</city><age>30</age><status>active</status><note>hello</note></row>' * 40_000 + '</rows>'
Ox.load(xml, mode: :hash_no_attrs)
```

Validation:

- Added coverage for UTF-8, Shift_JIS and binary names with both Symbol and String keys, repeated elements, XML-declared encoding, and encoded names passed to `element_key_mod`. These tests also pass against the original implementation.
- Added `Ox.load_file` coverage for the ASCII-8BIT fallback with Symbol and String keys. The test fails when that fallback is deliberately changed to UTF-8 in an isolated build.
- Encoding tests use the input String or XML declaration and reset default options; they also pass when run after setting the default encoding to ASCII-8BIT.
- `test/hash_load_test.rb`: 15 tests, 72 assertions passed.
- The additional `*_test.rb` suite (using the Rake test task's exclusions): 340 tests, 7,007 assertions passed.
- `test/tests.rb` passed.
- `git diff --check` passed.

