### PR TITLE
Speed up hash mode by interning element names directly

### DIFF
--- a/ext/ox/hash_load.c
+++ b/ext/ox/hash_load.c
@@ -88,10 +88,10 @@ static void add_cdata(PInfo pi, const char *text, size_t len) {
 }
 
 static void add_element(PInfo pi, const char *ename, Attr attrs, int hasChildren) {
-    VALUE s = rb_str_new2(ename);
-    if (0 != pi->options->rb_enc) {
-        rb_enc_associate(s, pi->options->rb_enc);
-    }
+    // Keep the name's encoding without allocating a temporary String. Intern
+    // after the attributes as before, including any key modifier callbacks.
+    rb_encoding *enc = NULL == pi->options->rb_enc ? rb_ascii8bit_encoding() : pi->options->rb_enc;
+
     if (helper_stack_empty(&pi->helpers)) {
         create_top(pi);
     }
@@ -120,9 +120,9 @@ static void add_element(PInfo pi, const char *ename, Attr attrs, int hasChildren
         a = rb_ary_new();
         rb_ary_push(a, h);
         mark_value(pi, a);
-        helper_stack_push(&pi->helpers, rb_intern_str(s), a, ArrayCode);
+        helper_stack_push(&pi->helpers, rb_intern3(ename, strlen(ename), enc), a, ArrayCode);
     } else {
-        helper_stack_push(&pi->helpers, rb_intern_str(s), Qnil, NoCode);
+        helper_stack_push(&pi->helpers, rb_intern3(ename, strlen(ename), enc), Qnil, NoCode);
     }
 }
 

--- a/test/hash_load_test.rb
+++ b/test/hash_load_test.rb
@@ -169,4 +169,67 @@ class HashLoadTest < ::Test::Unit::TestCase
     assert_equal({'top' => [{'a' => '1'}]},
                  Ox.load('<top a="1"/>', mode: :hash, symbolize_keys: false))
   end
+
+  def test_hash_element_name_encodings
+    %w[UTF-8 Shift_JIS ASCII-8BIT].each do |encoding|
+      name = '項目'.encode(encoding == 'ASCII-8BIT' ? 'UTF-8' : encoding).force_encoding(encoding)
+      [true, false].each do |with_attrs|
+        attrs = with_attrs ? ' id="1"' : ''
+        xml = '<'.b + name.b + attrs.b + '>one</'.b + name.b + '>'
+        xml = (xml * 2).force_encoding(encoding)
+        [true, false].each do |symbolize|
+          key = symbolize ? name.to_sym : name
+          attr_key = symbolize ? :id : 'id'
+          value = with_attrs ? [{attr_key => '1'}, 'one'] : 'one'
+          result = Ox.load(xml, mode: :hash, symbolize_keys: symbolize)
+          assert_equal({key => [value, value]}, result)
+          assert_equal(name.encoding, result.keys.first.encoding)
+        end
+      end
+    end
+  end
+
+  def test_hash_file_element_name_defaults_to_binary
+    Dir.mktmpdir('ox-hash') do |dir|
+      path = File.join(dir, 'names.xml')
+      [true, false].each do |with_attrs|
+        attrs = with_attrs ? ' id="1"' : ''
+        File.binwrite(path, "<root><項目#{attrs}>one</項目></root>")
+        [true, false].each do |symbolize|
+          root_key = symbolize ? :root : 'root'
+          name_key = symbolize ? '項目'.b.to_sym : '項目'.b
+          attr_key = symbolize ? :id : 'id'
+          value = with_attrs ? [{attr_key => '1'}, 'one'] : 'one'
+          result = Ox.load_file(path, mode: :hash, symbolize_keys: symbolize)
+          assert_equal({root_key => {name_key => value}}, result)
+          assert_equal(Encoding::ASCII_8BIT, result[root_key].keys.first.encoding)
+        end
+      end
+    end
+  end
+
+  def test_hash_declared_element_name_encoding
+    xml = '<?xml version="1.0" encoding="UTF-8"?><項目 id="1"/>'.b
+    result = Ox.load(xml, mode: :hash, symbolize_keys: false)
+    assert_equal({'項目' => [{'id' => '1'}]}, result)
+    assert_equal(Encoding::UTF_8, result.keys.first.encoding)
+  end
+
+  def test_hash_key_modifiers_receive_encoded_names
+    names = []
+    attr_modifier = lambda do |name|
+      names << [:attribute, name.dup]
+      GC.start
+      name.replace('ID')
+    end
+    element_modifier = lambda do |name|
+      names << [:element, name]
+      name.upcase
+    end
+    result = Ox.load('<項目 番号="1">one</項目>', mode: :hash,
+                     attr_key_mod: attr_modifier, element_key_mod: element_modifier)
+    assert_equal({'項目' => [{'ID' => '1'}, 'one']}, result)
+    assert_equal([[:attribute, '番号'], [:element, '項目']], names)
+    assert_equal([Encoding::UTF_8, Encoding::UTF_8], names.map { |_, name| name.encoding })
+  end
 end


### PR DESCRIPTION
`Ox.load(..., mode: :hash)` creates a temporary Ruby String for every element name, associates its encoding, and immediately interns it. Repeated tags therefore allocate a new String even when the name is already interned.

Use `rb_intern3()` on the name bytes, preserving the parser's encoding and the ASCII-8BIT fallback for file input without an encoding. Keep interning after attribute processing, including attribute key modifier callbacks. This extends the element-name optimization in #474 to hash mode; attribute key handling is unchanged.

On Ruby 4.0.6 / arm64, parsing 40,000 records with five text fields per record:

| | Before | After |
| --- | ---: | ---: |
| Parse time | 46.10 ms | 41.75 ms |
| Allocated objects | 800,006 | 560,005 |

This is a 9.4% reduction in parse time. Each process warmed up twice, then measured seven parses with `GC.start` before each measurement. These are the medians of four process-level medians, alternating the before/after execution order. All result digests matched. The unchanged `hash_no_attrs` control measured 28.27 ms before and 29.23 ms after, with identical allocation counts.

Input:

```ruby
xml = '<rows>' + '<row id="1"><name>Alice</name><city>Tokyo</city><age>30</age><status>active</status><note>hello</note></row>' * 40_000 + '</rows>'
Ox.load(xml, mode: :hash)
```

Validation:

- Added tests for repeated elements with and without attributes, UTF-8/Shift_JIS/binary names, Symbol and String keys, XML-declared encoding, and the file-input binary fallback.
- Added coverage for encoded names passed to attribute and element key modifiers, including allocation/GC during the attribute callback.
- `test/hash_load_test.rb`: 19 tests, 109 assertions passed against both the original and updated implementation. Also passed with ASCII-8BIT configured as the default encoding before running the suite.
- Additional `*_test.rb` suite, using the Rake test task's exclusions: 344 tests, 7,044 assertions passed.
- `test/tests.rb` and `test/sax/sax_test.rb` passed.
- `clang-format --dry-run --Werror ext/ox/hash_load.c` and `git diff --check` passed.
